### PR TITLE
removal of Firefox desktop support for window.onappinstalled

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4440,22 +4440,17 @@
             "edge": {
               "version_added": "≤79"
             },
-            "firefox": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "49",
-                "version_removed": "76",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.manifest.onappinstall",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49",
+              "version_removed": "76",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.manifest.onappinstall",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": "49",
               "flags": [

--- a/api/Window.json
+++ b/api/Window.json
@@ -4440,16 +4440,22 @@
             "edge": {
               "version_added": "≤79"
             },
-            "firefox": {
-              "version_added": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.manifest.onappinstall",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "49",
+                "version_removed": "76",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.manifest.onappinstall",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "49",
               "flags": [


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1625384

Basically, `window.onappinstalled` has been removed in Fx 76.

We'll do the same for Fx mobile when the new version is available.