### PR TITLE
Update versions for Attr API

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Attr",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "As of Chrome 45, this property no longer inherits from Node."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "As of Chrome 45, this property no longer inherits from Node."
           },
           "edge": {
@@ -22,28 +22,28 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true,
+            "version_added": "8",
             "notes": "As of Opera 32, this property no longer inherits from Node."
           },
           "opera_android": {
-            "version_added": true,
+            "version_added": "10.1",
             "notes": "As of Opera 32, this property no longer inherits from Node."
           },
           "safari": {
-            "version_added": true
+            "version_added": "1.3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "notes": "As of Samsung Internet 5.0, this property no longer inherits from Node."
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "As of Chrome 45, this property no longer inherits from Node."
           }
         },
@@ -61,6 +61,10 @@
               "version_added": "46",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
+            "chrome_android": {
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -73,22 +77,29 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             }
           },
           "status": {
@@ -106,6 +117,10 @@
               "version_added": "46",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
+            "chrome_android": {
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -118,22 +133,29 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             }
           },
           "status": {
@@ -151,6 +173,10 @@
               "version_added": "46",
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
+            "chrome_android": {
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -163,22 +189,29 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "33",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "46",
+              "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates various versions for the `Attr` API based upon both mirroring and manual testing.  Data is as follows:

```
api.Attr
	- Chrome - 1
	- IE - 8
	- Opera - 8
	- Safari - 1.3
api.Attr.localName
	- IE - false
	- Opera - Blink
	- Safari - false
api.Attr.namespaceURI
	- IE - false
	- Opera - Blink
	- Safari - false
api.Attr.prefix
	- IE - false
	- Opera - Blink
	- Safari - false
```