### PR TITLE
Update compat data for all new RegExp features in Fx78

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -171,7 +171,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "78"
               },
               "firefox_android": {
                 "version_added": false
@@ -803,8 +803,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
+                "version_added": "78"
               },
               "firefox_android": {
                 "version_added": false,
@@ -1012,7 +1011,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "78"
               },
               "firefox_android": {
                 "version_added": false
@@ -1074,7 +1073,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "78"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
- Implement RegExp lookbehind (https://bugzilla.mozilla.org/show_bug.cgi?id=1225665)
- Implement RegExp s (dotAll) flag (https://bugzilla.mozilla.org/show_bug.cgi?id=1361856)
- Implement RegExp Unicode Property Escapes (https://bugzilla.mozilla.org/show_bug.cgi?id=1361876)
- Implement RegExp named groups (https://bugzilla.mozilla.org/show_bug.cgi?id=1362154)

