### PR TITLE
Samsung Internet 12.0 is actually in beta

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -161,13 +161,13 @@
         },
         "11.2": {
           "release_date": "2020-03-22",
-          "status": "retired",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "75"
         },
         "12.0": {
           "release_date": "2020-05-07",
-          "status": "current",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "79"
         }


### PR DESCRIPTION
As mentioned in https://github.com/mdn/browser-compat-data/pull/6158#issuecomment-635240568:
> 11.2 is current, 12.0 is our beta version

This PR updates the Samsung Internet browser data accordingly.