### PR TITLE
Implement-permissions-API-events

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -57,8 +57,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill available</a>."
+                "version_added": "77",
+                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill</a> available for earlier versions."
               },
               "firefox_android": {
                 "version_added": false
@@ -80,8 +80,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill available</a>."
+                "version_added": "77",
+                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill</a> available for earlier versions."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Bug [1444294](https://bugzilla.mozilla.org/show_bug.cgi?id=1444294) implemented the onAdded and onRemoved events in the permissions API. Also see the updated [permissions.json](https://hg.mozilla.org/mozilla-central/diff/cb1de4ab7ddb904355ec105a9c049bdf12a288d6/toolkit/components/extensions/schemas/permissions.json). This change is to indicate this support in the compatibility data for Firefox version 77.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
