### PR TITLE
Mark DataTransferItem supported in Safari 5.1

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -29,10 +29,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
https://trac.webkit.org/changeset/80536/webkit added `DataTransferItem` support to WebKit. Per https://trac.webkit.org/log/webkit/tags/Safari-534.24 that puts it in WebKit 534.24, which means it shipped in Safari 5.1.