### PR TITLE
Update Attr API data for Safari

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -88,10 +88,10 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": false
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -144,10 +144,10 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": false
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -200,10 +200,10 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": false
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",


### PR DESCRIPTION
Follow-up to #6147.  I had accidentally determined that Safari had no support for these properties, however after testing once again, it turns out these features were supported since the Attr API was.  (Determined via manual testing.)

CC @sideshowbarker