### PR TITLE
bugfix: ios safari does not have getDisplayMedia support

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -245,7 +245,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Pull Request #5844 correctly indicated getDisplayMedia was introduced with Safari 13. But this was only enabled for the desktop version, Safari on iOS/iPadOS still don't have getDisplayMedia.