### PR TITLE
Update AudioTrack and VideoTrack support data

### DIFF
--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -26,9 +26,6 @@
           },
           "edge": [
             {
-              "version_added": "12"
-            },
-            {
               "version_added": "79",
               "flags": [
                 {
@@ -37,6 +34,10 @@
                   "value_to_set": "enabled"
                 }
               ]
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79"
             }
           ],
           "firefox": {
@@ -127,9 +128,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -138,6 +136,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -229,9 +231,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -240,6 +239,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -331,9 +334,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -342,6 +342,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -433,9 +437,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -444,6 +445,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -535,9 +540,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -546,6 +548,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -637,9 +643,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -648,6 +651,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -5,40 +5,94 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "45",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "45",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
-          "edge": {
-            "version_added": "≤18"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
-            "version_added": null
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
-            "version_added": null
+            "version_added": "32",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "32",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "45"
           }
         },
         "status": {
@@ -52,40 +106,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/enabled",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -100,40 +208,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/id",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -148,40 +310,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/kind",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -196,40 +412,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/label",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -244,40 +514,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/language",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -292,40 +616,80 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/sourceBuffer",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -5,40 +5,94 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "45",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "45",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
-          "edge": {
-            "version_added": "≤18"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
-            "version_added": null
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "33",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "media.track.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
-            "version_added": null
+            "version_added": "32",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "32",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "45"
           }
         },
         "status": {
@@ -52,40 +106,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/id",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -100,40 +208,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/kind",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -148,40 +310,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/label",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -196,40 +412,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/language",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -244,40 +514,94 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/selected",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.track.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {
@@ -292,40 +616,80 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/sourceBuffer",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "45"
             }
           },
           "status": {

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -26,9 +26,6 @@
           },
           "edge": [
             {
-              "version_added": "12"
-            },
-            {
               "version_added": "79",
               "flags": [
                 {
@@ -37,6 +34,10 @@
                   "value_to_set": "enabled"
                 }
               ]
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79"
             }
           ],
           "firefox": {
@@ -127,9 +128,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -138,6 +136,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -229,9 +231,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -240,6 +239,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -331,9 +334,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -342,6 +342,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -433,9 +437,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -444,6 +445,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -535,9 +540,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -546,6 +548,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -637,9 +643,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -648,6 +651,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {


### PR DESCRIPTION
This change updates the support data for `AudioTrack` and `VideoTrack`. The data was confirmed by doing manual testing and by checking browser-engine change/revision histories. It mirrors data from https://github.com/mdn/browser-compat-data/pull/2863 (https://github.com/mdn/browser-compat-data/commit/b378e47) for `AudioTrackList` and `VideoTrackList` (when we first added those).