### PR TITLE
Samsung Internet 11.2 and 12.0 are released

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -155,6 +155,12 @@
         },
         "11.0": {
           "release_date": "2019-12-05",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "75"
+        },
+        "11.2": {
+          "release_date": "2020-05-01",
           "status": "current",
           "engine": "Blink",
           "engine_version": "75"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -161,9 +161,15 @@
         },
         "11.2": {
           "release_date": "2020-05-01",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "75"
+        },
+        "12.0": {
+          "release_date": "2020-05-07",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "79"
         }
       }
     }


### PR DESCRIPTION
Took a look at my testing device to find that Samsung Internet 11.2 is now out.  Release date comes from https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-for-android-11-2-1-3-release/.

Edit: this also includes data for Samsung Internet 12.0, therefore making this a cherrypick of the browser data from #6113.