### PR TITLE
Add desktop value for autocapitalize.

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -54,7 +54,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "66"


### PR DESCRIPTION
I confirmed with the feature owner that this is not yet available on desktop. 

The interface is visible on desktop, but doesn't do anything. I don't remember how we handled this before.