### PR TITLE
Arrow functions don't work on IOS.

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -307,7 +307,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
On both ios safari and ios chrome i got this error :

`SyntaxError: Unexpected token '='. Expected an opening '(' before a method's parameter list.`

for this line :

`setLoading = (bool) => {`

I had to change all my arrows function with normal functions and replace this with self, and all works fine.

I tested on a real iPhone X and a real iPhone 6, and also on lambdaTest that emulate iPhones.

Hope this PR could help !