### PR TITLE
Update Chromium/Safari data for form novalidate

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -429,7 +429,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "10"
               },
               "chrome_android": {
                 "version_added": "18"
@@ -450,13 +450,13 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
Part of work for #5932.  This PR updates Chrome and Safari data for the `novalidate` attribute to the form element.  This feature was supported since Chrome 10 and Safari 10.1 -- these are the first versions that support validation as well.