### PR TITLE
Rename Feature Policy directive for WebAuthn

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1386,9 +1386,9 @@
             }
           }
         },
-        "publickey-credentials": {
+        "publickey-credentials-get": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/publickey-credentials",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/publickey-credentials-get",
             "support": {
               "chrome": {
                 "version_added": false,


### PR DESCRIPTION
Feature Policy directive controlling WebAuth was renamed from
publickey-credentials to publickey-credentials-get.
Sources:
  Feature Policy change:
    https://github.com/w3c/webappsec-feature-policy/pull/370
  WebAuthn specification change:
    https://github.com/w3c/webauthn/pull/1394
  Chrome already updated the name:
    https://crbug.com/993007#c9

Fortunately, this directive wasn't shipped anywhere yet, so there is no actual compat data to be updated. Even Chromium bug number is still relevant.

Relevant sprint issue: https://github.com/mdn/sprints/issues/3214

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
