### PR TITLE
fix: add NodeJS support for Intl.NumberFormat

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": "15"
@@ -78,7 +78,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -130,7 +130,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -182,7 +182,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "51"
@@ -234,7 +234,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -286,7 +286,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"


### PR DESCRIPTION
This sets support for `NumberFormat` for all versions of NodeJS, and `formatToParts` to version `10.0.0`+ of NodeJS.

In my local development environment, I ran the following (I'm using Fish shell, and have `asdf` installed with the NodeJS plugin):

```fish
for v in (asdf list nodejs | sort -n)
    set trimmed (echo $v|xargs echo -n)
    asdf shell nodejs $trimmed
    node -e 'console.log(process.version, Intl.NumberFormat, Intl.NumberFormat().formatToParts)'
end
```

which gave me the following:

```
v0.12.18 function () { [native code] } undefined
v4.9.1 function () { [native code] } undefined
v5.12.0 function () { [native code] } undefined
v6.17.1 function NumberFormat() { [native code] } undefined
v6.4.0 function () { [native code] } undefined
v7.10.1 function NumberFormat() { [native code] } undefined
v8.17.0 function NumberFormat() { [native code] } undefined
v10.0.0 function NumberFormat() { [native code] } function formatToParts() { [native code] }
v10.20.1 function NumberFormat() { [native code] } function formatToParts() { [native code] }
v11.11.0 function NumberFormat() { [native code] } function formatToParts() { [native code] }
v12.16.2 [Function: NumberFormat] [Function: formatToParts]
v14.0.0 [Function: NumberFormat] [Function: formatToParts]
```

From this we can deduce that pretty much all versions of NodeJS support `NumberFormat` (I can't download older versions of Node as they're not signed correctly), meanwhile v10.0.0+ seems to support `formatToParts` in some manner.