### PR TITLE
Update Safari compat data for ::marker

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -49,7 +49,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -52,7 +52,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Added data for Safari Desktop
Tested through Safari 10.1 to 13.0
Safari 10.1 (macOS Sierra)
Safari 11.1 (macOS High Sierra)
Safari 12 (macOS Mojave)
Safari 13 (macOS Catalina)