### PR TITLE
Update Safari data for AnalyserNode API

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -32,7 +32,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -77,10 +77,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -128,7 +128,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -176,7 +176,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -224,7 +224,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -272,7 +272,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -320,7 +320,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -368,7 +368,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -416,7 +416,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -464,7 +464,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -512,7 +512,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates the Safari and Safari iOS data for the `AnalyserNode` API.  The constructor was found to be supported since Safari 6 (based upon manual testing), whilst the rest of the changes are just mirroring Safari Desktop to Safari iOS.