### PR TITLE
Track PRs for release notes

### DIFF
--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -102,20 +102,12 @@ const contributors = (version, previousVersion) =>
     },
   ]);
 
-const notableChanges = async () => {
-  const { result } = await prompt([
-    {
-      name: 'result',
-      message:
-        'Does this release contain any schema, test, or infrastructure changes?',
-      type: confirm,
-    },
-  ]);
+const notableChanges = previousReleaseDate => {
+  const searchUrl = new URL('https://github.com/mdn/browser-compat-data/pulls');
+  const querySafeDate = previousReleaseDate.replace('+', '%2B');
+  searchUrl.search = `q=is:pr merged:>=${querySafeDate} label:"needs-release-note :newspaper:"`;
 
-  if (!result) {
-    return 'None';
-  }
-  return 'REPLACE ME WITH ACTUAL RELEASE NOTES';
+  return `SUMMARIZE THESE PRs: ${searchUrl.href}`;
 };
 
 const countFeatures = () => {
@@ -146,6 +138,12 @@ const main = async () => {
   const previousVersion = execSync(`git describe --abbrev=0 ${version}^`, {
     encoding: 'utf8',
   }).trim();
+  const previousReleaseDate = execSync(
+    `git log -1 --format=%aI ${previousVersion}`,
+    {
+      encoding: 'utf8',
+    },
+  ).trim();
 
   const { commits, changed, insertions, deletions } = stats(
     version,
@@ -156,7 +154,7 @@ const main = async () => {
     version,
     previousVersion,
   );
-  const changeMessage = await notableChanges();
+  const changeMessage = notableChanges(previousReleaseDate);
   const stars = await stargazers();
   const features = countFeatures();
 


### PR DESCRIPTION
This PR updates the release notes script to remind the releaser of issues which may be worth mentioning in the release notes. If this PR is merged, we must also create a new label: `needs-release-note :newspaper:`.

Here's the idea:

1. While reviewing PRs, PRs with notable changes (e.g., schema changes, removal of features, major restructuring, etc.) would be flagged with the _needs-release-note_ label.
2. When the releaser (usually @Elchi3) creates the release notes, they'll follow the generated link to see all of the PRs labeled _needs-release-note_ that have been merged since the time of the last release. As needed, they'll update the release notes to reflect these PRs.

There's probably some more automation that could happen here to generate more text for the release notes, but I thought we could try out the process and, if it's successful, expend the effort to automate the listing.