### PR TITLE
Mark DataTransferItemList supported in Safari 6

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -29,10 +29,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "11.1"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -126,10 +126,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -174,10 +174,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -222,7 +222,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": false

--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -225,7 +225,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
https://trac.webkit.org/changeset/98821/webkit is when `DataTransferItemList` landed in WebKit. Per https://trac.webkit.org/log/webkit/tags/Safari-534.52.7 that puts it in 534.52.7, which means it shipped in Safari 6.