### PR TITLE
Safari supports Rest in arrays

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -144,10 +144,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -144,10 +144,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
Part of #5934. Safari supports "rest in arrays" destructuring since version 9.1 (based upon manual testing). This PR updates the data accordingly.