### PR TITLE
Add Firefox version for `SubmitEvent.submitter`

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -15,7 +15,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "75"
           },
           "firefox_android": {
             "version_added": null


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/75#Changes_for_web_developers

Tested on browserstack to confirm on Firefox 74 (not working) and 75 (working)