### PR TITLE
Explicitly set arrowParens for Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
+  "arrowParens": "avoid",
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
In Prettier v2.0, the default for `arrowParens` was changed from `avoid` to `always`.  To help with the transition in the future, this PR explicitly sets `arrowParents` to `avoid` to keep this preference across Prettier versions.  (Alternatively, we can switch to the new default now.)

This fixes #6088.