### PR TITLE
updating firefox support for idbcursor.request

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -592,12 +592,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1536540'>bug 1536540</a>."
+              "version_added": "77"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1536540'>bug 1536540</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1536540

I've only updated Firefox desktop to 77. The Firefox android version that would include support for this is still not released. We'll do that when it happens.