### PR TITLE
Complete NodeJS support data for all Intl APIs

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "0.12",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "15"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -196,7 +190,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Collator()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -249,7 +243,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Collator()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -307,7 +301,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {

--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": {
-                "version_added": "0.12"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "0.12",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "15"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -181,7 +195,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Collator()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -233,7 +248,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Collator()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -284,9 +300,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },

--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "15"
@@ -78,7 +78,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -129,7 +129,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -181,7 +181,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -233,7 +233,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -285,7 +285,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": {
-                "version_added": "0.12"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "0.12",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "15"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -331,7 +345,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -383,7 +398,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.9.0"
+                  "version_added": "12.9.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": false
@@ -435,7 +451,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.9.0"
+                  "version_added": "12.9.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": false
@@ -490,7 +507,10 @@
                 },
                 "nodejs": {
                   "version_added": "8.0.0",
-                  "notes": "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
+                  "notes": [
+                    "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>.",
+                    "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                  ]
                 },
                 "opera": {
                   "version_added": "44",
@@ -546,7 +566,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -648,9 +669,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "15"
@@ -78,7 +78,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -127,7 +127,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": true
+                    "version_added": "12.9.0"
                   },
                   "opera": {
                     "version_added": "63"
@@ -278,7 +278,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": true
+                    "version_added": "12.9.0"
                   },
                   "opera": {
                     "version_added": "63"
@@ -489,7 +489,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "8.0.0",
+                  "notes": "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "opera": {
                   "version_added": "44",

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -383,7 +383,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.9.0"
                 },
                 "opera": {
                   "version_added": false
@@ -435,7 +435,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.9.0"
                 },
                 "opera": {
                   "version_added": false

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "0.12",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "15"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -346,7 +340,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -399,7 +393,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.9.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": false
@@ -452,7 +446,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.9.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": false
@@ -509,7 +503,7 @@
                   "version_added": "8.0.0",
                   "notes": [
                     "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>.",
-                    "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                    "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                   ]
                 },
                 "opera": {
@@ -567,7 +561,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>DateTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -676,7 +670,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -177,7 +177,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": null
+                    "version_added": "12.0.0"
                   },
                   "opera": {
                     "version_added": "60"
@@ -228,7 +228,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": null
+                    "version_added": "4.0.0"
                   },
                   "opera": {
                     "version_added": "15"
@@ -331,7 +331,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -545,7 +545,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -595,7 +595,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": null
+                    "version_added": "8.10.0"
                   },
                   "opera": {
                     "version_added": "30"
@@ -648,7 +648,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -76,7 +76,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "7.0.0"
               },
               "opera": {
                 "version_added": false

--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -24,16 +24,10 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": [
-              {
-                "version_added": "13.0.0"
-              },
-              {
-                "version_added": "0.12",
-                "partial_implementation": true,
-                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Intl</code> APIs silently fall back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-              }
-            ],
+            "nodejs": {
+              "version_added": "0.12",
+              "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Intl</code> APIs silently fall back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
+            },
             "opera": {
               "version_added": "15"
             },

--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -25,7 +25,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.12"
             },
             "opera": {
               "version_added": "15"

--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -24,9 +24,16 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": {
-              "version_added": "0.12"
-            },
+            "nodejs": [
+              {
+                "version_added": "13.0.0"
+              },
+              {
+                "version_added": "0.12",
+                "partial_implementation": true,
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Intl</code> APIs silently fall back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+              }
+            ],
             "opera": {
               "version_added": "15"
             },

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "12.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "12.0.0",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>ListFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "60"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "12.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>ListFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "60"
                 },
