### PR TITLE
updating firefox support data for :is(); adding support data for :where()

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -77,6 +77,9 @@
             ],
             "firefox": [
               {
+                "version_added": "78"
+              },
+              {
                 "version_added": "77",
                 "flags": [
                   {
@@ -209,7 +212,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -75,14 +75,27 @@
                 "notes": "Doesn't support combinators."
               }
             ],
-            "firefox": {
-              "version_added": "4",
-              "alternative_name": ":-moz-any()",
-              "notes": [
-                "Doesn't support combinators.",
-                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.is-where-selectors.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              },
+              {
+                "version_added": "4",
+                "alternative_name": ":-moz-any()",
+                "notes": [
+                  "Doesn't support combinators.",
+                  "See <a href='https://bugzil.la/906353'>bug 906353</a>"
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "4",
               "alternative_name": ":-moz-any()",
@@ -196,7 +209,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -15,17 +15,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.is-where-selectors.enabled",
-                  "value_to_set": "enabled"
-                }
-              ],
-              "notes": "Enabled by default in Firefox Nightly."
-            },
+            "firefox": [
+              {
+                "version_added": "78"
+              },
+              {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.is-where-selectors.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -52,7 +57,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -1,0 +1,73 @@
+{
+  "css": {
+    "selectors": {
+      "where": {
+        "__compat": {
+          "description": "<code>:where()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.is-where-selectors.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              },
+              {
+                "version_added": "4",
+                "alternative_name": ":-moz-any()",
+                "notes": [
+                  "Doesn't support combinators.",
+                  "See <a href='https://bugzil.la/906353'>bug 906353</a>"
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -15,27 +15,17 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.is-where-selectors.enabled",
-                    "value_to_set": "enabled"
-                  }
-                ],
-                "notes": "Enabled by default in Firefox Nightly."
-              },
-              {
-                "version_added": "4",
-                "alternative_name": ":-moz-any()",
-                "notes": [
-                  "Doesn't support combinators.",
-                  "See <a href='https://bugzil.la/906353'>bug 906353</a>"
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "77",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.is-where-selectors.enabled",
+                  "value_to_set": "enabled"
+                }
+              ],
+              "notes": "Enabled by default in Firefox Nightly."
+            },
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1509418

This is supported in Fx 77+, but preffed off in all versions except Nightly.

I couldn't find any evidence of support for :where() in any other browsers. 