### PR TITLE
Add statuses for NodeJS releases

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -6,210 +6,245 @@
         "0.1.100": {
           "release_date": "2010-07-03",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.100/ChangeLog",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "2.2"
         },
         "0.1.101": {
           "release_date": "2010-07-16",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.101/ChangeLog",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "2.2"
         },
         "0.1.104": {
           "release_date": "2010-08-13",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.104/ChangeLog",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "2.2"
         },
         "0.9.1": {
           "release_date": "2012-08-28",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.9.1/ChangeLog",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "3.11"
         },
         "0.10": {
           "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "3.14"
         },
         "0.12": {
           "release_date": "2015-02-06",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "3.28"
         },
         "4.0.0": {
           "release_date": "2015-09-08",
           "release_notes": "https://nodejs.org/en/blog/release/v4.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "4.5"
         },
         "5.0.0": {
           "release_date": "2015-10-29",
           "release_notes": "https://nodejs.org/en/blog/release/v5.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "4.6"
         },
         "6.0.0": {
           "release_date": "2016-04-26",
           "release_notes": "https://nodejs.org/en/blog/release/v6.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5"
         },
         "6.5.0": {
           "release_date": "2016-08-26",
           "release_notes": "https://nodejs.org/en/blog/release/v6.5.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.1"
         },
         "7.0.0": {
           "release_date": "2016-10-25",
           "release_notes": "https://nodejs.org/en/blog/release/v7.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.4"
         },
         "7.5.0": {
           "release_date": "2017-01-31",
           "release_notes": "https://nodejs.org/en/blog/release/v7.5.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.4"
         },
         "7.6.0": {
           "release_date": "2017-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v7.6.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
         "7.7.0": {
           "release_date": "2017-02-28",
           "release_notes": "https://nodejs.org/en/blog/release/v7.7.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
         "7.10.0": {
           "release_date": "2017-05-02",
           "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
         "8.0.0": {
           "release_date": "2017-05-30",
           "release_notes": "https://nodejs.org/en/blog/release/v8.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "5.8"
         },
         "8.3.0": {
           "release_date": "2017-08-09",
           "release_notes": "https://nodejs.org/en/blog/release/v8.3.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.0"
         },
         "8.5.0": {
           "release_date": "2017-09-12",
           "release_notes": "https://nodejs.org/en/blog/release/v8.5.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.0"
         },
         "8.7.0": {
           "release_date": "2017-10-11",
           "release_notes": "https://nodejs.org/en/blog/release/v8.7.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.1"
         },
         "8.10.0": {
           "release_date": "2018-03-06",
           "release_notes": "https://nodejs.org/en/blog/release/v8.10.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.2"
         },
         "9.3.0": {
           "release_date": "2017-12-12",
           "release_notes": "https://nodejs.org/en/blog/release/v9.3.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.2"
         },
         "10.0.0": {
           "release_date": "2018-04-24",
           "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.6"
         },
         "10.4.0": {
           "release_date": "2018-06-06",
           "release_notes": "https://nodejs.org/en/blog/release/v10.4.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
         "10.5.0": {
           "release_date": "2018-06-20",
           "release_notes": "https://nodejs.org/en/blog/release/v10.5.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
         "10.7.0": {
           "release_date": "2018-07-18",
           "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
         "10.9.0": {
           "release_date": "2018-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "6.8"
         },
         "11.0.0": {
           "release_date": "2018-10-23",
           "release_notes": "https://nodejs.org/en/blog/release/v11.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.0"
         },
         "11.7.0": {
           "release_date": "2019-01-18",
           "release_notes": "https://nodejs.org/en/blog/release/v11.7.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.0"
         },
         "12.0.0": {
           "release_date": "2019-04-23",
           "release_notes": "https://nodejs.org/en/blog/release/v12.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.4"
         },
         "12.5.0": {
           "release_date": "2019-06-27",
           "release_notes": "https://nodejs.org/en/blog/release/v12.5.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.5"
         },
         "12.9.0": {
           "release_date": "2019-08-20",
           "release_notes": "https://nodejs.org/en/blog/release/v12.9.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.6"
         },
         "12.11.0": {
           "release_date": "2019-09-25",
           "release_notes": "https://nodejs.org/en/blog/release/v12.11.0/",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "7.7"
         },
         "13.0.0": {
           "release_date": "2019-10-10",
           "release_notes": "https://nodejs.org/en/blog/release/v13.0.0/",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.8"
         },
         "13.2.0": {
           "release_date": "2019-11-21",
           "release_notes": "https://nodejs.org/en/blog/release/v13.2.0/",
+          "status": "current",
           "engine": "V8",
           "engine_version": "7.9"
         },
         "14.0.0": {
           "release_date": "2020-04-21",
           "release_notes": "https://nodejs.org/en/blog/release/v14.0.0/",
+          "status": "current",
           "engine": "V8",
           "engine_version": "8.1"
         }


### PR DESCRIPTION
I was looking at all of our browser data to provide updates, and I saw NodeJS without statuses.  I figured that while I was here, I could try to add statuses to all the NodeJS releases.

Most of my data comes from https://nodejs.org/en/about/releases/.  All old NodeJS editions are marked as Retired, as well as all minor releases that aren't the most recent of a current or LTS release.  The most recent minor versions of active LTS releases are marked as "ESR", and the most recent minor versions of current releases are marked as "current".

This fixes #2446.