### PR TITLE
Chrome 81 is released

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -560,19 +560,26 @@
         "80": {
           "release_date": "2020-02-04",
           "release_notes": "https://chromereleases.googleblog.com/2020/02/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2020-04-07",
+          "release_notes": "https://chromereleases.googleblog.com/2020/04/stable-channel-update-for-desktop_7.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
+        },
+        "84": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "84"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -397,19 +397,26 @@
         "80": {
           "release_date": "2020-02-04",
           "release_notes": "https://chromereleases.googleblog.com/2020/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2020-04-07",
+          "release_notes": "https://chromereleases.googleblog.com/2020/04/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
+        },
+        "84": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "84"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -388,19 +388,26 @@
         "80": {
           "release_date": "2020-02-04",
           "release_notes": "https://chromereleases.googleblog.com/2020/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2020-04-07",
+          "release_notes": "https://chromereleases.googleblog.com/2020/04/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
+        },
+        "84": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "84"
         }
       }
     }


### PR DESCRIPTION
Chrome 81 has been released as of last month.  This PR updates the data accordingly.  (Since it also adds Chrome 84 as the new nightly, this fixes #6056.)