### PR TITLE
Revise notes to avoid exclusionary word choice

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -73,7 +73,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -211,7 +211,7 @@
               {
                 "version_added": "33",
                 "version_removed": "66",
-                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable whitelist."
+                "notes": "Since Firefox 33 you can capture screen data using <code><a href='https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia'>getUserMedia()</a></code>, with a <code>video</code> constraint called <code>mediaSource</code>. Prior to 52 it relied on a client-configurable list of allowed sites."
               }
             ],
             "firefox_android": {

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -40,7 +40,7 @@
                   "name": "media.mediasource.enabled"
                 }
               ],
-              "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
             }
           ],
           "firefox_android": {
@@ -129,7 +129,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -191,7 +191,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -253,7 +253,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -360,7 +360,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -422,7 +422,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -484,7 +484,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -546,7 +546,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -608,7 +608,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -670,7 +670,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -732,7 +732,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -794,7 +794,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -901,7 +901,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1744,14 +1744,14 @@
           "support": {
             "chrome": {
               "version_added": "13",
-              "notes": "Protocol whitelist includes <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
+              "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "≤79",
-              "notes": "Protocol whitelist includes <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
+              "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
             },
             "firefox": {
               "version_added": "3"

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -41,7 +41,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
             }
           ],
           "firefox_android": {
@@ -124,7 +124,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -187,7 +187,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -342,7 +342,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -405,7 +405,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -517,7 +517,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -667,7 +667,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -727,7 +727,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -784,7 +784,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -841,7 +841,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -898,7 +898,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -955,7 +955,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -1015,7 +1015,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -1181,7 +1181,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -1280,7 +1280,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -33,7 +33,7 @@
                   "name": "media.mediasource.enabled"
                 }
               ],
-              "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
             }
           ],
           "firefox_android": {
@@ -94,7 +94,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -156,7 +156,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -218,7 +218,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -280,7 +280,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -23,7 +23,7 @@
                   "name": "media.mediasource.enabled"
                 }
               ],
-              "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
             }
           ],
           "firefox_android": {
@@ -82,7 +82,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -141,7 +141,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -197,7 +197,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {
@@ -249,7 +249,7 @@
                   "name": "media.mediasource.enabled"
                 }
               ],
-              "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites."
+              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites."
             },
             "firefox_android": {
               "version_added": false
@@ -304,7 +304,7 @@
                     "name": "media.mediasource.enabled"
                   }
                 ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
+                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
I ran into a distracting word choice — "whitelist" — in a note. I discovered it was used in several places and I removed them. In most cases, the revision adds some clarity to the notes.

See also: style guides from [Microsoft](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/b/blacklist), [Google](https://developers.google.com/style/word-list#blacklist)