### PR TITLE
Add desynchronized WebGL context attribute

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -192,6 +192,66 @@
             }
           }
         },
+        "desynchronized": {
+          "__compat": {
+            "description": "<code>desynchronized</code> attribute",
+            "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "81",
+                  "notes": "ChromeOS and Windows"
+                },
+                {
+                  "version_added": "75",
+                  "notes": "ChromeOS only"
+                },
+                {
+                  "version_added": "71",
+                  "alternative_name": "lowLatency"
+                }
+              ],
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "failIfMajorPerformanceCaveat": {
           "__compat": {
             "description": "failIfMajorPerformanceCaveat attribute",


### PR DESCRIPTION
Add support listing for desynchronized WebGL context creation attribute.

spec: https://www.khronos.org/registry/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES
spec discussion: https://github.com/whatwg/html/issues/4087
article: https://developers.google.com/web/updates/2019/05/desynchronized
