### PR TITLE
Structure ES6 classes data for Chromium browsers

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -5,14 +5,48 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
         "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
         "support": {
-          "chrome": {
-            "version_added": "49",
-            "notes": "From Chrome 42 to 48, strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-          },
-          "chrome_android": {
-            "version_added": "49",
-            "notes": "From Chrome 42 to 48, strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-          },
+          "chrome": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_removed": "49",
+              "version_added": "42",
+              "notes": "Strict mode is required."
+            },
+            {
+              "version_removed": "49",
+              "version_added": "42",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_removed": "49",
+              "version_added": "42",
+              "notes": "Strict mode is required."
+            },
+            {
+              "version_removed": "49",
+              "version_added": "42",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "edge": {
             "version_added": "13"
           },
@@ -48,28 +82,74 @@
               ]
             }
           ],
-          "opera": {
-            "version_added": "36",
-            "notes": "From Opera 29 to 35, strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-          },
-          "opera_android": {
-            "version_added": "36",
-            "notes": "From Opera 29 to 35, strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-          },
+          "opera": [
+            {
+              "version_added": "36"
+            },
+            {
+              "version_removed": "36",
+              "version_added": "29",
+              "notes": "Strict mode is required."
+            },
+            {
+              "version_removed": "36",
+              "version_added": "29",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "36"
+            },
+            {
+              "version_removed": "36",
+              "version_added": "29",
+              "notes": "Strict mode is required."
+            },
+            {
+              "version_removed": "36",
+              "version_added": "29",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "9"
           },
           "safari_ios": {
             "version_added": "9"
           },
-          "samsunginternet_android": {
-            "version_added": "5.0",
-            "notes": "In Samsung Internet 4.0, strict mode is required."
-          },
-          "webview_android": {
-            "version_added": "49",
-            "notes": "From WebView 42 to 48, strict mode is required."
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "5.0"
+            },
+            {
+              "version_removed": "5.0",
+              "version_added": "4.0",
+              "notes": "Strict mode is required."
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "49"
+            },
+            {
+              "version_removed": "49",
+              "version_added": "42",
+              "notes": "Strict mode is required."
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -82,14 +162,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
           "spec_url": "https://tc39.es/ecma262/#sec-static-semantics-constructormethod",
           "support": {
-            "chrome": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "chrome_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "13"
             },
@@ -125,27 +239,74 @@
                 ]
               }
             ],
-            "opera": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "opera_android": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "opera": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_removed": "5.0",
+                "version_added": "4.0",
+                "notes": "Strict mode is required."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -159,14 +320,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
           "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
-            "chrome": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "chrome_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "13"
             },
@@ -202,27 +397,74 @@
                 ]
               }
             ],
-            "opera": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "opera_android": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "opera": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_removed": "5.0",
+                "version_added": "4.0",
+                "notes": "Strict mode is required."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -342,14 +584,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
           "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
-            "chrome": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "chrome_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "13"
             },
@@ -385,27 +661,74 @@
                 ]
               }
             ],
-            "opera": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "opera_android": {
-              "version_added": "36",
-              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "opera": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_removed": "5.0",
+                "version_added": "4.0",
+                "notes": "Strict mode is required."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -228,14 +228,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/class",
           "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
-            "chrome": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "chrome_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "chrome": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "13"
             },
@@ -251,27 +285,74 @@
             "nodejs": {
               "version_added": "6.0.0"
             },
-            "opera": {
-              "version_added": "36"
-            },
-            "opera_android": {
-              "version_added": "36",
-              "notes": "From Opera 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
+            "opera": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "notes": "Strict mode is required."
+              },
+              {
+                "version_removed": "36",
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": "4.0",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            },
-            "webview_android": {
-              "version_added": "49",
-              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_removed": "5.0",
+                "version_added": "4.0",
+                "notes": "Strict mode is required."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "49"
+              },
+              {
+                "version_removed": "49",
+                "version_added": "42",
+                "notes": "Strict mode is required."
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
In the course of reviewing #5997, I discovered some oddities in the way the data for ES6 classes is recorded for the Chromium browsers. I've attempted to structure some data that was cleverly hidden in notes.

@Elchi3 I've tagged you for review because you've been working on some the JS stuff recently, but it's not urgent.

## Before

Before this PR, the data said that ES6 classes were fully supported in some version and unsupported in previous versions. There was a note, however, that said it _was_ supported in earlier versions, but in strict mode only and non-strict mode was also supported behind a flag. In other words, the note said there was considerable support before the version reported in the data. 😬

## After

This PR restructures the data as follows:

* Supported, fully, in some version X
* Supported in some version Y with a note describing the strict mode only caveat
* Supported, fully, in some version Y behind a flag (for the browsers that support Chromium flags)

This makes the diff look rather large, but it's mostly a copy-and-paste operation. Once you've seen one feature, you've seen 'em all.

Incidentally, this also fixes:

* A few more notes (like in #5997) that had the wrong browser name
* An inconsistency in the Samsung Internet data, between the `javascript.classes` feature and the `javascript.statements.class` feature.