### PR TITLE
Update Safari data for css clamp()

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -34,7 +34,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -31,7 +31,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
### Summary
Updated support data for Safari and iOS Safari for CSS `clamp()` function

### Data

- [Safari commit](https://github.com/WebKit/webkit/commit/0c93f723416dff1a4cdbf6d55e334b9292e1f6c5) for implementation
- Manually tested the following [test case](https://jsfiddle.net/as9t4jek/) with the following results: 
![image](https://user-images.githubusercontent.com/80928/81764087-b6276480-949e-11ea-9d4e-f4be9bf1b893.png)
