### PR TITLE
Mark all CSS Shadow Parts features as supported in Safari 13.1

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5954,10 +5954,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -919,10 +919,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1531,10 +1531,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Along with the `::part` pseudo-element marked as Safari-supported in #5941, the `part` and `exportparts` markup attributes and `Element.prototype.part` IDL/DOM property are all included in CSS Shadow Parts, which as noted in #5941 and https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes shipped in Safari 13.1

See also https://bugs.webkit.org/show_bug.cgi?id=202409 and https://bugs.webkit.org/show_bug.cgi?id=202520 and https://bugs.webkit.org/show_bug.cgi?id=202644.

So the whole set of CSS Shadow Parts features was turned on in https://trac.webkit.org/changeset/250889/webkit/, which was after https://trac.webkit.org/log/webkit/tags/Safari-608.2.11 (=Safari 13) and before https://trac.webkit.org/log/webkit/tags/Safari-609.1.20 (=Safari 13.1).