### PR TITLE
Add internet explorer support for document.title

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9802,7 +9802,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
I tested that `document.title = 'test'` works successfully in IE8+. It may work in earlier versions as well, but I have not tested that.