### PR TITLE
CSS Transitions/Animations DOM events in Safari

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -433,12 +433,42 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -10367,12 +10397,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -10465,12 +10525,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -10514,12 +10604,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -434,10 +434,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10368,10 +10368,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10466,10 +10466,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10515,10 +10515,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -124,10 +124,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4481,10 +4481,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4582,10 +4582,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4630,10 +4630,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -129,7 +129,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "safari_ios": [
@@ -138,7 +139,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "samsunginternet_android": {
@@ -4498,7 +4500,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "safari_ios": [
@@ -4507,7 +4510,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "samsunginternet_android": {
@@ -4611,7 +4615,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "safari_ios": [
@@ -4620,7 +4625,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "samsunginternet_android": {
@@ -4671,7 +4677,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "safari_ios": [
@@ -4680,7 +4687,8 @@
               },
               {
                 "version_added": "12",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "The event handler is exposed but will not actually be called unless both the \"Web Animations\" and \"CSS Animations via Web Animations\" preferences are enabled."
               }
             ],
             "samsunginternet_android": {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -123,12 +123,24 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -4480,12 +4492,24 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -4581,12 +4605,24 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -4629,12 +4665,24 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -172,12 +172,42 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -3194,12 +3224,42 @@
             "opera_android": {
               "version_added": "53"
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "11.0"
             },
@@ -3356,12 +3416,42 @@
             "opera_android": {
               "version_added": "53"
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "11.0"
             },
@@ -3405,12 +3495,42 @@
             "opera_android": {
               "version_added": "53"
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "11.0"
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -173,10 +173,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3195,10 +3195,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -3357,10 +3357,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -3406,10 +3406,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -277,10 +277,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9396,10 +9396,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9494,10 +9494,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9543,10 +9543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -276,12 +276,42 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -9395,12 +9425,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -9493,12 +9553,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -9542,12 +9632,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "12"
-            },
-            "safari_ios": {
-              "version_added": "12"
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },


### PR DESCRIPTION
https://trac.webkit.org/changeset/229818/webkit#file15 added support to WebKit for the `animationcancel`, `transitioncancel`, `transitionrun`, and `transitionstart` events, and the `onanimationcancel`, `ontransitionrun`, `ontransitionstart`, and `ontransitioncancel` event handlers.

https://trac.webkit.org/browser/webkit/tags/Safari-606.1.36/Source/WebCore/dom/GlobalEventHandlers.idl#L100 shows that change was included in the Safari 12 release tag.