### PR TITLE
Firefox 77 ships String.prototype.replaceAll()

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1994,10 +1994,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2007,7 +2007,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1961,6 +1961,58 @@
             }
           }
         },
+        "replaceAll": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll",
+            "spec_url": "https://tc39.es/proposal-string-replaceall/#sec-string.prototype.replaceall",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "77"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/search",


### PR DESCRIPTION
Sources:
 - https://bugzil.la/1608168
 - SpiderMonkey Newsletter 4
   https://mozilla-spidermonkey.github.io/blog/2020/05/11/newsletter-4.html