### PR TITLE
Mark window.visualViewport supported in Safari 13

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -9770,10 +9770,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/commit/075eb4c (https://github.com/mdn/browser-compat-data/pull/4850) correctly updated the `api/VisualViewport.json` data to indicate that support for the Visual Viewport API shipped in Safari 13 — but it missed updating the data for `window.visualViewport`, which is part of the same API.
https://trac.webkit.org/changeset/225103/webkit#file41