@@ -130,7 +144,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -182,7 +197,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -234,7 +250,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -285,9 +302,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "12.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "60"
                 },

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "12.0.0",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>ListFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "12.0.0",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat'>the <code>ListFormat()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "60"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "12.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>ListFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>ListFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -145,7 +139,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat'>the <code>ListFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -198,7 +192,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat'>the <code>ListFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -251,7 +245,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>ListFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat'>the <code>ListFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "60"
@@ -309,7 +303,7 @@
                   {
                     "version_added": "12.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "60"
@@ -78,7 +78,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -130,7 +130,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -182,7 +182,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -234,7 +234,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -286,7 +286,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "12.0.0",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Locale</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "12.0.0",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "62"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "12.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Locale</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Locale</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -145,7 +139,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -198,7 +192,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -251,7 +245,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -304,7 +298,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -357,7 +351,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -410,7 +404,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -463,7 +457,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -516,7 +510,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -569,7 +563,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -622,7 +616,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -675,7 +669,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -728,7 +722,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -781,7 +775,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale'>the <code>Locale()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "62"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "62"
@@ -78,7 +78,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -130,7 +130,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -182,7 +182,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -234,7 +234,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -286,7 +286,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -338,7 +338,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -390,7 +390,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -442,7 +442,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -494,7 +494,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -546,7 +546,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -598,7 +598,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -650,7 +650,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -702,7 +702,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"
@@ -754,7 +754,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "62"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "12.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "12.0.0",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Locale</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "62"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "12.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Locale</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "62"
                 },
@@ -130,7 +144,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -182,7 +197,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -234,7 +250,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -286,7 +303,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -338,7 +356,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -390,7 +409,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -442,7 +462,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -494,7 +515,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -546,7 +568,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -598,7 +621,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -650,7 +674,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -702,7 +727,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"
@@ -754,7 +780,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>Locale()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "62"

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "0.12",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "15"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -145,7 +139,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -198,7 +192,7 @@
                 },
                 "nodejs": {
                   "version_added": "10.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "51"
@@ -251,7 +245,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -309,7 +303,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": {
-                "version_added": "0.12"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "0.12",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "15"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -130,7 +144,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -182,7 +197,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "10.0.0"
+                  "version_added": "10.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "51"
@@ -234,7 +250,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>NumberFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "15"
@@ -285,9 +302,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "15"
@@ -78,7 +78,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -130,7 +130,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -234,7 +234,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -286,7 +286,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "10.0.0",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>PluralRules</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules'>the <code>PluralRules()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "50"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "10.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>PluralRules</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>PluralRules</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -144,7 +138,7 @@
                 },
                 "nodejs": {
                   "version_added": "10.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules'>the <code>PluralRules()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "50"
@@ -196,7 +190,7 @@
                 },
                 "nodejs": {
                   "version_added": "10.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules'>the <code>PluralRules()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "50"
@@ -248,7 +242,7 @@
                 },
                 "nodejs": {
                   "version_added": "10.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules'>the <code>PluralRules()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "50"

--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "10.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "10.0.0",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>PluralRules</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "50"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "10.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "10.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>PluralRules</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "50"
                 },
@@ -129,7 +143,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "10.0.0"
+                  "version_added": "10.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "50"
@@ -180,7 +195,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "10.0.0"
+                  "version_added": "10.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "50"
@@ -231,7 +247,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "10.0.0"
+                  "version_added": "10.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>PluralRules()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "50"

--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -25,9 +25,16 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "12.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.0.0"
+                },
+                {
+                  "version_added": "12.0.0",
+                  "partial_implementation": true,
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                }
+              ],
               "opera": {
                 "version_added": "58"
               },
@@ -77,9 +84,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "12.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "58"
                 },
@@ -130,7 +144,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -182,7 +197,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -234,7 +250,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "12.0.0"
+                  "version_added": "12.0.0",
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -335,9 +352,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "12.0.0",
+                    "partial_implementation": true,
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "58"
                 },

--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -25,16 +25,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.0.0"
-                },
-                {
-                  "version_added": "12.0.0",
-                  "partial_implementation": true,
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                }
-              ],
+              "nodejs": {
+                "version_added": "12.0.0",
+                "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat'>the <code>RelativeTimeFormat()</code> constructor</a> for more details."
+              },
               "opera": {
                 "version_added": "58"
               },
