### PR TITLE
IE11: mark Intl.NumberFormat support as partial

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -77,7 +77,7 @@
                 "ie": {
                   "version_added": "11",
                   "partial_implementation": true,
-                  "notes": "The `style` option only supports the values: 'decimal', 'percent', and 'currency'."
+                  "notes": "The <code>style</code> option only supports the values <code>'decimal'</code>, <code>'percent'</code>, and <code>'currency'</code>."
                 },
                 "nodejs": {
                   "version_added": true

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -23,9 +23,7 @@
                 "version_added": "56"
               },
               "ie": {
-                "version_added": "11",
-                "partial_implementation": true,
-                "notes": "The `style` option only supports the values: 'decimal', 'percent', and 'currency'."
+                "version_added": "11"
               },
               "nodejs": {
                 "version_added": true
@@ -77,7 +75,9 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": "11"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "The `style` option only supports the values: 'decimal', 'percent', and 'currency'."
                 },
                 "nodejs": {
                   "version_added": true

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -23,7 +23,9 @@
                 "version_added": "56"
               },
               "ie": {
-                "version_added": "11"
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "The `style` option only supports the values: 'decimal', 'percent', and 'currency'."
               },
               "nodejs": {
                 "version_added": true


### PR DESCRIPTION
I was trying to set the option `style` to "unit" in order to use Intl.NumberFormat to format kilobytes / megabytes / and so on.

I got this error on IE11:

<img width="823" alt="Screenshot 2020-05-20 at 19 13 05" src="https://user-images.githubusercontent.com/1285361/82478767-ad9fe100-9ad1-11ea-8158-71e6771c027a.png">

It would seem that the only allowed values for the `style` option are:
- decimal
- percent
- currency