### PR TITLE
Add support for MediaSession in Opera 

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -237,7 +237,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
             "version_added": false
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This was tested in Opera 68 for Windows 10 64-bit and MediaSession appeared to be accessible. If anyone has tested this in Opera Mobile, please let me know.