### PR TITLE
MouseEvent.p.(movementX|movementY) in Safari 9

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -841,12 +841,26 @@
             "opera_android": {
               "version_added": true
             },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "8",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "8"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "8",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "3.0"
@@ -931,12 +945,26 @@
             "opera_android": {
               "version_added": true
             },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "8",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "8"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "8",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "3.0"


### PR DESCRIPTION
https://trac.webkit.org/changeset/170585/#file8 is when WebKit landed un-prefixed `MouseEvent.p.movementX` and `MouseEvent.p.movementY`.  That puts it in https://trac.webkit.org/log/webkit/tags/Safari-538.44, which means it shipped in Safari 9.

Prior to that, https://trac.webkit.org/changeset/100366/#file2 had landed prefixed support; https://trac.webkit.org/browser/webkit/tags/Safari-535.9, Safari 6.

Fixes https://github.com/mdn/browser-compat-data/issues/5775