### PR TITLE
Remove String.replace flags sub feature

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1855,58 +1855,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "flags": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "1",
-                  "version_removed": "49"
-                },
-                "firefox_android": {
-                  "version_added": "4",
-                  "version_removed": "49"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
           }
         },
         "replaceAll": {


### PR DESCRIPTION
Should have removed this in https://github.com/mdn/browser-compat-data/pull/6184 but "flags" is hard to search for in BCD.

See the "flags" row on https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Browser_compatibility

This non-standard feature isn't actually described on the page anymore and it is more confusing than helpful at this point.

Qualifies as irrelevant feature: https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features