### PR TITLE
AudioContext.p.state|onstatechange in Safari 9

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1638,10 +1638,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "9",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1752,10 +1754,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "9",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
https://trac.webkit.org/changeset/182141/webkit added support for `AudioContext.p.state` and `AudioContext.p.onstatechange` to WebKit, which per https://trac.webkit.org/log/webkit/tags/Safari-601.1.25 went into WebKit 601.1.25 and so into Safari 9 and iOS Safari 9.