### PR TITLE
HTMLMediaElement.p.srcObject supported in Safari

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3431,10 +3431,10 @@
               "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "partial_implementation": true,


### PR DESCRIPTION
https://trac.webkit.org/changeset/159797/webkit landed (behind a flag) `HTMLMediaElement.p.srcObject` support in WebKit back in 2013, around the time of Safari 8. And WebKit appears to have had support for setting `srcObject` to a `MediaSource` or `Blob` (not just a `MediaStream`) since at least https://trac.webkit.org/changeset/212311/webkit. Per https://trac.webkit.org/changeset/222829/webkit it all seems to have first actually shipped in Safari 11, as part of shipping support for Media Capture and Streams.  https://web-confluence.appspot.com/#!/catalog?releases=%5B%22Safari_10.1.2_OSX_10.12.6%22,%22Safari_11.0.3_OSX_10.13.3%22%5D&q=%22HTMLMediaElement%23srcObject%22 also appears to confirm that `srcObject` wasn’t exposed until Safari 11.