### PR TITLE
DataTransferItemList.p.remove support in Safari 6

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -270,10 +270,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
https://trac.webkit.org/changeset/220829/webkit added support for `DataTransferItemList.p.remove` to WebKit. So https://trac.webkit.org/log/webkit/tags/Safari-604.2.4, which means Safari 6.