### PR TITLE
Add transform-origin to presentation SVG element

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2899,7 +2899,7 @@
                 "version_added": "77"
               },
               "firefox_android": {
-                "version_added": "77"
+                "version_added": false
               },
               "ie": {
                 "version_added": null

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2882,6 +2882,54 @@
             }
           }
         },
+        "transform-origin": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/transform-origin",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "77"
+              },
+              "firefox_android": {
+                "version_added": "77"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "unicode-bidi": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/unicode-bidi",


### PR DESCRIPTION
Supersedes #6172 (which was just closed).  This PR adds `transform-origin` to the `presentation` SVG element.

---

From the original PR:

> - New in Fx 77, per https://bugzil.la/1581691
> - Description of that bug says both Blink and Webkit support it.
