### PR TITLE
File and Directory Entries API in Safari 11.1

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -35,10 +35,10 @@
             "prefix": "webkit"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -84,10 +84,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -132,10 +132,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -33,10 +33,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -132,10 +132,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -182,10 +182,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -33,10 +33,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -129,10 +129,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -177,10 +177,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -273,10 +273,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -321,10 +321,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -369,10 +369,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -465,10 +465,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1575,10 +1575,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1622,10 +1622,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
https://trac.webkit.org/changeset/222412/webkit enabled WebKit support for the File and Directory Entries API, including `DataTransferItem.p.webkitGetAsEntry`, `HTMLInputElement.p.webkitdirectory`, `HTMLInputElement.p.webkitEntries`, `FileSystem, FileSystemDirectoryEntry`, `FileSystemDirectoryReader`, `FileSystemEntry`, and `FileSystemFileEntry`.

Per https://trac.webkit.org/log/webkit/tags/Safari-605.1.7.1, that puts all those
in WebKit 605.1.7.1 — which means they shipped in Safari 11.1 and iOS Safari 11.3.

Fixes https://github.com/mdn/browser-compat-data/issues/5356