### PR TITLE
Fix typo in Permissions API descriptions

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -49,7 +49,7 @@
       },
       "accelerometer_permission": {
         "__compat": {
-          "description": "<code>accelerometer</code> permisson",
+          "description": "<code>accelerometer</code> permission",
           "support": {
             "chrome": {
               "version_added": "62"
@@ -97,7 +97,7 @@
       },
       "accessibility-events_permission": {
         "__compat": {
-          "description": "<code>accessibility-events</code> events permisson",
+          "description": "<code>accessibility-events</code> permission",
           "support": {
             "chrome": {
               "version_added": "62"
@@ -145,7 +145,7 @@
       },
       "ambient-light-sensor_permission": {
         "__compat": {
-          "description": "<code>ambient-light-sensor</code> permisson",
+          "description": "<code>ambient-light-sensor</code> permission",
           "support": {
             "chrome": {
               "version_added": "62"
@@ -193,7 +193,7 @@
       },
       "background-sync_permission": {
         "__compat": {
-          "description": "<code>background-sync</code> permisson",
+          "description": "<code>background-sync</code> permission",
           "support": {
             "chrome": {
               "version_added": "62"
@@ -289,7 +289,7 @@
       },
       "clipboard-read_permission": {
         "__compat": {
-          "description": "<code>clipboard-read</code> permisson",
+          "description": "<code>clipboard-read</code> permission",
           "support": {
             "chrome": {
               "version_added": "64"


### PR DESCRIPTION
Preparatory work for landing descriptions linter.

This was extracted from #6156 as per [request](https://github.com/mdn/browser-compat-data/pull/6156#issuecomment-628982856).

@vinyldarkscratch