### PR TITLE
Actually mark all toSource methods as removed

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -428,6 +428,7 @@
               },
               "firefox": {
                 "version_added": "1",
+                "version_removed": "74",
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -739,6 +739,7 @@
               },
               "firefox": {
                 "version_added": "1",
+                "version_removed": "74",
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1166,6 +1166,7 @@
               },
               "firefox": {
                 "version_added": "1",
+                "version_removed": "74",
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2835,6 +2835,7 @@
               },
               "firefox": {
                 "version_added": "1",
+                "version_removed": "74",
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -883,6 +883,7 @@
               },
               "firefox": {
                 "version_added": "36",
+                "version_removed": "74",
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {


### PR DESCRIPTION
These were missed by #5735. And for some reason I only marked
RegExp.prototype.toSource as removed in #5900.
