### PR TITLE
Update status of BeforeInstallPromptEvent

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -44,7 +44,7 @@
         "status": {
           "experimental": true,
           "standard_track": false,
-          "deprecated": true
+          "deprecated": false
         }
       },
       "BeforeInstallPromptEvent": {
@@ -92,7 +92,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -140,7 +140,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -188,7 +188,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -236,7 +236,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }

--- a/api/Window.json
+++ b/api/Window.json
@@ -4534,7 +4534,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This is actually not being deprecated. It's simply being moved to a different spec. As soon as it gets written [it will be here](https://github.com/WICG/beforeinstallprompt).

[From our site](https://web.dev/customize-install/):
>The Chrome team remains committed to supporting them, and has no plans to remove or deprecate support. web.dev continues to recommend using them to provide a customized install experience.