### PR TITLE
Chrome 83 supports CSP: trusted-types

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1670,7 +1670,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "83"
                 }
               },
               "status": {

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1612,7 +1612,7 @@
               "support": {
                 "chrome": [
                   {
-                    "version_added": null
+                    "version_added": "83"
                   },
                   {
                     "version_added": "73",
@@ -1628,7 +1628,7 @@
                 ],
                 "chrome_android": [
                   {
-                    "version_added": null
+                    "version_added": "83"
                   },
                   {
                     "version_added": "73",


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

CSP: trusted-types is enabled on Chrome 83 by default.
ref: [Trusted Types for DOM Manipulation - Chrome Platform Status](https://www.chromestatus.com/feature/5650088592408576).