### PR TITLE
Add target version to mirroring script

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,7 +67,7 @@ If the feature you're interested in is a JavaScript API, you can cross-reference
 
 ## Optional: Generating data using the mirroring script
 
-Many browsers within BCD can be derived from other browsers given they share the same engine, for example Opera derives from Chrome, and Firefox Android derives from Firefox. To help cut down time working on copying values between browsers, a mirroring script is provided. You can run `npm run mirror <browser> <feature_or_file> [--source=""] [--modify=""]` to automatically copy values.
+Many browsers within BCD can be derived from other browsers given they share the same engine, for example Opera derives from Chrome, and Firefox Android derives from Firefox. To help cut down time working on copying values between browsers, a mirroring script is provided. You can run `npm run mirror <browser> <feature_or_file> -- [--source=""] [--modify="nonreal"] [--target_version=""]` to automatically copy values.
 
 The <browser> argument is the destination browser that values will be copied to. The script automatically determines what browser to copy from based upon the destination (see table below), but manual specification is possible through the `--source=""` argument.
 
@@ -89,7 +89,9 @@ Note when using feature identifiers:
 - Updates aren't applied recursively; only the given data point is updated when using a feature ID. Use a filename or folder for mass mirroring.
 - The script assumes a predictable file structure when passing in a feature identifier, which BCD doesn't have right now. (See [issue 3617](https://github.com/mdn/browser-compat-data/issues/3617).) For example, even if "html.elements.input.input-button" is a valid query, it will fail because the file structure for input-button isn't consistent with the rest right now.
 
-By default, the mirroring script will only overwrite values in the destination that are `true` or `null`, but can take a `--modify=""` argument to specify whether to overwrite values that are `false` as well (`--modify=bool`), or any values (`--modify=always`).
+By default, the mirroring script will only overwrite values in the destination that are `true` or `null`, but can take a `--modify` (or `-m`) argument to specify whether to overwrite values that are `false` as well (`--modify=bool`), or any values (`--modify=always`).
+
+The script can also take a `--target_version` (or `-t`) argument to only perform mirroring if the data affects a specific browser release. This is used to update data when a new Opera or Opera Android version is released, and we wish to update data that only affects the new version.
 
 ## Getting help
 


### PR DESCRIPTION
This PR adds the ability for us to specify a version to isolate when running the mirroring script.  When a new browser version is released and we update the data, this will allow us to selectively mirror data that only affects this new browser version.