### PR TITLE
adding in compat data for ParentNode querySelector and replaceChildren

### DIFF
--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -632,7 +632,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -663,7 +663,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -624,6 +624,55 @@
           }
         }
       },
+      "querySelector": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ParentNode/querySelector",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9",
+              "notes": "Internet Explorer 8 only supported CSS2 selectors."
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "querySelectorAll": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ParentNode/querySelectorAll",
@@ -668,6 +717,54 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "replaceChildren": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ParentNode/replaceChildren",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "78"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1626015

I did a bit of testing around, and it doesn't seem to be supported anywhere else yet. I tested in Safari, and Chrome Canary, and it wasn't in either of those, so by extension, none of the other Chromiums will support it either.

I also took this opportunity to add in support for `ParentNode.querySelector`, which should just have the same support as `ParentNode.querySelectorAll`. Any reason why this wasn't added?