### PR TITLE
Fx76 Intersection Observer document support

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -346,7 +346,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "81"

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -91,7 +91,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "safari": {
               "version_added": "12.1"
@@ -110,6 +110,48 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "document_as_root": {
+          "__compat": {
+            "description": "<code>root</code> can be a <code>Document</code>",
+            "support": {
+              "chrome": {
+                "version_added": "81"
+              },
+              "chrome_android": {
+                "version_added": "81"
+              },
+              "edge": {
+                "version_added": "81"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "81"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -273,6 +315,48 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "document_as_root": {
+          "__compat": {
+            "description": "<code>root</code> can be a <code>Document</code>",
+            "support": {
+              "chrome": {
+                "version_added": "81"
+              },
+              "chrome_android": {
+                "version_added": "81"
+              },
+              "edge": {
+                "version_added": "81"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "81"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -141,7 +141,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "81"


### PR DESCRIPTION
You can now specify a `document` as the `root` of an `IntersectionObserver`.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1623623
* https://groups.google.com/forum/#!msg/mozilla.dev.platform/64nDLTAZGzY/CQMV7WqtCAAJ