### PR TITLE
Support tabs.goForward and tabs.goBack

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1890,13 +1890,13 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "77"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "60"
               }
             }
           }
@@ -1911,13 +1911,13 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "77"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "60"
               }
             }
           }


### PR DESCRIPTION
Update to identify support in Firefox 77. In addition, information from Opera in their [Extension APIs Supported in Opera](https://dev.opera.com/extensions/apis/) doesn't list these as unsupported and the relevant version of chromium (72) was implemented in Opera 60 (Opera 60 was actually chromium version 73).

For more information see the bug [1603796](https://bugzilla.mozilla.org/show_bug.cgi?id=1603796) and these [manifests changes](https://hg.mozilla.org/mozilla-central/diff/dd832923a26f8e9bb16292788457cc49db914370/browser/components/extensions/schemas/tabs.json).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
