### PR TITLE
fix(api/font-face): version_added to edge 79

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -11,7 +11,7 @@
             "version_added": "35"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "41"
@@ -59,7 +59,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -107,7 +107,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "58"
@@ -155,7 +155,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -203,7 +203,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -267,7 +267,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -347,7 +347,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -411,7 +411,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -459,7 +459,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -507,7 +507,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -555,7 +555,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -603,7 +603,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -651,7 +651,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -699,7 +699,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
## Changes
Updates the `version_added` from `<= 79` to `79` for CSS FontLoading API

## Ressources
- https://caniuse.com/#feat=font-loading
- https://chromestatus.com/feature/6244676289953792

## Related Issues
Fixes #6041 
