### PR TITLE
Update BCD - Firefox support for iceRestart in 48

### DIFF
--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -73,10 +73,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox has supported ICE restart since 48. Oops.