### PR TITLE
Safari supports CSP header for worker scripts

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1806,10 +1806,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "samsunginternet_android": {
                   "version_added": true

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1809,7 +1809,7 @@
                   "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": true

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1806,7 +1806,7 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
                   "version_added": true


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Safari supports CSP header for worker scripts, which includes iOS Safari.
I'm not sure which version Safari had added the feature, but we can test that it works fine on Safari 13.1 (macOS 10.15.4).

I've created a glitch to test the behavior.
- https://rift-innate-meerkat.glitch.me/ (demo)
- https://glitch.com/edit/#!/rift-innate-meerkat (code)

You can see failing to fetch a json on a worker script, and see the following error message on Safari.

> Refused to connect to https://hacker-news.firebaseio.com/v0/item/8863.json because it appears in neither the connect-src directive nor the default-src directive of the Content Security Policy.

