### PR TITLE
Opera 68 is released

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -541,7 +541,7 @@
           "engine_version": "83"
         },
         "70": {
-          "status": "beta",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "84"
         }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -524,19 +524,26 @@
         "67": {
           "release_date": "2020-03-03",
           "release_notes": "https://blogs.opera.com/desktop/2020/03/opera-67-3575-53-stable-update/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "68": {
-          "status": "beta",
+          "release_date": "2020-04-22",
+          "release_notes": "https://blogs.opera.com/desktop/2020/04/opera-68-is-here-with-built-in-instagram-in-the-sidebar/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "81"
         },
         "69": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
-          "engine_version": "82"
+          "engine_version": "83"
+        },
+        "70": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "84"
         }
       }
     }


### PR DESCRIPTION
Opera 68 was released about two weeks ago.  This PR updates the BCD to reflect this information.  It also includes some updates to the beta/nightly releases of Opera, specifically that Opera 69 will be released with Chrome 83 as its engine.  (As such, this fixes #6079.)