### PR TITLE
Async Methods Safari and Safari iOS

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -840,10 +840,10 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -843,7 +843,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -840,7 +840,7 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "10.1"
               },
               "safari_ios": {
                 "version_added": "10"


### PR DESCRIPTION
Add information for async method support for Safari and Safari iOS.

Tested on Browserstack with this codepen: https://codepen.io/tbremer/pen/PoPKQzX

I tried finding release information on the Webkit blog, but the only mention of `async`/`await` I easily came across was here: https://webkit.org/blog/7477/new-web-features-in-safari-10-1/

---

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
