### PR TITLE
Correct Android data for Element.getAnimations()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3188,7 +3188,7 @@
                 "version_added": "44",
                 "version_removed": "67",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3201,7 +3201,7 @@
                 "version_added": "38",
                 "version_removed": "44",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3236,7 +3236,7 @@
                 "version_added": "44",
                 "version_removed": "67",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3249,7 +3249,7 @@
                 "version_added": "38",
                 "version_removed": "44",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3305,7 +3305,7 @@
               },
               {
                 "alternative_name": "getAnimationPlayers",
-                "version_added": "33",
+                "version_added": "35",
                 "version_removed": "40",
                 "partial_implementation": true,
                 "notes": "Does not support the <code>subtree</code> option.",
@@ -3315,19 +3315,80 @@
                     "name": "dom.animations-api.core.enabled"
                   }
                 ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "33",
+                "version_removed": "35",
+                "partial_implementation": true,
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
               }
             ],
-            "firefox_android": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "Does not return any animations added via CSS.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.getAnimations.enabled"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "40",
+                "version_removed": "48",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "35",
+                "version_removed": "40",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "33",
+                "version_removed": "35",
+                "partial_implementation": true,
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -3357,7 +3418,7 @@
                 "version_added": "31",
                 "version_removed": "54",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3370,7 +3431,7 @@
                 "version_added": "25",
                 "version_removed": "31",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3395,7 +3456,7 @@
                 "version_added": "32",
                 "version_removed": "48",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3408,7 +3469,7 @@
                 "version_added": "25",
                 "version_removed": "32",
                 "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
While preparing a PR for the related [DocumentOrShadowRoot.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Document/getAnimations), I realised I made two errors in my data for [Element.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations) updated in https://github.com/mdn/browser-compat-data/pull/5743:

### Android CSS Animations ###

I found an error in my tests related to JS Bin, where browsers at phone-sized resolutions would set the output tab to `display: none` when the console tab is in the foreground, erroneously causing no results to be returned. My fault for testing Firefox for Android at a smaller resolution on my physical device, rather than double checking in browserstack with the older v65! I have subsequently rewritten the tests to output to the page directly instead:

- Basic support: https://jsbin.com/talabom/edit?html,css,js,output
- Returns css animations: https://jsbin.com/danisex/edit?html,css,js,output
- Supports options.subtree: https://jsbin.com/hasihan/edit?html,css,js,output
- Returns animations on pseudoelements: https://jsbin.com/zuyadoh/edit?html,css,js,output

Because of this, I have amended the results for Firefox for Android, since they now match the results for regular desktop Firefox. The slight change also picked out some subtle timing issues, so I updated Firefox's early data [(corresponding bug 1073396)](https://bugzilla.mozilla.org/show_bug.cgi?id=1073396) and Chromium's note.

### Samsung Internet Browser Flags ###

_Fixed by https://github.com/mdn/browser-compat-data/pull/5866._

Samsung Internet Browser does not appear to support the Chromium flag that activates this behaviour in Chrome, Edge and Opera, so its support should still be false. (I've double checked my previous PRs and I don't believe I've made this error elsewhere.)