### PR TITLE
Make various support updates to BaseAudioContext

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -89,7 +89,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -521,7 +521,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -827,7 +827,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -1105,7 +1105,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
Testing and code inspection confirm that Safari doesn’t support the `audioWorklet` and `createIIRFilter` members of `(Base)AudioContext`, nor have support for disabling normalisation.

Testing and code inspection also confirm that `createConstantSource`, which had been marked as supported in Safari, isn't actually supported in Safari.