### PR TITLE
Fill in missing IE compat data for DOMTokenList

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -211,7 +211,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "32"
@@ -355,7 +355,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "32"
@@ -403,7 +403,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -598,7 +598,7 @@
               "version_added": "49"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -840,7 +840,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "37",
@@ -892,7 +892,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "32"


### PR DESCRIPTION
Fill in compat data for the `entries`, `keys`, `replace` and `values` methods and the `length` and `value` properties.

