### PR TITLE
Update DataTransferItemList Chrome support data

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -35,10 +35,10 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>DataTransferItemList[]</code>",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -83,10 +83,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
@@ -132,10 +132,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/clear",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -180,10 +180,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -198,10 +198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/length",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -228,10 +228,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -246,10 +246,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/remove",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -276,10 +276,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
https://source.chromium.org/chromium/chromium/src/+/9f23921 and https://src.chromium.org/viewvc/blink?revision=156015&view=revision show that `DataTransferItemList.p.remove()` support was added to the Blink sources in 2013-08-13. Based on that date, that’d seem to mean it shipped in Chrome 30.

---

For the days and weeks after `DataTransferItemList.p.remove()` landed in the sources on 2013-08-13, here are the release dates:

 * Chrome 29: 2013-08-20
 * Chrome 30: 2013-10-01
 * Chrome 31: 2013-11-12
 * Chrome 32: 2014-01-14

So it’s not impossible it shipped in Chrome 29 — just three days after being merged — but that seems unlikely. I guess it’s also possible it shipped as late as 5 months or so later, in Chrome 32. But it seems most likely it shipped in Chrome 30, around 45 days after it landed.

In general, for Blink/Chromium changes from that era — which I guess amounts to the range of some years after Blink was first split off from WebKit but before systematic association of tags with revisions started happening — I don’t know how to deterministically identify what Chrome release a particular revision shipped in.

I tried https://storage.googleapis.com/chromium-find-releases-static/index.html with 9f239214f3c903fd7ad4491a67372070d116325c but it didn’t give me anything…

cc @jpmedley for guidance