### PR TITLE
Permissions API permissions descriptions linter

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -120,6 +120,27 @@ For example, the `ImageData` API has worker support, recorded like this:
 
 Formerly named `available_in_workers`, this policy was set in [#2362](https://github.com/mdn/browser-compat-data/pull/2362).
 
+### Permissions API permission descriptions (`api.Permissions.*_permission.__compat.description`)
+
+Document Permissions API permissions called `[permissionname]` as `api.Permissions.[permissionname]_permission` and add a description that reads `"<code>[permissionname]</code> permission"`
+For example, the Geolocation permission is named `geolocation_permission` with the description text `<code>geolocation</code> permission`, like this:
+
+```
+{
+  "api": {
+    "Permissions": {
+      "__compat": { ... },
+      "geolocation_permission": {
+        "__compat": {
+          "description": "<code>geolocation</code> permission",
+          "support": { ... }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Non-functional defined names imply `partial_implementation`
 
 If a browser recognizes an API name, but the API doesn’t have any discernable behavior, use `"partial_implementation": true` instead of `"version_added": false`, as if the feature has non-standard support, rather than no support.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -7,6 +7,7 @@ This file contains recommendations to help you record data in a consistent and u
   - [DOM events (`eventname_event`)](#dom-events-eventname_event)
   - [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)
   - [Web Workers (`worker_support`)](#web-workers-worker_support)
+  - [Permissions API permissions (`permissionname_permission`)](#permissions-api-permissions-permissionname_permission)
   - [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply-partial_implementation)
   - [Release lines and backported features](#release-lines-and-backported-features)
   - [Safari for iOS versioning](#safari-for-ios-versioning)

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -120,9 +120,10 @@ For example, the `ImageData` API has worker support, recorded like this:
 
 Formerly named `available_in_workers`, this policy was set in [#2362](https://github.com/mdn/browser-compat-data/pull/2362).
 
-### Permissions API permission descriptions (`api.Permissions.*_permission.__compat.description`)
+## Permissions API permissions (`permissionname_permission`)
 
-Document Permissions API permissions called `[permissionname]` as `api.Permissions.[permissionname]_permission` and add a description that reads `"<code>[permissionname]</code> permission"`
+Add [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) permissions as subfeatures of [`api.Permissions`](https://developer.mozilla.org/en-US/docs/Web/API/Permissions) using the name _permissionname_\_permission with the description text set to `<code>permissionname</code> permission`.
+
 For example, the Geolocation permission is named `geolocation_permission` with the description text `<code>geolocation</code> permission`, like this:
 
 ```
@@ -140,6 +141,8 @@ For example, the Geolocation permission is named `geolocation_permission` with t
   }
 }
 ```
+
+This guideline was proposed in [#6156](https://github.com/mdn/browser-compat-data/pull/6156).
 
 ## Non-functional defined names imply `partial_implementation`
 

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -76,6 +76,29 @@ function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
 }
 
 /**
+ * @param {Identifier} apiData
+ * @param {String} apiName
+ * @param {Logger} logger
+ */
+function hasCorrectPermissionDescription(apiData, apiName, logger) {
+  const expectedDescrition = `<code>${apiName.replace(
+    '_permission',
+    '',
+  )}</code> permission`;
+  if (
+    apiName &&
+    apiName.match('_permission$') &&
+    apiData &&
+    apiData.__compat &&
+    apiData.__compat.description !== expectedDescrition
+  ) {
+    logger.error(chalk`{red Incorrect permission description for {bold ${apiName}}}
+      {yellow Actual: {bold "${apiData.__compat.description || ''}"}}
+      {green Expected: {bold "${expectedDescrition}"}}`);
+  }
+}
+
+/**
  * @param {string} filename
  */
 function testDescriptions(filename) {
@@ -98,6 +121,13 @@ function testDescriptions(filename) {
       hasCorrectDOMEventsDescription(apiData, apiName, logger);
       hasCorrectSecureContextRequiredDescription(apiData, apiName, logger);
       hasCorrectWebWorkersDescription(apiData, apiName, logger);
+    }
+  }
+
+  if (data.api && data.api.Permissions) {
+    for (const permissionKey in data.api.Permissions) {
+      const apiData = data.api.Permissions[permissionKey];
+      hasCorrectPermissionDescription(apiData, permissionKey, logger);
     }
   }
 


### PR DESCRIPTION
Fixes #5911.

 - Document existing convention for naming Permissions API permissions
 - Add linter to enforce this convention
 - Fix typo in "permissons" caught by linter

I have no idea how I made a typo "permissons" in the original #5909 and it slipped through the review, but that perfectly demonstrates the need for linter.