### PR TITLE
Add-the-ability-to-duplicate-tab-to-a-specified-index

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1646,6 +1646,48 @@
                 "version_added": true
               }
             }
+          },
+          "duplicateProperties": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "77"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "tabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
           }
         },
         "executeScript": {


### PR DESCRIPTION
Addition of compatibility data for the new object `duplicateProperties` with `tabId` added for completeness.  For details see the following [scheme update](https://hg.mozilla.org/mozilla-central/diff/8accdd6152c6e2eb7c4f76436fbffc611771469f/browser/components/extensions/schemas/tabs.json) which reflects changes for [1560218](https://bugzilla.mozilla.org/show_bug.cgi?id=1560218).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
