### PR TITLE
Add full MediaMetadata support in both Opera and Chrome

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true
           },
           "chrome_android": {
             "version_added": "57"
@@ -53,7 +53,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/MediaMetadata",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": "57"
@@ -101,7 +101,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/album",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": "57"
@@ -149,7 +149,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artist",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": "57"
@@ -197,7 +197,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artwork",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": "57"
@@ -245,7 +245,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/title",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": "57"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -53,7 +53,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/MediaMetadata",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "57"
             },
             "chrome_android": {
               "version_added": "57"
@@ -101,7 +101,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/album",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "57"
             },
             "chrome_android": {
               "version_added": "57"
@@ -149,7 +149,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artist",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "57"
             },
             "chrome_android": {
               "version_added": "57"
@@ -197,7 +197,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artwork",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "57"
             },
             "chrome_android": {
               "version_added": "57"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
             "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -119,7 +119,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "57"
           },
           "chrome_android": {
             "version_added": "57"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -245,7 +245,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/title",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "57"
             },
             "chrome_android": {
               "version_added": "57"


### PR DESCRIPTION
This was tested in Chrome 83 and Opera 68 on Windows 10 64-bit.