### PR TITLE
HTTP Referer header length limit

### DIFF
--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -77,8 +77,7 @@
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false,
-                "notes": "Implementation already landed on master, just wasn't released yet. See <a href='https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1'>commit</a>."
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -47,6 +47,56 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "length_limit_4096B": {
+          "__compat": {
+            "description": "Limit length to 4096 bytes",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "Implementation already landed on master, just wasn't released yet. See <a href='https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1'>commit</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "Implementation already landed on master, just wasn't released yet. See <a href='https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1'>commit</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -50,7 +50,7 @@
         },
         "length_limit_4096B": {
           "__compat": {
-            "description": "Limit length to 4096 bytes",
+            "description": "Length limited to 4096 bytes",
             "support": {
               "chrome": {
                 "version_added": "77"

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -81,8 +81,7 @@
                 "notes": "Implementation already landed on master, just wasn't released yet. See <a href='https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1'>commit</a>."
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "Implementation already landed on master, just wasn't released yet. See <a href='https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1'>commit</a>."
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
## Summary
Spec requires that HTTP `Referer` header is now limited to 4096 bytes (if full `Referer` is longer but origin is shorter, origin is used; if even origin is too long, no Referer is sent). It would be nice to document this on MDN and BCD.

## Data
Landed in the following revisions:
 - Firefox 70: [bug 1557346](https://bugzilla.mozilla.org/show_bug.cgi?id=1557346)
 - Chromium 77: [bug 959757](https://bugs.chromium.org/p/chromium/issues/detail?id=959757)
 - Safari just landed this change in a [commit](https://github.com/WebKit/webkit/commit/19dcaaa36e943eded75ac996c91160cdc88a4fc1), so I just added a note and left `"version_added": false`.
 - Chromium derivatives data was just extrapolated from Chromium

Related: #6125