### PR TITLE
Update Intl.RelativeTimeFormat Edge support

### DIFF
--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -14,7 +14,7 @@
                 "version_added": "71"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "65"
@@ -66,7 +66,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "65"
@@ -118,7 +118,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "65"
@@ -170,7 +170,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "70"
@@ -222,7 +222,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "65"
@@ -271,7 +271,7 @@
                     "version_added": "73"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "70"
@@ -324,7 +324,7 @@
                   "version_added": "71"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "65"


### PR DESCRIPTION
Closes https://github.com/mdn/browser-compat-data/issues/6006

I'm guessing that Edge supports `Intl.RelativeTimeFormat` since it's based on Chromium now. According to https://en.wikipedia.org/wiki/Microsoft_Edge version 79 is the one based on Chromium