### PR TITLE
Clean up activeVRDisplays data

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -61,7 +61,8 @@
             },
             "edge": {
               "version_added": "15",
-              "version_removed": "79"
+              "version_removed": "79",
+              "notes": "WebVR content requires a Windows Mixed Reality headset or the Windows Mixed Reality Portal Simulator."
             },
             "firefox": [
               {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -104,6 +104,53 @@
             "standard_track": true,
             "deprecated": true
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       },
       "authentication": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -119,10 +119,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": "73"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -109,6 +109,7 @@
         },
         "secure_context_required": {
           "__compat": {
+            "description": "Secure context required",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -52,12 +52,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/activeVRDisplays",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Currently supported only by Google Daydream."
+              "version_added": "79",
+              "version_removed": "80",
+              "notes": "Supported only by Google Daydream."
             },
             "edge": {
               "version_added": "15",
@@ -97,7 +97,8 @@
               "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "79",
+              "version_removed": "80"
             }
           },
           "status": {
@@ -113,7 +114,8 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "79",
+                "version_removed": "80"
               },
               "edge": {
                 "version_added": false
@@ -143,7 +145,8 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "79",
+                "version_removed": "80"
               }
             },
             "status": {


### PR DESCRIPTION
Based heavily on #5838. This PR does a few things to `api.Navigator.activeVRDisplays`:

* It adds a `secure_context_required` subfeature to `activeVRDisplays`.
* Firefox: Sets `secure_context_required` to version 73, according to https://bugzilla.mozilla.org/show_bug.cgi?id=1381645. 
* Chrome: Removes notes for non-release builds of Chrome. Sets version numbers based on @jpmedley's commentary on https://github.com/mdn/browser-compat-data/pull/5838#pullrequestreview-412853387.
* Edge: Updates based on [Edge platform status](https://developer.microsoft.com/en-us/microsoft-edge/status/webvr/?q=webvr) and Chromium.

There are probably other changes that need to be made other WebVR data points. I've decided to restrict things to `activeVRDisplays` for the purposes of this PR. The Chromium-derived browser data looks iffy. We may want to open an issue to track all the WebVR features and collect research (or @ vendor reps) to get data to properly fill this stuff out.

Closes #5838.