### PR TITLE
Implicit rollback in setRemoteDescription added in Chrome M80

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -4172,13 +4172,13 @@
             "description": "Implicit rollback",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "80"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "80"
               },
               "edge": {
-                "version_added": false
+                "version_added": "80"
               },
               "firefox": {
                 "version_added": "70"
@@ -4205,7 +4205,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "80"
               }
             },
             "status": {


### PR DESCRIPTION
Chrome [M80 release notes](https://groups.google.com/forum/#!msg/discuss-webrtc/Ozvbd0p7Q1Y/M4WN2cRKCwAJ). [wpt](https://wpt.fyi/results/webrtc/RTCPeerConnection-setRemoteDescription-offer.html) showing comparable edge support.

Test fiddle: https://jsfiddle.net/jib1/yaL5mor9/