### PR TITLE
fix(Request): Firefox 65+ support `credentials` and `"same-origin"`

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -749,7 +749,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "65"
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -818,7 +818,7 @@
                 "version_added": "61"
               },
               "firefox_android": {
-                "version_added": "65"
+                "version_added": true
               },
               "ie": {
                 "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -749,7 +749,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "65"
             },
             "ie": {
               "version_added": false
@@ -818,7 +818,7 @@
                 "version_added": "61"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "65"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This sets support for the `Request` `credentials` key and "Default value `same-origin`" for Firefox on Android 65+

Similar to https://github.com/mdn/browser-compat-data/pull/6057.

I ran this: `(new Request(window.location.href)).credentials` code in Browserstack for Firefox 65 on Android. It's the only version I have access to but it supports `credentials: "same-origin"`:

![image](https://user-images.githubusercontent.com/118266/80800378-3ac1db00-8ba1-11ea-8401-50e58ccf7de0.png)

I figured I'd raise a separate PR to https://github.com/mdn/browser-compat-data/pull/6057 as this covers a slightly different issue, also I'm not sure what the protocol is around "best effort guessing"? I imagine earlier versions of Firefox for Android support this, but I don't have access to test them, is listing `65+` sufficient data considering it's likely a half truth?