### PR TITLE
Update for Node 14

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -206,6 +206,12 @@
           "release_notes": "https://nodejs.org/en/blog/release/v13.2.0/",
           "engine": "V8",
           "engine_version": "7.9"
+        },
+        "14.0.0": {
+          "release_date": "2020-04-21",
+          "release_notes": "https://nodejs.org/en/blog/release/v14.0.0/",
+          "engine": "V8",
+          "engine_version": "8.1"
         }
       }
     }

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "14.0.0"
             },
             "opera": {
               "version_added": "67"

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -62,7 +62,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "14.0.0"
             },
             "opera": [
               {


### PR DESCRIPTION
This PR adds Node v14, which has been released and uses V8 8.1. Nullish Coalescing and Optional Chaining are now enabled by default.

- https://nodejs.org/en/blog/release/v14.0.0/#update-to-v8-8-1
- https://medium.com/p/8170d384567e#03c1