### PR TITLE
Mark String.p.replaceAll supported in Chrome

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1915,10 +1915,10 @@
             "spec_url": "https://tc39.es/proposal-string-replaceall/#sec-string.prototype.replaceall",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "85"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "85"
               },
               "edge": {
                 "version_added": false
@@ -1951,7 +1951,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "85"
               }
             },
             "status": {


### PR DESCRIPTION
Based on https://www.chromestatus.com/feature/6040389083463680 and manual testing in Chrome Canary.

This depends on #6198 (update to `browsers/chrome.json`).