### PR TITLE
Adding notes to `transform-origin` for SVGs in Safari

### DIFF
--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -226,11 +226,11 @@
               },
               "safari": {
                 "version_added": "6",
-                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=""` SVG attribute."
+                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=\"\"` SVG attribute."
               },
               "safari_ios": {
                 "version_added": "6",
-                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=""` SVG attribute."
+                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=\"\"` SVG attribute."
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -225,10 +225,12 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6"
+                "version_added": "6",
+                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=""` SVG attribute."
               },
               "safari_ios": {
-                "version_added": "6"
+                "version_added": "6",
+                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=""` SVG attribute."
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -226,11 +226,11 @@
               },
               "safari": {
                 "version_added": "6",
-                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=\"\"` SVG attribute."
+                "notes": "Only supported for transformations applied using the CSS <code>transform</code> property (e.g. <code>.className { transform: rotate(45deg); transform-origin: center; }</code>). It has no effect on transformations applied using the <code>transform</code> SVG attribute (e.g. <code>&lt;rect style=&quot;transform-origin: center;&quot; transform=&quot;rotate(45)&quot; /&gt;</code>)."
               },
               "safari_ios": {
                 "version_added": "6",
-                "notes": "Only supported for transformations applied using the CSS `transform:` property. It has no effect on transformations applied using the `transform=\"\"` SVG attribute."
+                "notes": "Only supported for transformations applied using the CSS <code>transform</code> property (e.g. <code>.className { transform: rotate(45deg); transform-origin: center; }</code>). It has no effect on transformations applied using the <code>transform</code> SVG attribute (e.g. <code>&lt;rect style=&quot;transform-origin: center;&quot; transform=&quot;rotate(45)&quot; /&gt;</code>)."
               },
               "samsunginternet_android": {
                 "version_added": "1.5"


### PR DESCRIPTION
I'm adding clarifications to Safari's support for `transform-origin:` with SVG images.

I couldn't find any authoritative source to cite for Safari itself, unfortunately - only these StackOverflow posts (one of which is mine):

* https://stackoverflow.com/q/61272308/159145
* https://stackoverflow.com/q/57732067/159145

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
    - I can write a quick test-case for this, but does it belong here? How and where should I post it?
- [x] Data: if you tested something, describe how you tested with details like browser and version
    - Tested in JSFiddle with Safari Technology Preview Release 102 (13.2).
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
    - The Travis CI build failed, but it won't show me the reason why (it just says "There was an error while trying to fetch the log.")
    - *UPDATE*: The Travis CI log is now available, but the log doesn't show any errors. 
    - *UPDATE*: Ah, there was  a syntax error that @sideshowbarker fixed for me.
- [ ] Link to related issues or pull requests, if any
