### PR TITLE
Mark DataTransferItem supported in Chrome 11

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "11"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -35,10 +35,10 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsFile",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,10 +82,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsString",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -130,10 +130,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/kind",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -178,10 +178,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4"
             }
           },
           "status": {
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/type",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -226,10 +226,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4"
             }
           },
           "status": {


### PR DESCRIPTION
https://trac.webkit.org/changeset/80536/webkit added `DataTransferItem` support to WebKit. https://trac.webkit.org/log/webkit/tags/Safari-534.24 is where that puts it, which means it shipped in Chrome 11.