### PR TITLE
Edge 81 is released

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -62,19 +62,27 @@
         },
         "80": {
           "release_date": "2020-02-07",
-          "status": "current",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-80036148-february-7",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2020-04-13",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-81041653-april-13",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
+        },
+        "84": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "84"
         }
       }
     }


### PR DESCRIPTION
Microsoft Edge 81 is out.  This PR updates the data accordingly, and adds release notes for both it and Edge 80.