### PR TITLE
Update data for Document.getAnimations()

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5114,7 +5114,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5126,7 +5126,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5138,7 +5138,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               }
@@ -5149,7 +5149,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5161,7 +5161,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5173,7 +5173,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               }
@@ -5184,7 +5184,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5196,7 +5196,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               }
@@ -5298,7 +5298,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5310,7 +5310,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5322,7 +5322,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               }
@@ -5335,7 +5335,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               },
@@ -5347,7 +5347,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features"
+                    "name": "#enable-experimental-web-platform-features"
                   }
                 ]
               }

--- a/api/Document.json
+++ b/api/Document.json
@@ -5108,37 +5108,301 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getAnimations",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "Currently available only in Firefox Nightly and Firefox Developer Edition."
-            },
-            "firefox_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "67",
+                "version_removed": "83",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see <a href='https://crbug.com/828585'>Chromium bug 828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "61",
+                "version_removed": "67",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification, does not automatically flush pending style changes and not supported on <code>ShadowRoot</code>, see Chromium bugs <a href='https://crbug.com/828424'>828424</a> and <a href='https://crbug.com/828585'>828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "67",
+                "version_removed": "83",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see <a href='https://crbug.com/828585'>Chromium bug 828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "61",
+                "version_removed": "67",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification, does not automatically flush pending style changes and not supported on <code>ShadowRoot</code>, see Chromium bugs <a href='https://crbug.com/828424'>828424</a> and <a href='https://crbug.com/828585'>828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "79",
+                "version_removed": "83",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see <a href='https://crbug.com/828585'>Chromium bug 828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "75"
+              },
+              {
+                "version_added": "72",
+                "version_removed": "75",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "63",
+                "version_removed": "72",
+                "partial_implementation": true,
+                "notes": "Not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "47",
+                "version_removed": "63",
+                "partial_implementation": true,
+                "notes": "Not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "46",
+                "version_removed": "47",
+                "partial_implementation": true,
+                "notes": "Does not return any animations on pseudo-elements and is not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "version_removed": "72",
+                "partial_implementation": true,
+                "notes": "Not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "47",
+                "version_removed": "63",
+                "partial_implementation": true,
+                "notes": "Not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "46",
+                "version_removed": "47",
+                "partial_implementation": true,
+                "notes": "Does not return any animations on pseudo-elements and is not supported on <code>ShadowRoot</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "54",
+                "version_removed": "69",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see <a href='https://crbug.com/828585'>Chromium bug 828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "54",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification, does not automatically flush pending style changes and not supported on <code>ShadowRoot</code>, see Chromium bugs <a href='https://crbug.com/828424'>828424</a> and <a href='https://crbug.com/828585'>828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "48",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see <a href='https://crbug.com/828585'>Chromium bug 828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "45",
+                "version_removed": "48",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification, does not automatically flush pending style changes and not supported on <code>ShadowRoot</code>, see Chromium bugs <a href='https://crbug.com/828424'>828424</a> and <a href='https://crbug.com/828585'>828585</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "13.1",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see Webkit bugs <a href='https://webkit.org/b/179536'>179536</a> and <a href='https://webkit.org/b/202192'>202192</a>."
+              },
+              {
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see Webkit bugs <a href='https://webkit.org/b/179536'>179536</a> and <a href='https://webkit.org/b/202192'>202192</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "13.4",
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see Webkit bugs <a href='https://webkit.org/b/179536'>179536</a> and <a href='https://webkit.org/b/202192'>202192</a>."
+              },
+              {
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification and not supported on <code>ShadowRoot</code>, see Webkit bugs <a href='https://webkit.org/b/179536'>179536</a> and <a href='https://webkit.org/b/202192'>202192</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -5255,7 +5255,6 @@
             "firefox_android": [
               {
                 "version_added": "63",
-                "version_removed": "72",
                 "partial_implementation": true,
                 "notes": "Not supported on <code>ShadowRoot</code>.",
                 "flags": [


### PR DESCRIPTION
This pull request updates the data for [DocumentOrShadowRoot.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Document/getAnimations). Please note that this is a different entry but similar function to [Element.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations).

For now, I'm not moving the data from `api.Document` to `api.DocumentOrShadowRoot`. This seems like something that should be done later by someone who can also move the page on MDN.

This feature used to exist as `AnimationTimeline.getAnimationPlayers`, ie on a different interface with an alternative name. This changed several details about the spec in a backwards-incompatible way, that imo isn't worth mentioning in BCD. You can read about the change here: https://lists.w3.org/Archives/Public/public-fx/2015JulSep/0073.html

Tests used are here:
* Basic support: https://jsbin.com/febomo/edit?html,css,js,output
* Returns css animations: https://jsbin.com/wojijux/edit?html,css,js,output
* Returns animations on pseudo-elements: https://jsbin.com/tihuvop/edit?html,css,js,output
* Web platform tests: http://wpt.live/web-animations/interfaces/DocumentOrShadowRoot/getAnimations.html

### Firefox & Firefox for Android ###

Firefox data is taken from the relevant bugs below and manual testing. The latest Android version appears to match Firefox 68 for desktop so I mirrored the data up until that release.

Web platform test results:
* v46: broken
* v52: 7 pass, 3 fail, 1 timeout
* v53: 8 pass, 3 fail
* v72: 11 pass

Relevant bugs:
* Previous implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1150810
* Basic + css animation support: https://bugzilla.mozilla.org/show_bug.cgi?id=1212720
* Returns pseudo-element animations: https://bugzilla.mozilla.org/show_bug.cgi?id=1234403
* Rename pref: https://bugzilla.mozilla.org/show_bug.cgi?id=1471814
* Supported on ShadowRoot: https://bugzilla.mozilla.org/show_bug.cgi?id=1590971
* Shipped: https://bugzilla.mozilla.org/show_bug.cgi?id=1619821

### Chrome & Chrome for Android ###

Chrome data is taken from the relevant bugs below and manual testing. The only anomaly is despite merging a fix to always flush pending style changes in the 66 branch, I still have intermittent failures until 67. The latest Android version appears to match the latest desktop version so I mirrored the data.

Web platform test results:
* v61: 3 pass, 7 fail, 1 timeout
* v67: 5 pass, 5 fail, 1 timeout
* v74: 6 pass, 5 fail
* v83: 11 pass

Relevant bugs:
* Previous implementation: https://bugs.chromium.org/p/chromium/issues/detail?id=391364
* Rename function: https://bugs.chromium.org/p/chromium/issues/detail?id=483272
* Move to Document interface: https://bugs.chromium.org/p/chromium/issues/detail?id=624639
* Flush pending style changes: https://bugs.chromium.org/p/chromium/issues/detail?id=813908
* Update to latest spec: https://bugs.chromium.org/p/chromium/issues/detail?id=828424 and https://bugs.chromium.org/p/chromium/issues/detail?id=828585
* Support on ShadowRoot: https://bugs.chromium.org/p/chromium/issues/detail?id=1046916
* Shipped: https://bugs.chromium.org/p/chromium/issues/detail?id=978551

### Safari & Safari for iOS ###

Stable Safari data is taken from manual testing and Technology Preview data is taken from the [Web Platform Tests Dashboard here](https://wpt.fyi/results/web-animations/interfaces/DocumentOrShadowRoot/getAnimations.html?run_id=524320002&run_id=518530001&run_id=528080001&run_id=499760002). Unfortunately due to the limitations of browserstack and Apple's bug tracking, I can't narrow down the versions before 13 any further. The latest Technology Preview still fails two web platform tests but these seem minor to me compared to eg Safari 13.1, Chrome 81, etc, so I have marked Safari 14 as supported for the time being.

Web platform test results:
* v10-10.1: 1 pass, 10 fail
* v11-11.1: 1 pass, 9 fail, 1 timeout
* v12-12.1: 6 pass, 5 fail
* v13: 6 pass, 5 fail
* v13.1: 6 pass, 5 fail
* TP105: 9 pass, 2 fail

Relevant bugs:
* Basic support: https://bugs.webkit.org/show_bug.cgi?id=156096, https://bugs.webkit.org/show_bug.cgi?id=179535 and https://bugs.webkit.org/show_bug.cgi?id=179536
* Support on ShadowRoot: https://bugs.webkit.org/show_bug.cgi?id=202192

### Edge ###

Edge 18 does not support the web animations API at all so the Edge data is mirrored from Chrome.

### Opera & Opera for Android ###

Mirrored from Chrome and Chrome for Android. I verified Opera 69 data manually since its engine version data in BCD is out of date.