### PR TITLE
Fixed #5649 - set CSS logical properties shorthands as flag enabled in Chromium

### DIFF
--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -9,8 +9,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                 "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -18,8 +18,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -27,8 +27,8 @@
               "version_added": "79",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -9,8 +9,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -18,8 +19,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -27,8 +29,9 @@
               "version_added": "79",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -9,7 +9,7 @@
               "version_added": "69",
               "flags": [
                 {
-                 "type": "runtime_flag",
+                  "type": "runtime_flag",
                   "name": "--enable-experimental-web-platform-features"
                 }
               ]

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -6,13 +6,31 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "69",
+              "flags": [
+                {
+                "type": "runtime_flag",
+                "name": "--enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "69",
+              "flags": [
+                {
+                "type": "runtime_flag",
+                "name": "--enable-experimental-web-platform-features"
+                }
+              ]
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                "type": "runtime_flag",
+                "name": "--enable-experimental-web-platform-features"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -9,8 +9,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -18,8 +18,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -27,8 +27,8 @@
               "version_added": "79",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -9,8 +9,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -18,8 +19,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -27,8 +29,9 @@
               "version_added": "79",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -9,8 +9,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -18,8 +18,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -27,8 +27,8 @@
               "version_added": "79",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -9,8 +9,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -18,8 +19,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -27,8 +29,9 @@
               "version_added": "79",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -9,8 +9,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -18,8 +18,8 @@
               "version_added": "69",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },
@@ -27,8 +27,8 @@
               "version_added": "79",
               "flags": [
                 {
-                "type": "runtime_flag",
-                "name": "--enable-experimental-web-platform-features"
+                  "type": "runtime_flag",
+                  "name": "--enable-experimental-web-platform-features"
                 }
               ]
             },

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -9,8 +9,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -18,8 +19,9 @@
               "version_added": "69",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -27,8 +29,9 @@
               "version_added": "79",
               "flags": [
                 {
-                  "type": "runtime_flag",
-                  "name": "--enable-experimental-web-platform-features"
+                  "type": "preference",
+                  "name": "Experimental Web Platform features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },


### PR DESCRIPTION
Fixed https://github.com/mdn/browser-compat-data/issues/5649.
`margin-block`, `padding-block`, `margin-inline` and `padding-inline` are not enabled by default yet.
Sources -
https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/css_properties.json5;l=5276?q=padding-block%20-file:test%20file:json
https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/runtime_enabled_features.json5;l=445?q=CSSLogical%20file:json5