### PR TITLE
Update Push-in-Fx-ESR notes; remove outdated notes

### DIFF
--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -26,10 +26,7 @@
           ],
           "firefox": {
             "version_added": "44",
-            "notes": [
-              "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)",
-              "Enabled only in Nightly, Developer Edition, and Beta channels."
-            ]
+            "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45, 52, 60, and 68 Extended Support Releases</a> (ESR.)"
           },
           "firefox_android": [
             {
@@ -95,10 +92,7 @@
             ],
             "firefox": {
               "version_added": "44",
-              "notes": [
-                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)",
-                "Enabled only in Nightly, Developer Edition, and Beta channels."
-              ]
+              "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45, 52, 60, and 68 Extended Support Releases</a> (ESR.)"
             },
             "firefox_android": [
               {
@@ -164,10 +158,7 @@
             ],
             "firefox": {
               "version_added": "44",
-              "notes": [
-                "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)",
-                "Enabled only in Nightly, Developer Edition, and Beta channels."
-              ]
+              "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45, 52, 60, and 68 Extended Support Releases</a> (ESR.)"
             },
             "firefox_android": [
               {


### PR DESCRIPTION
Per https://hg.mozilla.org/releases/mozilla-esr60/file/default/browser/app/profile/firefox.js#l1573 and https://hg.mozilla.org/releases/mozilla-esr68/file/default/browser/app/profile/firefox.js#l1710 Push is disabled in ESR 60 and 68.

Per https://hg.mozilla.org/releases/mozilla-release/file/default/browser/app/profile/firefox.js#l1696 Push is not only enabled in Nightly/Dev/Beta; it’s enabled by default in Firefox 44+ releases, per http://bugzil.la/1153499 (which enabled it for Fx 42), and per http://bugzil.la/1207875 (which subsequently disabled it for Fx 42 and 43 only, but not for any releases after Fx 43).

cc @KaiRo-at