### PR TITLE
Samsung Internet 11.0 and 11.2 are retired

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -155,13 +155,13 @@
         },
         "11.0": {
           "release_date": "2019-12-05",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "75"
         },
         "11.2": {
           "release_date": "2020-03-22",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "75"
         },


### PR DESCRIPTION
In #6113, Samsung Internet 11.0 and 11.2 were accidentally left as `current`,  This PR fixes it by changing them to `retired`.