### PR TITLE
Update autocapitalize attribute support.

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -57,16 +57,16 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "66"
             },
             "edge": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -96,7 +96,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "66"
             }
           },
           "status": {


### PR DESCRIPTION
According to https://www.chromestatus.com/feature/4974738740871168,
Chrome Android and WebView support this on 66.

Also, this attribute doesn't support on Gecko yet. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1425291.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
