### PR TITLE
Fix Edge note for HTML summary element

### DIFF
--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -54,15 +54,15 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
+                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
               },
               "chrome_android": {
                 "version_added": false,
-                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
+                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
               },
               "edge": {
                 "version_added": false,
-                "notes": "Edge currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Edge. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
+                "notes": "Edge currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Edge. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
               },
               "firefox": {
                 "version_added": "49"

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -62,7 +62,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "Edge currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Edge. See <a href='https://crbug.com/590014'>Edge bug 590014</a> for details."
+                "notes": "Edge currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Edge. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
               },
               "firefox": {
                 "version_added": "49"


### PR DESCRIPTION
Part of work for #5932.  This fixes a slight issue in an Edge note that reads "Edge bug" instead of what's supposed to be "Chrome bug".