### PR TITLE
Most (Base)AudioContext members in iOS Safari 6

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -45,7 +45,8 @@
             "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -156,7 +157,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -220,7 +222,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -284,7 +287,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -348,7 +352,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -412,7 +417,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -476,7 +482,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -588,7 +595,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -652,7 +660,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -716,7 +725,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -780,7 +790,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -894,7 +905,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -958,7 +970,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1041,7 +1054,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": [
               {
@@ -1173,7 +1187,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1287,7 +1302,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1351,7 +1367,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1415,7 +1432,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1529,7 +1547,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1591,7 +1610,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1705,7 +1725,8 @@
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/PlayingandSynthesizingSounds/PlayingandSynthesizingSounds.html
> The Web Audio API is available on Safari 6 and later, and Safari on iOS 6 and later.

See also https://caniuse.com/#feat=audio-api

Fixes https://github.com/mdn/browser-compat-data/issues/6043