### PR TITLE
Add another caveat related to CORP in Chrome

### DIFF
--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -7,11 +7,17 @@
           "support": {
             "chrome": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": [
+                "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>.",
+                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+              ]
             },
             "chrome_android": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": [
+                "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>.",
+                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+              ]
             },
             "edge": {
               "version_added": "79"
@@ -54,7 +60,10 @@
             },
             "webview_android": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in WebView. See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": [
+                "Until version 75, downloads for files with this header would fail in WebView. See <a href='https://crbug.com/952834'>bug 952834</a>.",
+                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+              ]
             }
           },
           "status": {


### PR DESCRIPTION
Since this has bitten me in a production system, and it would've been really useful to get a warning about on the MDN docs page.

https://bugs.chromium.org/p/chromium/issues/detail?id=1074261

Version 80 comes from:

> https://crbug.com/1063034#c14 indicates that, due to a bug, partial PDF loading has not been used for some time. Now that it seems to be working again in M80, we're getting a number of new bugs involving partial loading, linearized PDFs, etc.
