### PR TITLE
Mark "referrer" meta name value as not deprecated

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -526,7 +526,6 @@
           },
           "referrer": {
             "__compat": {
-              "description": "referrer value",
               "support": {
                 "chrome": {
                   "version_added": "17",
@@ -575,7 +574,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "deprecated": true
+                "deprecated": false
               }
             }
           },


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer

This change also drops the `description` field for this feature – because it’s unnecessary in this case, and the corresponding features for other metadata names (`color-scheme`, `scheme`, and `theme-color`) don’t have a `description` field, which in the Browser Compatibility table in MDN causes the row for the `referrer` meta name to be unexpectedly rendered differently (not in monospace) than the other names.