### PR TITLE
Correct Chrome + Safari data for Element.getAttribute()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -29,7 +29,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1.3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/Element.json
+++ b/api/Element.json
@@ -3466,10 +3466,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAttribute",
           "support": {
             "chrome": {
-              "version_added": "29"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "29"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3490,16 +3490,16 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
While working on getting all real values for the `Attr` API, I found some errors in the data for `Element.getAttribute()`.  Chrome and Safari had support for this feature for MUCH, much longer than was initially mentioned.  Determined via manual testing.