### PR TITLE
fix(Request): Safari 12.1+ supports `"same-origin"` default

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -830,7 +830,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -783,10 +783,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -833,7 +833,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"

--- a/api/Request.json
+++ b/api/Request.json
@@ -786,7 +786,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -833,7 +833,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "12.1"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"


### PR DESCRIPTION
This sets support for the `Request` "Default value `same-origin`" for Safari 12.1+.

I ran this: `(new Request(window.location.href)).credentials` code in Browserstack for all Safari versions, plus a local copy of Safari 13.1, here are the results:

 - 9.1 `ReferenceError: Can't find variable: Request`
 - 10.1 `"omit"`
 - 11.1 `"omit"`
 - 12.1 `"same-origin"`
 - 13: `"same-origin"`
 - 13.1: `"same-origin"`

Safari iOS:

 - 9 `ReferenceError: Can't find variable: Request`
 - 10: `"omit"`
 - 11: `"omit"`
 - 12.1: `"same-origin"`

![image](https://user-images.githubusercontent.com/118266/80709908-0ccb9080-8ae6-11ea-9815-31ea9bd24f9d.png)
![image](https://user-images.githubusercontent.com/118266/80709917-0e955400-8ae6-11ea-928c-d509071a5c01.png)

The change was documented in Safari Tech Preview 61 (https://developer.apple.com/safari/technology-preview/release-notes/#r61), 

It looks like this was originally set to `12.1` in https://github.com/mdn/browser-compat-data/pull/3283. But support was accidentally removed in https://github.com/mdn/browser-compat-data/pull/3403 As far as I can see Safari 12.0 was based off of TP58, but I don't have 12.0 to test, so I have set this to 12.1 because I can test that.
