### PR TITLE
Update support for periodicSync of ServiceWorkerRegistration

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -519,7 +519,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -481,13 +481,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/periodicSync",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "80"
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": false
@@ -514,12 +514,12 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "80"
             }
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Based on the status update 'version_added' was set to '80':
- "Enabled by default": https://chromestatus.com/features/5689383275462656
- "Fixed (Closed)": https://bugs.chromium.org/p/chromium/issues/detail?id=925297
- "Launch": https://web.dev/periodic-background-sync/

Also, 'standard_track' was changed to 'true': as this is a relevant status now: "becoming a standard (waiting for all vendor implementation)"
