### PR TITLE
Safari 13.1 supports image-orientation

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -33,7 +33,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "13.1"
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -30,10 +30,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Safari 13.1 & Mobile Safari 13.1 supports `image-orientation`.
I'm not sure from which version of Safari has started supporting image-orientation property.

I've created examples to test a behavior of image-orientation.

- https://pirosikick.github.io/image-orientation-example/
  - [from-image.html](https://pirosikick.github.io/image-orientation-example/from-image.html): you can see images in the correct orientation because all images are set `image-orientation: from-image;` and the browser rotates images automatically.
  - [none.html](https://pirosikick.github.io/image-orientation-example/none.html): images are shown in the original orientation because all images are set `image-orientation: none;`.