### PR TITLE
updating compat data for pageshow and pagehide events

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6044,46 +6044,96 @@
           "description": "<code>pagehide</code> event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "persisted": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/persisted",
+            "description": "<code>persisted</code> event property",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "11",
+                "notes": "The <code>persisted</code> property is known to be buggy in Internet Explorer. It is advised to check if <code>window.performance.navigation.type == 2</code> as well."
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -6093,46 +6143,96 @@
           "description": "<code>pageshow</code> event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "persisted": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/persisted",
+            "description": "<code>persisted</code> event property",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "11",
+                "notes": "The <code>persisted</code> property is known to be buggy in Internet Explorer. It is advised to check if <code>window.performance.navigation.type == 2</code> as well."
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -6085,56 +6085,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "persisted": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/persisted",
-            "description": "<code>persisted</code> event property",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": "11",
-                "notes": "The <code>persisted</code> property is known to be buggy in Internet Explorer. It is advised to check if <code>window.performance.navigation.type == 2</code> as well."
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "pageshow_event": {
@@ -6183,56 +6133,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "persisted": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/persisted",
-            "description": "<code>persisted</code> event property",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": "11",
-                "notes": "The <code>persisted</code> property is known to be buggy in Internet Explorer. It is advised to check if <code>window.performance.navigation.type == 2</code> as well."
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/3141.

TL;DR is that the compat data for the `PageTransitionEvent` object looks right, but the related `pageshow` and `pagehide` event pages have incomplete compat data.

To fix this, I've just updated the compat data for the latter two, to match the compat data for the former.