### PR TITLE
Safari (on)animation(end|start|iteration) support

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -483,10 +483,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -532,10 +532,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -581,10 +581,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -190,10 +190,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -268,10 +268,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -346,10 +346,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -222,10 +222,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -271,10 +271,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -320,10 +320,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -344,10 +344,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -423,10 +423,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -502,10 +502,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
https://trac.webkit.org/changeset/176423/webkit#file36 added support to WebKit for the `animationstart`, `animationiteration`, `animationend` events, and the `onanimationstart`, `onanimationiteration`, `onanimationend` event handlers.

Per https://trac.webkit.org/browser/webkit/tags/Safari-601.1.56/Source/WebCore/page/DOMWindow.idl#L228 that revision went into the tag for the Safari 9 release.