### PR TITLE
File.p.(webkitRelativePath|lastModified) in Safari

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -139,10 +139,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -334,10 +334,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "prefix": "webkit",


### PR DESCRIPTION
https://trac.webkit.org/changeset/221177/webkit#file23 added support in WebKit for `File.prototype.webkitRelativePath`. That puts it in WebKit 604.2.6 per https://trac.webkit.org/log/webkit/tags/Safari-604.2.6, which means it shipped in Safari 11.1 and iOS Safari 11.3.

https://trac.webkit.org/changeset/200032/webkit#file16 added support in WebKit for `File.prototype.lastModified`. That puts it in WebKit 602.1.30 per https://trac.webkit.org/log/webkit/tags/Safari-602.1.30, which means it shipped in Safari 10 and iOS Safari 10. That’s also confirmed by https://developer.apple.com/documentation/webkitjs/file/1777749-lastmodified

Fixes https://github.com/mdn/browser-compat-data/issues/4998