### PR TITLE
Mark DataTransferItemList supported in Chrome 13

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -35,10 +35,10 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>DataTransferItemList[]</code>",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -83,10 +83,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
@@ -132,10 +132,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/clear",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -180,10 +180,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -198,10 +198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/length",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -228,10 +228,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4"
             }
           },
           "status": {


### PR DESCRIPTION
https://trac.webkit.org/changeset/98821/webkit is when `DataTransferItemList` landed in WebKit. That puts it in https://trac.webkit.org/log/webkit/tags/Safari-534.52.7, which means it shipped in Chrome 13.