### PR TITLE
Add that Safari supports X-Content-Type-Options (as of 11.0).

### DIFF
--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -44,10 +44,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This PR adds that Safari supports `X-Content-Type-Options` as of Safari 11.0. Below is documentary evidence to support this:

1. WebKit has a blog entry called ["New WebKit Features in Safari 11,"](https://webkit.org/blog/7956/new-webkit-features-in-safari-11/) which says that it includes Safari Technology Preview release 30:
   
   > Changes in this release of Safari were included in the following Safari Technology Preview releases: 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36.

2. Safari Technology Preview 30 [says the following](https://webkit.org/blog/7614/release-notes-for-safari-technology-preview-30/):

   > Implemented X-Content-Type-Options:nosniff (r215753, r216195)
  
3. Additionally, the later of the two revisions mentioned is r216195 (dated May 4, 2017):
https://trac.webkit.org/changeset/216195/webkit

4. The "Safari version history" Wikipedia page says Safari 11.0 (dated Sep. 19, 2017) corresponds to WebKit version 604.2.4:
https://en.wikipedia.org/wiki/Safari_version_history#Safari_11

5. If you go to the "safari-604.2-branch" branch of WebKit and look at the following `ChangeLog` file, you can see that it contains the change mentioned in (3) above:
https://trac.webkit.org/browser/webkit/branches/safari-604.2-branch/Source/WebCore/ChangeLog

   > 2017-05-04  Daniel Bates  <dabates@apple.com>
importScripts() should respect X-Content-Type-Options: nosniff
https://bugs.webkit.org/show_bug.cgi?id=171248
<rdar://problem/31819023>

I'm CC'ing Daniel Bates who implemented this in WebKit: @dbates-wk