### PR TITLE
Update (Audio|Video)TrackList Edge support data

### DIFF
--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -24,9 +24,21 @@
               }
             ]
           },
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": "33",
             "flags": [
@@ -114,9 +126,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -205,9 +229,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -295,9 +331,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -385,9 +433,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -475,9 +535,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -565,9 +637,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -655,9 +739,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -746,9 +842,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -26,9 +26,6 @@
           },
           "edge": [
             {
-              "version_added": "12"
-            },
-            {
               "version_added": "79",
               "flags": [
                 {
@@ -37,6 +34,10 @@
                   "value_to_set": "enabled"
                 }
               ]
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79"
             }
           ],
           "firefox": {
@@ -128,9 +129,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -139,6 +137,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -231,9 +233,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -242,6 +241,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -333,9 +336,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -344,6 +344,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -435,9 +439,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -446,6 +447,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -537,9 +542,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -548,6 +550,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -639,9 +645,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -650,6 +653,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -741,9 +748,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -752,6 +756,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -844,9 +852,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -855,6 +860,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -24,9 +24,21 @@
               }
             ]
           },
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": "33",
             "flags": [
@@ -114,9 +126,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -205,9 +229,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -295,9 +331,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -385,9 +433,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -475,9 +535,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -565,9 +637,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -655,9 +739,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -746,9 +842,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -836,9 +944,21 @@
                 }
               ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -26,9 +26,6 @@
           },
           "edge": [
             {
-              "version_added": "12"
-            },
-            {
               "version_added": "79",
               "flags": [
                 {
@@ -37,6 +34,10 @@
                   "value_to_set": "enabled"
                 }
               ]
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79"
             }
           ],
           "firefox": {
@@ -128,9 +129,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -139,6 +137,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -231,9 +233,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -242,6 +241,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -333,9 +336,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -344,6 +344,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -435,9 +439,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -446,6 +447,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -537,9 +542,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -548,6 +550,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -639,9 +645,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -650,6 +653,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -741,9 +748,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -752,6 +756,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -844,9 +852,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -855,6 +860,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -946,9 +955,6 @@
             },
             "edge": [
               {
-                "version_added": "12"
-              },
-              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -957,6 +963,10 @@
                     "value_to_set": "enabled"
                   }
                 ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
               }
             ],
             "firefox": {


### PR DESCRIPTION
This change updates that Edge support data for `AudioTrackList` and `VideoTrackList`, to indicate they’re supported in Blink-based Edge 79+ behind the same flag as Chrome, and to retain the indication that they’re supported in legacy Edge since version 12.