### PR TITLE
Chrome doesn't support autocomplete=off

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -113,21 +113,33 @@
             "chrome": [
               {
                 "version_added": "66",
-                "notes": "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements."
+                "notes": [
+                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                  "Chrome does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               },
               {
                 "version_added": true,
-                "notes": "Originally only supported on the <code>&lt;input&gt;</code> element."
+                "notes": [
+                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                  "Chrome does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               }
             ],
             "chrome_android": [
               {
                 "version_added": "66",
-                "notes": "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements."
+                "notes": [
+                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                  "Chrome does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               },
               {
                 "version_added": true,
-                "notes": "Originally only supported on the <code>&lt;input&gt;</code> element."
+                "notes": [
+                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                  "Chrome does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               }
             ],
             "edge": {
@@ -159,11 +171,17 @@
             },
             "samsunginternet_android": [
               {
-                "notes": "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                "notes": [
+                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                  "Samsung Internet does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ],
                 "version_added": "9.0"
               },
               {
-                "notes": "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                "notes": [
+                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                  "Samsung Internet does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ],
                 "version_added": true
               }
             ],
@@ -176,11 +194,17 @@
             "webview_android": [
               {
                 "version_added": "66",
-                "notes": "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements."
+                "notes": [
+                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                  "WebView does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               },
               {
                 "version_added": true,
-                "notes": "Originally only supported on the <code>&lt;input&gt;</code> element."
+                "notes": [
+                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                  "WebView does not accept <code>off</code> as a value.  See <a href='https://crbug.com/587466'>bug 587466</a>."
+                ]
               }
             ]
           },


### PR DESCRIPTION
Part of work for #5932.  It was reported that Chrome doesn't support setting `autocomplete` to `off`...which is unfortunately true.  This PR updates our data to add a note indicating as such.