### PR TITLE
Add prettier and git config files to labeler config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,18 +30,18 @@ dependencies :chains::
 docs :writing_hand::
   - "*.md"
 infra :building_construction::
-  - "/*.js"
-  - "/*.ts"
   - ".editorconfig"
   - ".git*"
-  - ".npm*"
-  - ".travis.yml"
+  - ".gitattributes"
   - ".github/**"
+  - ".gitignore"
+  - ".npm*"
+  - ".prettier*"
+  - ".travis.yml"
+  - "/*.js"
+  - "/*.ts"
   - "LICENSE"
   - "package*"
-  - ".gitattributes"
-  - ".gitignore"
-  - ".prettier*"
 linter :house_with_garden::
   - "test/**"
 scripts :scroll::

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -39,6 +39,9 @@ infra :building_construction::
   - ".github/**"
   - "LICENSE"
   - "package*"
+  - ".gitattributes"
+  - ".gitignore"
+  - ".prettier*"
 linter :house_with_garden::
   - "test/**"
 scripts :scroll::


### PR DESCRIPTION
This adds a few entries to the labeler configuration, to cover prettier and git configuration files. I also sorted the entries (see the commits for detail).

Suggested in a comment by @vinyldarkscratch in https://github.com/mdn/browser-compat-data/pull/6110#issuecomment-625217074.