### PR TITLE
Document and element animation events support in IE

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -425,7 +425,7 @@
               "version_added": "54"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -164,7 +164,7 @@
               "version_added": "54"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -262,7 +262,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -311,7 +311,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -204,7 +204,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -253,7 +253,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51"
@@ -302,7 +302,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51"


### PR DESCRIPTION
Update IE support for document and element animation events. Fixes #6135.