### PR TITLE
Fix browser data to remove multiple `current` versions

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -468,7 +468,7 @@
         "57": {
           "release_date": "2018-11-28",
           "release_notes": "https://dev.opera.com/blog/opera-57/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "70"
         },
@@ -496,7 +496,7 @@
         "63": {
           "release_date": "2019-08-20",
           "release_notes": "https://blogs.opera.com/desktop/2019/08/opera-63-initial-release/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "76"
         },

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -140,7 +140,7 @@
         "13": {
           "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "608.2.11"
         },


### PR DESCRIPTION
Looks like we had some browsers with multiple `current` releases!  This PR fixes that up.