### PR TITLE
Update data for AbsoluteOrientationSensor API

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "56"
@@ -26,7 +26,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -56,10 +56,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -68,7 +68,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR updates the `AbsoluteOrientationSensor` API data based upon manual testing.  Data is as follows:

```
api.AbsoluteOrientationSensor
	- Firefox - false
	- IE - false
	- Safari - false
api.AbsoluteOrientationSensor.AbsoluteOrientationSensor
	- Firefox - false
	- IE - false
	- Safari - false
```