### PR TITLE
Update Safari compat data for <data>, HTMLDataElement

### DIFF
--- a/api/HTMLDataElement.json
+++ b/api/HTMLDataElement.json
@@ -29,10 +29,10 @@
             "version_added": "46"
           },
           "safari": {
-            "version_added": false
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10"
           },
           "samsunginternet_android": {
             "version_added": "8.0"
@@ -76,10 +76,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -30,10 +30,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
Apple Developer documentation link referencing support for
`HTMLDataElement` in Safari 10.0+ SDKs (Desktop and Mobile):
https://developer.apple.com/documentation/webkitjs/htmldataelement

Live example:  https://karlstolley.github.io/safari-data-attribute
Source: https://github.com/karlstolley/safari-data-attribute/blob/master/index.html

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
