### PR TITLE
Move Intl.Collator caseFirst option under the constructor

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -112,56 +112,56 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          },
-          "caseFirst": {
-            "__compat": {
-              "description": "<code>caseFirst</code> option",
-              "support": {
-                "chrome": {
-                  "version_added": "24"
+            },
+            "caseFirst": {
+              "__compat": {
+                "description": "<code>caseFirst</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "25"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "55"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "0.12"
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": "14"
+                  },
+                  "safari": {
+                    "version_added": "11"
+                  },
+                  "safari_ios": {
+                    "version_added": "11"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "1.5"
+                  },
+                  "webview_android": {
+                    "version_added": "4.4"
+                  }
                 },
-                "chrome_android": {
-                  "version_added": "25"
-                },
-                "edge": {
-                  "version_added": "18"
-                },
-                "firefox": {
-                  "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "0.12"
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": "14"
-                },
-                "safari": {
-                  "version_added": "11"
-                },
-                "safari_ios": {
-                  "version_added": "11"
-                },
-                "samsunginternet_android": {
-                  "version_added": "1.5"
-                },
-                "webview_android": {
-                  "version_added": "4.4"
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
                 }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
               }
             }
           },


### PR DESCRIPTION
This is a follow-up to the discussion in #6202. There was an inconsistency in the data structure regarding options to `Intl` object constructors. The options for `Intl.DateTimeFormat()` are nested under the constructor, but the option for `Intl.Collator()` was at the same level as the constructor.

As discussed with @ddbeck, this PR moves the `caseFirst` option so that it's nested underneath the `Intl.Collator()` constructor. This might be considered a breaking change, though.