### PR TITLE
Safari supports trailing commas in functions

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -978,10 +978,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
Safari supports  since version 10 (based upon manual testing and TP release notes for TP 7). This PR updates the data accordingly.