@@ -91,7 +85,7 @@
                   {
                     "version_added": "12.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>RelativeTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -145,7 +139,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat'>the <code>RelativeTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -198,7 +192,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat'>the <code>RelativeTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -251,7 +245,7 @@
                 },
                 "nodejs": {
                   "version_added": "12.0.0",
-                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See the <code>RelativeTimeFormat()</code> constructor for more details."
+                  "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat'>the <code>RelativeTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
                   "version_added": "58"
@@ -359,7 +353,7 @@
                   {
                     "version_added": "12.0.0",
                     "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
                 ],
                 "opera": {


### PR DESCRIPTION
This corrects all the support data for the `Intl` APIs in NodeJS. I started with just filling in the `null` values (the first commit), and ended up getting carried away by doing the rest (the second and third commits).

Some notes on this data:

### References

Most of the `Intl` support was added in version `0.12.0`, as listed in the [release notes](https://nodejs.org/en/blog/release/v0.12.0/). For the rest of the features, the release notes weren't particularly helpful, so I ran a script to verify support instead.

I used `nvm` to download all the releases listed in `nodejs.json` which bumped the included version of V8. Then my script ran a series of tests against each version, and only logged when the output of the test changed.

<details><summary>For completeness, this is the output of the script…</summary>

- A feature test being listed for a version of Node means that the output changed from the previous version.
- I cleaned up and removed any differences in formatting of error messages and `console.log` across versions.
- The script was run on my machine in Sydney (so a system-default locale of `en-AU`), using a test locale string of `ja-JP` with a heap of Unicode extensions in it. That way it was super-obvious when non-`en-US` locales were supported by default.

```
=== VERSION: 0.12.0 ===
Collator: [Function]
Collator().compare: [Function: __boundcompare__]
Collator().resolvedOptions(): { locale: 'en-AU',
  usage: 'sort',
  sensitivity: 'variant',
  ignorePunctuation: false,
  numeric: false,
  caseFirst: 'false',
  collation: 'default' }
Collator.supportedLocalesOf(): [ 'en-ZA', 'en' ]
DateTimeFormat: [Function]
DateTimeFormat(): dateStyle: [ false, '5/23/2020' ]
DateTimeFormat(): timeStyle: [ false, '5/23/2020' ]
DateTimeFormat(): hourCycle: TypeError: undefined is not a function
DateTimeFormat(): timeZone: TypeError: undefined is not a function
DateTimeFormat().format(): 5/23/2020, 2:23:56 PM GMT+10
DateTimeFormat().formatToParts(): TypeError: undefined is not a function
DateTimeFormat().formatRange(): TypeError: undefined is not a function
DateTimeFormat().formatRangeToParts(): TypeError: undefined is not a function
DateTimeFormat().resolvedOptions(): { locale: 'en-AU',
  numberingSystem: 'latn',
  calendar: 'gregory',
  timeZone: undefined,
  year: 'numeric',
  month: 'numeric',
  day: 'numeric' }
DateTimeFormat.supportedLocalesOf(): [ 'en-ZA', 'en' ]
Intl.getCanonicalLocales(): TypeError: undefined is not a function
ListFormat: undefined
ListFormat().format(): TypeError: undefined is not a function
ListFormat().formatToParts(): TypeError: undefined is not a function
ListFormat().resolvedOptions(): TypeError: undefined is not a function
ListFormat.supportedLocalesOf(): TypeError: Cannot read property 'supportedLocalesOf' of undefined
Locale: undefined
Locale().baseName: TypeError: undefined is not a function
Locale().calendar: TypeError: undefined is not a function
Locale().caseFirst: TypeError: undefined is not a function
Locale().collation: TypeError: undefined is not a function
Locale().hourCycle: TypeError: undefined is not a function
Locale().language: TypeError: undefined is not a function
Locale().numberingSystem: TypeError: undefined is not a function
Locale().numeric: TypeError: undefined is not a function
Locale().region: TypeError: undefined is not a function
Locale().script: TypeError: undefined is not a function
Locale().minimize(): TypeError: undefined is not a function
Locale().maximize(): TypeError: undefined is not a function
Locale().toString(): TypeError: undefined is not a function
NumberFormat: [Function]
NumberFormat().format(): 1,590,207,836,000
NumberFormat().formatToParts(): TypeError: undefined is not a function
NumberFormat().resolvedOptions(): { locale: 'en-AU',
  numberingSystem: 'latn',
  style: 'decimal',
  useGrouping: true,
  minimumIntegerDigits: 1,
  minimumFractionDigits: 0,
  maximumFractionDigits: 3 }
NumberFormat.supportedLocalesOf(): [ 'en-ZA', 'en' ]
PluralRules: undefined
PluralRules().resolvedOptions(): TypeError: undefined is not a function
RelativeTimeFormat: undefined
RelativeTimeFormat().format(): TypeError: undefined is not a function
RelativeTimeFormat().formatToParts(): TypeError: undefined is not a function
RelativeTimeFormat().resolvedOptions(): TypeError: undefined is not a function
RelativeTimeFormat.supportedLocalesOf(): TypeError: Cannot read property 'supportedLocalesOf' of undefined

=== VERSION: 4.0.0 ===
DateTimeFormat(): hourCycle: [ false, '2:23:56 PM' ]
DateTimeFormat(): timeZone: [ false, '5/23/2020, 1:23:56 AM GMT-3' ]

=== VERSION: 5.0.0 ===

=== VERSION: 6.0.0 ===

=== VERSION: 6.5.0 ===

=== VERSION: 7.0.0 ===
Intl.getCanonicalLocales(): [ 'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-true-nu-jpanyear',
  'ja',
  'en-ZA',
  'en' ]

=== VERSION: 7.6.0 ===
DateTimeFormat(): timeZone: [ true, '5/23/2020, 12:23:56 AM GMT-4' ]

=== VERSION: 8.0.0 ===
DateTimeFormat().formatToParts(): [ { type: 'year', value: '2020' },
  { type: 'literal', value: '-' },
  { type: 'month', value: '5' },
  { type: 'literal', value: '-' },
  { type: 'day', value: '23' },
  { type: 'literal', value: ' ' },
  { type: 'hour', value: '2' },
  { type: 'literal', value: ':' },
  { type: 'minute', value: '23' },
  { type: 'literal', value: ':' },
  { type: 'second', value: '56' },
  { type: 'literal', value: ' ' },
  { type: 'dayperiod', value: 'PM' },
  { type: 'literal', value: ' ' },
  { type: 'timeZoneName', value: 'GMT+10' } ]

=== VERSION: 8.3.0 ===

=== VERSION: 8.7.0 ===

=== VERSION: 8.10.0 ===
DateTimeFormat().resolvedOptions(): { locale: 'und',
  numberingSystem: 'latn',
  calendar: 'gregory',
  timeZone: 'Australia/Sydney',
  year: 'numeric',
  month: 'numeric',
  day: 'numeric' }

=== VERSION: 10.0.0 ===
NumberFormat().formatToParts(): [ { type: 'integer', value: '1' },
  { type: 'group', value: ',' },
  { type: 'integer', value: '590' },
  { type: 'group', value: ',' },
  { type: 'integer', value: '207' },
  { type: 'group', value: ',' },
  { type: 'integer', value: '836' },
  { type: 'group', value: ',' },
  { type: 'integer', value: '000' } ]
PluralRules: [Function: PluralRules]
PluralRules().resolvedOptions(): { locale: 'und',
  type: 'cardinal',
  minimumIntegerDigits: 1,
  minimumFractionDigits: 0,
  maximumFractionDigits: 3,
  pluralCategories: [ 'other' ] }

=== VERSION: 10.4.0 ===

=== VERSION: 10.9.0 ===

=== VERSION: 11.0.0 ===

=== VERSION: 12.0.0 ===
DateTimeFormat(): hourCycle: [ true, '14:23:56' ]
ListFormat: [Function: ListFormat]
ListFormat().format(): ja-Jpan-JP-u-ca-japanese-kf-upper-co-emoji-hc-h12-nu-jpanyear-kn-true, ja, en-ZA, and en
ListFormat().formatToParts(): [
  {
    type: 'element',
    value: 'ja-Jpan-JP-u-ca-japanese-kf-upper-co-emoji-hc-h12-nu-jpanyear-kn-true'
  },
  { type: 'literal', value: ', ' },
  { type: 'element', value: 'ja' },
  { type: 'literal', value: ', ' },
  { type: 'element', value: 'en-ZA' },
  { type: 'literal', value: ', and ' },
  { type: 'element', value: 'en' }
]
ListFormat().resolvedOptions(): { locale: 'en-AU', type: 'conjunction', style: 'long' }
ListFormat.supportedLocalesOf(): [ 'en-ZA', 'en' ]
Locale: [Function: Locale]
Locale().baseName: ja-Jpan-JP
Locale().calendar: japanese
Locale().caseFirst: upper
Locale().collation: emoji
Locale().hourCycle: h12
Locale().language: ja
Locale().numberingSystem: jpanyear
Locale().numeric: true
Locale().region: JP
Locale().script: Jpan
Locale().minimize(): Locale [Intl.Locale] {}
Locale().maximize(): Locale [Intl.Locale] {}
Locale().toString(): ja-Jpan-JP-u-ca-gregory-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear
RelativeTimeFormat: [Function: RelativeTimeFormat]
RelativeTimeFormat().format(): in 3 days
RelativeTimeFormat().formatToParts(): [
  { type: 'literal', value: 'in ' },
  { type: 'integer', value: '3', unit: 'day' },
  { type: 'literal', value: ' days' }
]
RelativeTimeFormat().resolvedOptions(): {
  locale: 'en-AU',
  style: 'long',
  numeric: 'always',
  numberingSystem: 'latn'
}
RelativeTimeFormat.supportedLocalesOf(): [ 'en-ZA', 'en' ]

=== VERSION: 12.5.0 ===

=== VERSION: 12.9.0 ===
DateTimeFormat(): dateStyle: [ true, 'Saturday, May 23, 2020' ]
DateTimeFormat(): timeStyle: [ true, '2:23:56 PM Australian Eastern Standard Time' ]
DateTimeFormat().formatRange(): 5/23/2020, 2:23:56 PM GMT+10 – 6/23/2020, 2:23:56 PM GMT+10
DateTimeFormat().formatRangeToParts(): [
  { type: 'month', value: '5', source: 'startRange' },
  { type: 'literal', value: '/', source: 'startRange' },
  { type: 'day', value: '23', source: 'startRange' },
  { type: 'literal', value: '/', source: 'startRange' },
  { type: 'year', value: '2020', source: 'startRange' },
  { type: 'literal', value: ', ', source: 'startRange' },
  { type: 'hour', value: '2', source: 'startRange' },
  { type: 'literal', value: ':', source: 'startRange' },
  { type: 'minute', value: '23', source: 'startRange' },
  { type: 'literal', value: ':', source: 'startRange' },
  { type: 'second', value: '56', source: 'startRange' },
  { type: 'literal', value: ' ', source: 'startRange' },
  { type: 'dayPeriod', value: 'PM', source: 'startRange' },
  { type: 'literal', value: ' ', source: 'startRange' },
  { type: 'timeZoneName', value: 'GMT+10', source: 'startRange' },
  { type: 'literal', value: ' – ', source: 'shared' },
  { type: 'month', value: '6', source: 'endRange' },
  { type: 'literal', value: '/', source: 'endRange' },
  { type: 'day', value: '23', source: 'endRange' },
  { type: 'literal', value: '/', source: 'endRange' },
  { type: 'year', value: '2020', source: 'endRange' },
  { type: 'literal', value: ', ', source: 'endRange' },
  { type: 'hour', value: '2', source: 'endRange' },
  { type: 'literal', value: ':', source: 'endRange' },
  { type: 'minute', value: '23', source: 'endRange' },
  { type: 'literal', value: ':', source: 'endRange' },
  { type: 'second', value: '56', source: 'endRange' },
  { type: 'literal', value: ' ', source: 'endRange' },
  { type: 'dayPeriod', value: 'PM', source: 'endRange' },
  { type: 'literal', value: ' ', source: 'endRange' },
  { type: 'timeZoneName', value: 'GMT+10', source: 'endRange' }
]

=== VERSION: 12.11.0 ===

=== VERSION: 13.0.0 ===
Collator().resolvedOptions(): {
  locale: 'ja-u-co-emoji',
  usage: 'sort',
  sensitivity: 'variant',
  ignorePunctuation: false,
  collation: 'emoji',
  numeric: true,
  caseFirst: 'upper'
}
Collator.supportedLocalesOf(): [
  'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear',
  'ja',
  'en-ZA',
  'en'
]
DateTimeFormat(): dateStyle: [ true, '令和2年5月23日土曜日' ]
DateTimeFormat(): timeStyle: [ true, '午後2:23:56 オーストラリア東部標準時' ]
DateTimeFormat(): timeZone: [ true, '2/5/23 午前0:23:56 GMT-4' ]
DateTimeFormat().format(): 2/5/23 午後2:23:56 GMT+10
DateTimeFormat().formatToParts(): [
  { type: 'year', value: '2' },
  { type: 'literal', value: '/' },
  { type: 'month', value: '5' },
  { type: 'literal', value: '/' },
  { type: 'day', value: '23' },
  { type: 'literal', value: ' ' },
  { type: 'dayPeriod', value: '午後' },
  { type: 'hour', value: '2' },
  { type: 'literal', value: ':' },
  { type: 'minute', value: '23' },
  { type: 'literal', value: ':' },
  { type: 'second', value: '56' },
  { type: 'literal', value: ' ' },
  { type: 'timeZoneName', value: 'GMT+10' }
]
DateTimeFormat().formatRange(): R2/5/23 午後2:23:56 GMT+10～R2/6/23 午後2:23:56 GMT+10
DateTimeFormat().formatRangeToParts(): [
  { type: 'era', value: 'R', source: 'startRange' },
  { type: 'year', value: '2', source: 'startRange' },
  { type: 'literal', value: '/', source: 'startRange' },
  { type: 'month', value: '5', source: 'startRange' },
  { type: 'literal', value: '/', source: 'startRange' },
  { type: 'day', value: '23', source: 'startRange' },
  { type: 'literal', value: ' ', source: 'startRange' },
  { type: 'dayPeriod', value: '午後', source: 'startRange' },
  { type: 'hour', value: '2', source: 'startRange' },
  { type: 'literal', value: ':', source: 'startRange' },
  { type: 'minute', value: '23', source: 'startRange' },
  { type: 'literal', value: ':', source: 'startRange' },
  { type: 'second', value: '56', source: 'startRange' },
  { type: 'literal', value: ' ', source: 'startRange' },
  { type: 'timeZoneName', value: 'GMT+10', source: 'startRange' },
  { type: 'literal', value: '～', source: 'shared' },
  { type: 'era', value: 'R', source: 'endRange' },
  { type: 'year', value: '2', source: 'endRange' },
  { type: 'literal', value: '/', source: 'endRange' },
  { type: 'month', value: '6', source: 'endRange' },
  { type: 'literal', value: '/', source: 'endRange' },
  { type: 'day', value: '23', source: 'endRange' },
  { type: 'literal', value: ' ', source: 'endRange' },
  { type: 'dayPeriod', value: '午後', source: 'endRange' },
  { type: 'hour', value: '2', source: 'endRange' },
  { type: 'literal', value: ':', source: 'endRange' },
  { type: 'minute', value: '23', source: 'endRange' },
  { type: 'literal', value: ':', source: 'endRange' },
  { type: 'second', value: '56', source: 'endRange' },
  { type: 'literal', value: ' ', source: 'endRange' },
  { type: 'timeZoneName', value: 'GMT+10', source: 'endRange' }
]
DateTimeFormat().resolvedOptions(): {
  locale: 'ja-u-ca-japanese-hc-h12-nu-jpanyear',
  calendar: 'japanese',
  numberingSystem: 'jpanyear',
  timeZone: 'Australia/Sydney',
  year: 'numeric',
  month: 'numeric',
  day: 'numeric'
}
DateTimeFormat.supportedLocalesOf(): [
  'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear',
  'ja',
  'en-ZA',
  'en'
]
ListFormat().format(): ja-Jpan-JP-u-ca-japanese-kf-upper-co-emoji-hc-h12-nu-jpanyear-kn-true、ja、en-ZA、en
ListFormat().formatToParts(): [
  {
    type: 'element',
    value: 'ja-Jpan-JP-u-ca-japanese-kf-upper-co-emoji-hc-h12-nu-jpanyear-kn-true'
  },
  { type: 'literal', value: '、' },
  { type: 'element', value: 'ja' },
  { type: 'literal', value: '、' },
  { type: 'element', value: 'en-ZA' },
  { type: 'literal', value: '、' },
  { type: 'element', value: 'en' }
]
ListFormat().resolvedOptions(): { locale: 'ja', type: 'conjunction', style: 'long' }
ListFormat.supportedLocalesOf(): [
  'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear',
  'ja',
  'en-ZA',
  'en'
]
NumberFormat().resolvedOptions(): {
  locale: 'ja-u-nu-jpanyear',
  numberingSystem: 'jpanyear',
  style: 'decimal',
  minimumIntegerDigits: 1,
  minimumFractionDigits: 0,
  maximumFractionDigits: 3,
  useGrouping: true,
  notation: 'standard',
  signDisplay: 'auto'
}
NumberFormat.supportedLocalesOf(): [
  'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear',
  'ja',
  'en-ZA',
  'en'
]
RelativeTimeFormat().format(): 3 日後
RelativeTimeFormat().formatToParts(): [ { type: 'literal', value: '3 日後' } ]
RelativeTimeFormat().resolvedOptions(): {
  locale: 'ja-u-nu-jpanyear',
  style: 'long',
  numeric: 'always',
  numberingSystem: 'jpanyear'
}
RelativeTimeFormat.supportedLocalesOf(): [
  'ja-Jpan-JP-u-ca-japanese-co-emoji-hc-h12-kf-upper-kn-nu-jpanyear',
  'ja',
  'en-ZA',
  'en'
]

=== VERSION: 13.2.0 ===

=== VERSION: 14.0.0 ===
DateTimeFormat().resolvedOptions(): {
  locale: 'ja-u-ca-japanese-hc-h12-nu-jpanyear',
  calendar: 'japanese',
  numberingSystem: 'jpanyear',
  timeZone: 'Australia/Sydney',
  era: 'narrow',
  year: 'numeric',
  month: 'numeric',
  day: 'numeric'
}
```
</details>

### Locale support

Full support for all locale data by default didn't arrive until version 13 (as discussed heavily in #5068). But the APIs were still valid, so I left them as just `{ "version_added": "0.12" }` in this PR.

If it's desired, I can update this PR to do the dual-version listing that's currently done for things like [the `locales` parameter of `Number.prototype.toLocaleString()`](https://github.com/mdn/browser-compat-data/pull/5921/files#diff-d6f2309ba13e587b8b77480bfacbb07bR1068). But currently on MDN those dual-version entries make a first glance look like the API wasn't supported at all until version 13, which is misleading.
