### PR TITLE
Mark SubmitEvent as unsupported in IE

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -21,7 +21,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null
@@ -70,7 +70,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -119,7 +119,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
I checked in IE 11 that the `SubmitEvent` global variable does not exist, and that the event object passed to listeners for the `submit` event does not have a `submitter` property.
