### PR TITLE
Add missing require() to style test

### DIFF
--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -1,6 +1,7 @@
 'use strict';
 const fs = require('fs');
 const chalk = require('chalk');
+const url = require('url');
 const { IS_WINDOWS, indexToPos, jsonDiff } = require('../utils.js');
 const compareFeatures = require('../../scripts/compare-features');
 


### PR DESCRIPTION
Found in the error logs for #5894.  Apparently, we're missing an import for `url` in our test...which makes me wonder why this wasn't an issue already.  This PR adds the import for the `url` module, therefore fixing the missing import.