### PR TITLE
Update sharedwokers

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "12"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "29"
@@ -20,7 +20,7 @@
             "version_added": "33"
           },
           "ie": {
-            "version_added": "10"
+            "version_added": false
           },
           "opera": {
             "version_added": "10.6"
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "29"
@@ -70,7 +70,7 @@
               "version_added": "33"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "10.6"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "29"
@@ -216,7 +216,7 @@
               "version_added": "33"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "10.6"

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -38,8 +38,8 @@
             "version_removed": "7"
           },
           "samsunginternet_android": {
-            "version_added": "4",
-            "version_removed": "5"
+            "version_added": "4.0",
+            "version_removed": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -90,8 +90,8 @@
               "version_removed": "7"
             },
             "samsunginternet_android": {
-              "version_added": "4",
-              "version_removed": "5"
+              "version_added": "4.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -238,8 +238,8 @@
               "version_removed": "7"
             },
             "samsunginternet_android": {
-              "version_added": "4",
-              "version_removed": "5"
+              "version_added": "4.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -8,7 +8,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
             "version_added": "79"
@@ -26,7 +26,8 @@
             "version_added": "10.6"
           },
           "opera_android": {
-            "version_added": "11"
+            "version_added": "11",
+            "version_removed": "14"
           },
           "safari": {
             "version_added": "5",
@@ -37,7 +38,8 @@
             "version_removed": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4",
+            "version_removed": "5"
           },
           "webview_android": {
             "version_added": false
@@ -58,7 +60,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "79"
@@ -76,7 +78,8 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "11"
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": "5",
@@ -87,7 +90,8 @@
               "version_removed": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "5"
             },
             "webview_android": {
               "version_added": false
@@ -204,7 +208,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "79"
@@ -222,7 +226,8 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "11"
+              "version_added": "11",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": "5",
@@ -233,7 +238,8 @@
               "version_removed": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "5"
             },
             "webview_android": {
               "version_added": false

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -111,7 +111,7 @@
                 "version_added": null
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -159,7 +159,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": "≤79"
@@ -171,7 +171,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -186,7 +186,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0",
+                "version_removed": "5.0"
               },
               "webview_android": {
                 "version_added": false

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -129,7 +129,7 @@
                 "version_added": null
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -138,7 +138,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -177,7 +177,7 @@
                 "version_added": null
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
The support data for `SharedWorker` [on Caniuse](https://caniuse.com/#feat=sharedworkers) is very different from the one [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker#Browser_compatibility).

I ran some tests to align them, and it seems like MDN is wrong in this case. I have checked the history of the MDN table all the way back to the initial commit (#947), and i cannot find any source for the numbers on MDN.

Closes #5850
Closes Fyrd/caniuse#5387

## Accurate changes
I ran manual testing for these changes with the [caniuse test](https://tests.caniuse.com/?feat=sharedworkers) and some manual console work on the side to make sure the test was correct. I tested the current stable versions and the versions immediately before and after any alleged change according to either dataset.
The changes also align perfectly with the caniuse support table.

IE `10-11`->`false`

Edge `12+`->`79+`

## Mostly acccurate changes
These changes might not be perfect, but they bring the dataset much closer to the truth.
I have no way of testing older mobile browsers properly, but the current versions of these browsers, plus some random old versions i have access to (released 2013 - 2016) do not support `SharedWorker`.
The tests i was able to perform all aligned with caniuse, so i have based the specific details on the caniuse data.

Chrome Android `true`->`false`

Opera Android `11+`->`11-12.1`
This makes perfect sense, since 12.1 was the last version before Opera became Chromium-based.

Samsung Internet `true`->`4-4.2`
This data looks a little suspicious to me, but is definetely possible.

## Still needs fixing
A lot of compatibility data on the [SharedWorkerGlobalScope](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorkerGlobalScope) is showing support before `SharedWorker` was supported. Pretty sure that's wrong.

It would be great if you could fix (no, Github, i'm not fixing it) #4206 ([Mozilla bug 1417902 \#3](https://bugzilla.mozilla.org/show_bug.cgi?id=1417902#:~:text=3%29%20Look%20at%20the%20compatibility%20table%2E)). I spent a solid 20 minutes being confused about that and almost rewrote my commit even though it was correct.