### PR TITLE
Fix missing or incorrect Intl data for Edge, Android and Safari

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -45,7 +45,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -64,7 +64,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -104,7 +104,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -125,7 +125,7 @@
                   "version_added": "25"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -146,16 +146,16 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -174,7 +174,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -208,7 +208,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -227,7 +227,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -261,7 +261,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -280,7 +280,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -320,7 +320,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -358,7 +358,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -579,7 +579,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -629,7 +629,7 @@
                     "version_added": "3.0"
                   },
                   "webview_android": {
-                    "version_added": false
+                    "version_added": "4.4"
                   }
                 },
                 "status": {
@@ -689,7 +689,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -45,7 +45,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -106,7 +106,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -159,7 +159,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -265,7 +265,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -324,7 +324,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": "4.4"
                 }
               },
               "status": {


### PR DESCRIPTION
After raising #6253 I realised there were several missing or inaccurate records for `Intl.Collator`. Digging further, I found some more inconsistencies in a couple of other `Intl` APIs.

I've done as much digging for real version numbers as much as possible, with the following results:

- Safari and iOS Safari added support for the `caseFirst` option of `Intl.Collator` in version 11 (the same version that they got `Intl.DateTimeFormat().formatToParts()`). This was confirmed via [the WebKit changelog diff for version 11](https://trac.webkit.org/changeset?old_path=%2Fwebkit%2Freleases%2FApple%2FiOS+10.3.3%2FJavaScriptCore%2FChangeLog&old=262613&new_path=%2Fwebkit%2Freleases%2FApple%2FiOS+11.0%2FJavaScriptCore%2FChangeLog&new=262613).
- Edge added `caseFirst` in version 18 (again, the same as `DateTimeFormat().formatToParts()`). This was confirmed by manual testing in VMs.
   <details><summary>Edge 17</summary>
   <img width="969" alt="collator-edge-17" src="https://user-images.githubusercontent.com/159415/84012273-a9713000-a9ba-11ea-826e-be6b3244962e.png">
   </details>
   <details><summary>Edge 18</summary>
   <img width="973" alt="collator-edge-18" src="https://user-images.githubusercontent.com/159415/84012324-b68e1f00-a9ba-11ea-944f-7f64f2d21a83.png">
  </details>

- Android WebView got most `Intl` support in v4.4, including `caseFirst` for `Collator`. This is already accurate in most of the compat data, but there were some missing entries for `Collator`, `DateTimeFormat`, and `NumberFormat`. This led to the strange situation of the data saying that WebView supported an option for a constructor that it didn't have. I double-checked the support via manual testing in emulators.
   <details><summary>Collator in Android 4.4</summary>
   <img width="233" alt="collator-android-4-4" src="https://user-images.githubusercontent.com/159415/84013847-d0c8fc80-a9bc-11ea-992a-495ed9abae99.png">
   </details>

- Chrome Android had wonky versions for `Collator` features — a mixture of versions 25 and 26. Given that Chrome desktop had support in version 24, I set all the versions to 25, which also matches `DateTimeFormat`. However, `NumberFormat` currently lists the baseline support as Chrome Android 26, which doesn't match `DateTimeFormat`. I've left that alone, but can also change them to match if necessary. (I haven't been able to manually test versions that old to confirm).

---

### Questions

- Should I also change `Intl.NumberFormat` support in Chrome Android from version 26 to 25, to match the other data?
- I think the data for the related `locales` option of `{Array,Date}.prototype.toLocaleString()` is also incorrect for Android WebView. Should I correct that in this PR or a separate one?
- I also noticed that the `{ style: 'unit' }` option for `Intl.NumberFormat()` doesn't work in several browsers as it's relatively new. Currently only IE11 has a note saying that it's not supported. Should that `unit` option be split out into a separate support data entry?
