### PR TITLE
Firefox 76 is released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -591,6 +591,13 @@
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "80"
+        },
+        "81": {
+          "release_date": "2020-09-22",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "81"
         }
       }
     }

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -546,35 +546,35 @@
         "74": {
           "release_date": "2020-03-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/74",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "74"
         },
         "75": {
           "release_date": "2020-04-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/75",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "75"
         },
         "76": {
           "release_date": "2020-05-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/76",
-          "status": "nightly",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "76"
         },
         "77": {
           "release_date": "2020-06-02",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/77",
-          "status": "planned",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "77"
         },
         "78": {
           "release_date": "2020-06-30",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/78",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "78"
         },


### PR DESCRIPTION
As of today, Firefox 76 is out.  This PR updates the data accordingly, marking Firefox 74 and 75 as retired.  This also adds Firefox 81 as a planned release, with the date listed on https://wiki.mozilla.org/Release_Management/Calendar.