### PR TITLE
Add compat data for Proxy() constructor

### DIFF
--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "Proxy": {
+          "__compat": {
+            "description": "<code>Proxy()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy",
+            "spec_url": "https://tc39.es/ecma262/#sec-proxy-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "18"
+              },
+              "firefox_android": {
+                "version_added": "18"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "6.0.0"
+              },
+              "opera": {
+                "version_added": "36"
+              },
+              "opera_android": {
+                "version_added": "36"
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "49"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "handler": {
           "apply": {
             "__compat": {


### PR DESCRIPTION
As part of https://github.com/mdn/stumptown-content/issues/447 I wanted to add a page for the [`Proxy()` constructor](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy). This PR adds compat data for it.

The data itself is copied from the data for [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Browser_compatibility).