### PR TITLE
updating BCD for :read-only and :read-write

### DIFF
--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -15,15 +15,18 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "1.5",
-              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
-            },
+            "firefox": [
+              {
+                "version_added": "78"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
             "firefox_android": {
               "prefix": "-moz-",
-              "version_added": "4",
-              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -15,15 +15,18 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "1.5",
-              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
-            },
+            "firefox": [
+              {
+                "version_added": "78"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1.5"
+              }
+            ],
             "firefox_android": {
               "prefix": "-moz-",
-              "version_added": "4",
-              "notes": "See <a href='https://bugzil.la/312971'>bug 312971</a> for unprefixed status."
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -51,54 +54,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "matches_editable_elements": {
-          "__compat": {
-            "description": "Matches editable elements that are neither <code>&lt;input&gt;</code> elements nor <code>&lt;textarea&gt;</code> elements",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "1.5"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=312971

I removed the sub-section about `:read-write` matching editable elements that are neither `<input>` elements nor `<textarea>`, because it seems to work in all the browsers I tested in.

And I removed the notes from Firefox for Android, because it seems weird having that note present when the work is now finished (just not put into FxA yet). 