### PR TITLE
Update data for Accelerometer API

### DIFF
--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -14,13 +14,13 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "56"
@@ -29,10 +29,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -62,13 +62,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -77,10 +77,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -110,13 +110,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -125,10 +125,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -158,13 +158,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -173,10 +173,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -206,13 +206,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -221,10 +221,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR updates the `Accelerometer` API data based upon manual testing. Data is as follows:

```
api.Accelerometer
	- Firefox - false
	- IE - false
	- Safari - false
api.Accelerometer.Accelerometer
	- Firefox - false
	- IE - false
	- Safari - false
api.Accelerometer.x
	- Firefox - false
	- IE - false
	- Safari - false
api.Accelerometer.y
	- Firefox - false
	- IE - false
	- Safari - false
api.Accelerometer.z
	- Firefox - false
	- IE - false
	- Safari - false
```