### PR TITLE
fix: add NodeJS support for non constructrable generator methods

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -882,7 +882,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "29"


### PR DESCRIPTION
This sets the `"Generator methods are not constructable (ES2016)"` support for NodeJS to 6+, as tested locally.

In my local development environment, I ran the following (I'm using Fish shell, and have `asdf` installed with the NodeJS plugin):

```fish
for v in (asdf list nodejs | sort -n)
    set trimmed (echo $v|xargs echo -n)
    asdf shell nodejs $trimmed
    echo "Version $trimmed:"
    node -e 'const objB = { * g() {} }; new objB.g'
    echo "-----"
end
```

<details><summary>which gave me the following:</summary>

```
Version 0.12.18:
[eval]:1
const objB = { * g() {} }; new objB.g
               ^
SyntaxError: Unexpected token *
    at Object.exports.runInThisContext (vm.js:73:16)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:460:26)
    at evalScript (node.js:431:25)
    at startup (node.js:90:7)
    at node.js:814:3
-----
Version 4.9.1:
-----
Version 5.12.0:
-----
Version 6.17.1:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at ContextifyScript.Script.runInThisContext (vm.js:25:33)
    at Object.runInThisContext (vm.js:97:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:577:32)
    at evalScript (bootstrap_node.js:358:27)
    at run (bootstrap_node.js:133:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:132:9)
    at bootstrap_node.js:507:3
-----
Version 6.4.0:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at ContextifyScript.Script.runInThisContext (vm.js:25:33)
    at Object.exports.runInThisContext (vm.js:77:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:556:32)
    at bootstrap_node.js:357:29
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
-----
Version 7.10.1:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at ContextifyScript.Script.runInThisContext (vm.js:23:33)
    at Object.runInThisContext (vm.js:95:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:571:32)
    at evalScript (bootstrap_node.js:391:27)
    at run (bootstrap_node.js:124:11)
    at run (bootstrap_node.js:427:7)
    at startup (bootstrap_node.js:123:9)
    at bootstrap_node.js:542:3
-----
Version 8.17.0:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
    at Object.runInThisContext (vm.js:139:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:653:30)
    at evalScript (bootstrap_node.js:479:27)
    at startup (bootstrap_node.js:180:9)
    at bootstrap_node.js:625:3
-----
Version 10.0.0:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at Script.runInThisContext (vm.js:91:20)
    at Object.runInThisContext (vm.js:298:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at evalScript (internal/bootstrap/node.js:542:27)
    at startup (internal/bootstrap/node.js:204:9)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:575:3)
-----
Version 10.20.1:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at Script.runInThisContext (vm.js:122:20)
    at Object.runInThisContext (vm.js:329:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at evalScript (internal/bootstrap/node.js:590:27)
    at startup (internal/bootstrap/node.js:265:9)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
-----
Version 11.11.0:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at Script.runInThisContext (vm.js:124:20)
    at Object.runInThisContext (vm.js:314:38)
    at Object.<anonymous> ([eval]-wrapper:9:26)
    at Module._compile (internal/modules/cjs/loader.js:799:30)
    at evalScript (internal/process/execution.js:60:25)
    at internal/main/eval_string.js:16:1
-----
Version 12.16.2:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at Script.runInThisContext (vm.js:120:20)
    at Object.runInThisContext (vm.js:311:38)
    at Object.<anonymous> ([eval]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:1156:30)
    at evalScript (internal/process/execution.js:94:25)
    at internal/main/eval_string.js:23:3
-----
Version 14.0.0:
[eval]:1
const objB = { * g() {} }; new objB.g
                           ^

TypeError: objB.g is not a constructor
    at [eval]:1:28
    at Script.runInThisContext (vm.js:131:20)
    at Object.runInThisContext (vm.js:297:38)
    at Object.<anonymous> ([eval]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:1185:30)
    at evalScript (internal/process/execution.js:94:25)
    at internal/main/eval_string.js:23:3
-----
```

</details>

From this we can deduce that version 6+ throws errors with constructing generator functions (I tested 6.40/6.17.1 but NodeJS follows Semver so this would have been introduced in 6.0).