### PR TITLE
Update Opera Android + Safari data for contenteditable types

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -393,13 +393,13 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -441,13 +441,13 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -489,13 +489,13 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -537,13 +537,13 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Part of work for #5932.  This PR updates the Safari, Safari iOS, and Opera Android data for the specific types `contenteditable` can take.  Opera Android data was mirrored from Chrome Android, and Safari data was determined via JS-based testing in Safari 13.1 (by setting `contenteditable` on several divs and checking if it retains the value in the JavaScript attribute).