### PR TITLE
Update data for AmbientLightSensor API

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -26,13 +26,13 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "56"
@@ -41,10 +41,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": [
             {
@@ -98,13 +98,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -113,10 +113,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {
@@ -178,13 +178,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"
@@ -193,10 +193,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This PR updates the `AmbientLightSensor` API data based upon manual testing. Data is as follows:

```
api.AmbientLightSensor
	- Firefox - false
	- IE - false
	- Safari - false
api.AmbientLightSensor.AmbientLightSensor
	- Firefox - false
	- IE - false
	- Safari - false
api.AmbientLightSensor.illuminance
	- Firefox - false
	- IE - false
	- Safari - false
```