### PR TITLE
Scrub "EdgeHTML" from notes

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -320,7 +320,10 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
+                "notes": [
+                  "Before Edge 79, <code>%c</code> is not supported.",
+                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "firefox": {
                 "version_added": "9"
@@ -532,7 +535,10 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
+                "notes": [
+                  "Before Edge 79, <code>%c</code> is not supported.",
+                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "firefox": {
                 "version_added": "9"
@@ -542,7 +548,10 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "%c is not supported, %d will render as 0 when it is not a number"
+                "notes": [
+                  "<code>%c</code> is not supported.",
+                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "nodejs": {
                 "version_added": "0.1.100"
@@ -876,7 +885,10 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
+                "notes": [
+                  "Before Edge 79, <code>%c</code> is not supported.",
+                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "firefox": {
                 "version_added": "9"
@@ -886,7 +898,10 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "%c is not supported, %d will render as 0 when it is not a number"
+                "notes": [
+                  "<code>%c</code> is not supported.",
+                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "nodejs": {
                 "version_added": true
@@ -979,7 +994,10 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
+                "notes": [
+                  "Before Edge 79, <code>%c</code> is not supported.",
+                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "firefox": {
                 "version_added": "9"
@@ -989,7 +1007,10 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "%c is not supported, %d will render as 0 when it is not a number"
+                "notes": [
+                  "<code>%c</code> is not supported.",
+                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "nodejs": {
                 "version_added": "0.1.100"
@@ -1492,7 +1513,10 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
+                "notes": [
+                  "Before Edge 79, <code>%c</code> is not supported.",
+                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "firefox": {
                 "version_added": "9"
@@ -1502,7 +1526,10 @@
               },
               "ie": {
                 "version_added": "10",
-                "notes": "%c is not supported, %d will render as 0 when it is not a number"
+                "notes": [
+                  "<code>%c</code> is not supported.",
+                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
+                ]
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -540,7 +540,8 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "EdgeHTML versions of edge only trim whitespace - it doesn't remove duplicates. This behavior was fixed in Chromium versions of Edge."
+              "partial_implementation": true,
+              "notes": "Before Edge 79, <code>DOMTokenList</code> trims whitespace but doesn't remove duplicates."
             },
             "firefox": {
               "version_added": "55"
@@ -550,7 +551,8 @@
             },
             "ie": {
               "version_added": true,
-              "notes": " IE only trims whitespace - it doesn't remove duplicates."
+              "partial_implementation": true,
+              "notes": "<code>DOMTokenList</code> trims whitespace but doesn't remove duplicates."
             },
             "opera": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -5604,7 +5604,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this returns an <code>HTMLCollection</code>, not a <code>NodeList</code>. This behavior was fixed in Chromium versions of Edge."
+              "notes": "Before Edge 79, this method returns an <code>HTMLCollection</code>, not a <code>NodeList</code>."
             },
             "firefox": {
               "version_added": "1"

--- a/api/Location.json
+++ b/api/Location.json
@@ -596,7 +596,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML versions of Edge, if a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe).  This behavior was fixed in Edge 79."
+              "notes": "Before Edge 79, if a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "firefox": {
               "version_added": "1"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -186,8 +186,7 @@
               }
             ],
             "edge": {
-              "version_added": "12",
-              "notes": "Microsoft Edge (EdgeHTML) requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, Edge will throw a syntax error. This behavior is not present in Chromium based editions of Edge."
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "14",

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -105,7 +105,7 @@
             ],
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML versions of Edge, this requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, EdgeHTML will throw a syntax error. This behavior was fixed in Chromium versions of Edge."
+              "notes": "Before Edge 79, this requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, then Edge throws a syntax error."
             },
             "firefox": {
               "version_added": "14"
@@ -115,7 +115,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "Internet Explorer requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, Internet Explorer will throw a syntax error."
+              "notes": "Internet Explorer requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, then Internet Explorer throws a syntax error."
             },
             "opera": {
               "version_added": "15"

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -108,7 +108,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>. This behavior was fixed in Chromium versions of Edge."
+              "notes": "Before Edge 79, this property was only implemented for <code>Element</code>, not for <code>CharacterData</code>."
             },
             "firefox": {
               "version_added": "3.5"
@@ -159,7 +159,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>. This behavior was fixed in Chromium versions of Edge."
+              "notes": "Before Edge 79, this property was only implemented for <code>Element</code>, not for <code>CharacterData</code>."
             },
             "firefox": {
               "version_added": "3.5"

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -12,7 +12,7 @@
           },
           "edge": {
             "version_added": "12",
-            "notes": "In EdgeHTML, this only implements the SVG 1.1 specification of the interface."
+            "notes": "Before Edge 79, this interface only implements the SVG 1.1 specification."
           },
           "firefox": {
             "version_added": true,

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -12,7 +12,7 @@
           },
           "edge": {
             "version_added": "12",
-            "notes": "In EdgeHTML, this only implements the SVG 1.1 specification of the interface."
+            "notes": "Before Edge 79, this only implements the SVG 1.1 specification of the interface."
           },
           "firefox": {
             "version_added": true,

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -12,7 +12,7 @@
           },
           "edge": {
             "version_added": "12",
-            "notes": "In EdgeHTML, this only implements the SVG 1.1 specification of the interface."
+            "notes": "Before Edge 79, this interface implements only the SVG 1.1 specification."
           },
           "firefox": {
             "version_added": true,

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
+              "notes": "Before Edge 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
+              "notes": "Before Edge 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
+              "notes": "Before Edge 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
+              "notes": "Before Edge 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
+              "notes": "Before Edge 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"


### PR DESCRIPTION
Several notes have been introduced that mention EdgeHTML, which goes against usual practice of naming browsers and their versions. This PR removes all mentions of EdgeHTML from notes.

In a few cases (noted in the commit messages), I also updated IE notes for consistency. In one case, I removed a note which was erroneously duplicated in an adjacent feature.

Supersedes #6223.