### PR TITLE
Chromium supports image-orientation

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-orientation",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "81"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "81"
             },
             "edge": {
-              "version_added": false
+              "version_added": "81"
             },
             "firefox": {
               "version_added": "26"
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "67"
             },
             "opera_android": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "81"
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #5752.  Looks like Chrome supports this property since M81 (confirmed in SauceLabs).