### PR TITLE
Add Safari support for ChildNode.after and .before

### DIFF
--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -76,10 +76,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -124,10 +124,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
[ChildNode.after](https://developer.apple.com/documentation/webkitjs/childnode/1777966-after)
[ChildNode.before](https://developer.apple.com/documentation/webkitjs/childnode/1777912-before)

This might work before Safari 10 because [ChildNode.remove](https://developer.apple.com/documentation/webkitjs/childnode/1630714-remove) and [ChildNode.replaceWith](https://developer.apple.com/documentation/webkitjs/childnode/1777944-replacewith) are documented as 10+ by Apple but 7+ by MDN.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
