### PR TITLE
Remove try-catch cond clauses

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2282,59 +2282,6 @@
             "deprecated": false
           }
         },
-        "conditional_clauses": {
-          "__compat": {
-            "description": "Conditional clauses",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "59"
-              },
-              "firefox_android": {
-                "version_added": "4",
-                "version_removed": "59"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "optional_catch_binding": {
           "__compat": {
             "description": "Optional catch binding",


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#Browser_compatibility

Qualifies as irrelevant feature (Fx 59 was released in March 2018). 

See also https://github.com/mdn/sprints/issues/2712 where a user came to the same conclusion :)