### PR TITLE
Mark all Budget API features deprecated, per spec

### DIFF
--- a/api/BudgetService.json
+++ b/api/BudgetService.json
@@ -37,8 +37,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "getBudget": {
@@ -78,8 +78,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -120,8 +120,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -162,8 +162,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/BudgetState.json
+++ b/api/BudgetState.json
@@ -37,8 +37,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "budgetAt": {
@@ -78,8 +78,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -120,8 +120,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://wicg.github.io/budget-api/ says:

> This specification is not being actively maintained, and should not be used as a guide for implementations. It may be revived in the future, but for now should be considered obsolete.