### PR TITLE
fix: add NodeJS support for Symbol.toPrimitive

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1163,7 +1163,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "34"


### PR DESCRIPTION
This sets the `'@@toPrimitive"` (aka `Symbol.toPrimitive`) support for NodeJS to 6+, as tested locally.

In my local development environment, I ran the following (I'm using Fish shell, and have `asdf` installed with the NodeJS plugin):

```fish
for v in (asdf list nodejs | sort -n)
    set trimmed (echo $v|xargs echo -n)
    asdf shell nodejs $trimmed
    node -e 'console.log(process.version, Symbol.toPrimitive)'
end
```

which gave me the following:

```
v0.12.18 undefined
v4.9.1 undefined
v5.12.0 undefined
v6.4.0 Symbol(Symbol.toPrimitive)
v6.17.1 Symbol(Symbol.toPrimitive)
v7.10.1 Symbol(Symbol.toPrimitive)
v8.17.0 Symbol(Symbol.toPrimitive)
v10.0.0 Symbol(Symbol.toPrimitive)
v10.20.1 Symbol(Symbol.toPrimitive)
v11.11.0 Symbol(Symbol.toPrimitive)
v12.16.2 Symbol(Symbol.toPrimitive)
v14.0.0 Symbol(Symbol.toPrimitive)
```

From this we can deduce that NodeJS 6+ has support for `Symbol.toPrimitive` (I tested 6.4.0/6.17.0 but NodeJS follows Semver so this would have been introduced in 6.0).