### PR TITLE
Update Element.attributes IE value

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1215,7 +1215,7 @@
               "version_added": "26"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22"
@@ -1224,7 +1224,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1224,7 +1224,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": "8"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1224,7 +1224,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "8"


### PR DESCRIPTION
Fixes mistake introduced in #5740

https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/cc288590(v=vs.85)

Also, how would any of us ever have been able to access attributes way back when? LOL