### PR TITLE
Fixed 'getDisplayMedia' incorrectly stating Safari on iOS 13 as supported

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -245,7 +245,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION

MDN incorrectly lists `getDisplayMedia` as supported on iOS Safari.
Unfortunately the support is not there yet, I have manually re-verified this using remote devtools on iOS 13.4:
<img width="353" alt="Screen Shot 2020-04-22 at 12 58 58" src="https://user-images.githubusercontent.com/4955642/79939058-22630980-8499-11ea-8fa6-49703ef7c530.png">
<img width="302" alt="Screen Shot 2020-04-22 at 12 59 07" src="https://user-images.githubusercontent.com/4955642/79939064-24c56380-8499-11ea-8f3c-acc6b0342533.png">

Alternatively, here's a screenshot from [webrtc-experiment](https://www.webrtc-experiment.com/getDisplayMedia/) page:
![IMG_0099](https://user-images.githubusercontent.com/4955642/79939626-89cd8900-849a-11ea-869a-61cecba7e8a6.PNG)

Can't find official specs for mobile version of Safari, unfortunately.

It appears that the incorrect change was introduced in https://github.com/mdn/browser-compat-data/pull/5844. A lot of APIs were updated and while the PR summary lists `getDisplayMedia` for what appears to be desktop `Safari` only, both mobile and desktop were updated.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
