### PR TITLE
summary tag - set version_added to true for safari on ios

### DIFF
--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -33,7 +33,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
works fine on an iPhone SE 2020 with iOS 13.4.1