### PR TITLE
Narrow range for dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "homepage": "https://github.com/mdn/browser-compat-data#readme",
   "devDependencies": {
-    "ajv": "^6.12.0",
-    "better-ajv-errors": "^0.6.7",
-    "chalk": "^3.0.0",
-    "compare-versions": "^3.6.0",
-    "mdn-confluence": "^1.0.3",
-    "ora": "^4.0.3",
-    "prettier": "^1.19.1",
+    "ajv": "~6.12.2",
+    "better-ajv-errors": "~0.6.7",
+    "chalk": "~3.0.0",
+    "compare-versions": "~3.6.0",
+    "mdn-confluence": "~1.0.3",
+    "ora": "~4.0.3",
+    "prettier": "~1.19.1",
     "yargs": "~15.3.1"
   },
   "scripts": {


### PR DESCRIPTION
This is a follow up to #5912. We've been running with one of the dev dependencies more narrowly defined and it hasn't shown any problems (or annoyances with dependabot), so this does the same with the other dev dependencies.