### PR TITLE
el.(set|release|has)PointerCapture() in Safari 13

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4461,10 +4461,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -6291,10 +6291,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -7997,10 +7997,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
https://trac.webkit.org/changeset/240634/webkit#file16 added support to `Element` for the `setPointerCapture()`, `releasePointerCapture()`, and `hasPointerCapture()` methods

Per https://trac.webkit.org/log/webkit/tags/Safari-608.1.27.2 that change went into WebKit 608.1.27.2 and so into Safari 13 and iOS Safari 13.

Fixes https://github.com/mdn/browser-compat-data/issues/6062