### PR TITLE
feat(javascript): `Symbol.toStringTag` is available on all DOM objects

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1034,6 +1034,58 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "dom-objects": {
+            "__compat": {
+              "description": "<code>toStringTag</code> available on all DOM prototype objects",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects",
+              "support": {
+                "chrome": {
+                  "version_added": "50"
+                },
+                "chrome_android": {
+                  "version_added": "50"
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "78"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": "37"
+                },
+                "opera_android": {
+                  "version_added": "37"
+                },
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "14"
+                },
+                "samsunginternet_android": {
+                  "version_added": "5.0"
+                },
+                "webview_android": {
+                  "version_added": "50"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "unscopables": {


### PR DESCRIPTION
<dl>
<dt><strong>Firefox</strong></dt><dd>

- [Bug 1277799](https://bugzilla.mozilla.org/show_bug.cgi?id=1277799)
</dd>
<dt><strong>Chrome</strong></dt><dd>

- [Issue 239915](https://bugs.chromium.org/p/chromium/issues/detail?id=239915)
- [chromium@`909c0d7`](https://crrev.com/909c0d7d5a53c8526ded351683c65ea7d17531d4) ([landed in 50.0.2661.0](https://storage.googleapis.com/chromium-find-releases-static/909.html#909c0d7d5a53c8526ded351683c65ea7d17531d4))
</dd>
<dt><strong>WebKit</strong></dt><dd>

- [Bug 211020](https://bugs.webkit.org/show_bug.cgi?id=211020)
</dd>
</dl>