### PR TITLE
CSS Transitions/Animations DOM events in Safari

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -434,10 +434,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10368,10 +10368,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10466,10 +10466,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10515,10 +10515,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -124,10 +124,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4481,10 +4481,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4582,10 +4582,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4630,10 +4630,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -277,10 +277,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9396,10 +9396,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9494,10 +9494,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9543,10 +9543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
https://trac.webkit.org/changeset/229818/webkit#file15 added support to WebKit for the `animationcancel`, `transitioncancel`, `transitionrun`, and `transitionstart` events, and the `onanimationcancel`, `ontransitionrun`, `ontransitionstart`, and `ontransitioncancel` event handlers.

https://trac.webkit.org/browser/webkit/tags/Safari-606.1.36/Source/WebCore/dom/GlobalEventHandlers.idl#L100 shows that change was included in the Safari 12 release tag.