### PR TITLE
Update mdn_urls for Intl pages

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -4,7 +4,7 @@
       "Intl": {
         "Collator": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator",
             "spec_url": "https://tc39.es/ecma402/#collator-objects",
             "support": {
               "chrome": {
@@ -56,7 +56,7 @@
           "Collator": {
             "__compat": {
               "description": "<code>Collator()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator",
               "spec_url": "https://tc39.es/ecma402/#sec-the-intl-collator-constructor",
               "support": {
                 "chrome": {
@@ -159,7 +159,7 @@
           },
           "compare": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/compare",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype.compare",
               "support": {
                 "chrome": {
@@ -211,7 +211,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/resolvedOptions",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype.resolvedoptions",
               "support": {
                 "chrome": {
@@ -263,7 +263,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/supportedLocalesOf",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof",
               "support": {
                 "chrome": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -4,7 +4,7 @@
       "Intl": {
         "DateTimeFormat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat",
             "spec_url": "https://tc39.es/ecma402/#datetimeformat-objects",
             "support": {
               "chrome": {
@@ -56,7 +56,7 @@
           "DateTimeFormat": {
             "__compat": {
               "description": "<code>DateTimeFormat()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/DateTimeFormat",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor",
               "support": {
                 "chrome": {
@@ -309,7 +309,7 @@
           },
           "format": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/format",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format",
               "support": {
                 "chrome": {
@@ -361,7 +361,7 @@
           },
           "formatRange": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRange",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange",
               "spec_url": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-intl.datetimeformat.prototype.formatRange",
               "support": {
                 "chrome": {
@@ -413,7 +413,7 @@
           },
           "formatRangeToParts": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRangeToParts",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRangeToParts",
               "spec_url": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts",
               "support": {
                 "chrome": {
@@ -465,7 +465,7 @@
           },
           "formatToParts": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
@@ -523,7 +523,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
@@ -626,7 +626,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/supportedLocalesOf",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.supportedlocalesof",
               "support": {
                 "chrome": {

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -4,7 +4,7 @@
       "Intl": {
         "ListFormat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat",
             "spec_url": "https://tc39.es/proposal-intl-list-format/#listformat-objects",
             "support": {
               "chrome": {
@@ -56,7 +56,7 @@
           "ListFormat": {
             "__compat": {
               "description": "<code>ListFormat()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/ListFormat",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-intl-listformat-constructor",
               "support": {
                 "chrome": {
@@ -108,7 +108,7 @@
           },
           "format": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/format",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.format",
               "support": {
                 "chrome": {
@@ -160,7 +160,7 @@
           },
           "formatToParts": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/formatToParts",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/formatToParts",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
@@ -212,7 +212,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/resolvedOptions",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
@@ -264,7 +264,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/supportedLocalesOf",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.supportedLocalesOf",
               "support": {
                 "chrome": {

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -4,7 +4,7 @@
       "Intl": {
         "Locale": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale",
             "spec_url": "https://tc39.es/ecma402/#locale-objects",
             "support": {
               "chrome": {
@@ -56,7 +56,7 @@
           "Locale": {
             "__compat": {
               "description": "<code>Locale()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/Locale",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-locale-constructor",
               "support": {
                 "chrome": {
@@ -108,7 +108,7 @@
           },
           "baseName": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/baseName",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/baseName",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.baseName",
               "support": {
                 "chrome": {
@@ -160,7 +160,7 @@
           },
           "calendar": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/calendar",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar",
               "support": {
                 "chrome": {
@@ -212,7 +212,7 @@
           },
           "caseFirst": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/caseFirst",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/caseFirst",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.caseFirst",
               "support": {
                 "chrome": {
@@ -264,7 +264,7 @@
           },
           "collation": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/collation",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation",
               "support": {
                 "chrome": {
@@ -316,7 +316,7 @@
           },
           "hourCycle": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/hourCycle",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle",
               "support": {
                 "chrome": {
@@ -368,7 +368,7 @@
           },
           "language": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/language",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/language",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language",
               "support": {
                 "chrome": {
@@ -420,7 +420,7 @@
           },
           "maximize": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/maximize",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/maximize",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize",
               "support": {
                 "chrome": {
@@ -472,7 +472,7 @@
           },
           "minimize": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/minimize",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/minimize",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize",
               "support": {
                 "chrome": {
@@ -524,7 +524,7 @@
           },
           "numberingSystem": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numberingSystem",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem",
               "support": {
                 "chrome": {
@@ -576,7 +576,7 @@
           },
           "numeric": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numeric",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numeric",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric",
               "support": {
                 "chrome": {
@@ -628,7 +628,7 @@
           },
           "region": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/region",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/region",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region",
               "support": {
                 "chrome": {
@@ -680,7 +680,7 @@
           },
           "script": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/script",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/script",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script",
               "support": {
                 "chrome": {
@@ -732,7 +732,7 @@
           },
           "toString": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/toString",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/toString",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString",
               "support": {
                 "chrome": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -4,7 +4,7 @@
       "Intl": {
         "NumberFormat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat",
             "spec_url": "https://tc39.es/ecma402/#numberformat-objects",
             "support": {
               "chrome": {
@@ -56,7 +56,7 @@
           "NumberFormat": {
             "__compat": {
               "description": "<code>NumberFormat()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/NumberFormat",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-numberformat-constructor",
               "support": {
                 "chrome": {
@@ -108,7 +108,7 @@
           },
           "format": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format",
               "support": {
                 "chrome": {
@@ -160,7 +160,7 @@
           },
           "formatToParts": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts",
               "support": {
                 "chrome": {
@@ -212,7 +212,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/resolvedOptions",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
@@ -264,7 +264,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/supportedLocalesOf",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof",
               "support": {
                 "chrome": {

--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -4,7 +4,7 @@
       "Intl": {
         "PluralRules": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules",
             "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
             "support": {
               "chrome": {
@@ -55,7 +55,7 @@
           },
           "PluralRules": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/PluralRules",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
               "description": "<code>PluralRules()</code> constructor",
               "support": {
@@ -108,7 +108,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "63"
@@ -159,7 +159,7 @@
           },
           "select": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/select",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select",
               "support": {
                 "chrome": {
                   "version_added": "63"
@@ -210,7 +210,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "63"

--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -4,7 +4,7 @@
       "Intl": {
         "RelativeTimeFormat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat",
             "spec_url": "https://tc39.es/ecma402/#relativetimeformat-objects",
             "support": {
               "chrome": {
@@ -55,7 +55,7 @@
           },
           "RelativeTimeFormat": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/RelativeTimeFormat",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor",
               "description": "<code>RelativeTimeFormat()</code> constructor",
               "support": {
@@ -108,7 +108,7 @@
           },
           "format": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format",
               "support": {
                 "chrome": {
@@ -160,7 +160,7 @@
           },
           "formatToParts": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
@@ -212,7 +212,7 @@
           },
           "resolvedOptions": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/resolvedOptions",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
@@ -314,7 +314,7 @@
           },
           "supportedLocalesOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/supportedLocalesOf",
               "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
               "support": {
                 "chrome": {


### PR DESCRIPTION
Per https://github.com/mdn/sprints/issues/2537 I moved the `Intl` pages under the https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl page tree. This PR updates the URLs in BCD accordingly.