### PR TITLE
Split JS assignment operators

### DIFF
--- a/javascript/operators/addition_assignment.json
+++ b/javascript/operators/addition_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "addition_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Addition assignment (<code>x += y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Addition_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/bitwise_and_assignment.json
+++ b/javascript/operators/bitwise_and_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "bitwise_and_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Bitwise AND assignment (<code>x &amp;= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/bitwise_or_assignment.json
+++ b/javascript/operators/bitwise_or_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "bitwise_or_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Bitwise OR assignment (<code>x |= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/bitwise_xor_assignment.json
+++ b/javascript/operators/bitwise_xor_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "bitwise_xor_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Bitwise XOR assignment (<code>x ^= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/division_assignment.json
+++ b/javascript/operators/division_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "division_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Division assignment (<code>x /= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Division_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/exponentiation_assignment.json
+++ b/javascript/operators/exponentiation_assignment.json
@@ -1,0 +1,69 @@
+{
+  "javascript": {
+    "operators": {
+      "exponentiation_assignment": {
+        "__compat": {
+          "description": "Exponentiation assignment (<code>x **= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": [
+              {
+                "version_added": "7.0.0"
+              },
+              {
+                "version_added": "6.5.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
+            "opera": {
+              "version_added": "39"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "51"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/operators/left_shift_assignment.json
+++ b/javascript/operators/left_shift_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "left_shift_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Left shift assignment (<code>x &lt;&lt;= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Left_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/multiplication_assignment.json
+++ b/javascript/operators/multiplication_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "multiplication_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Multiplication assignment (<code>x *= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/remainder_assignment.json
+++ b/javascript/operators/remainder_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "remainder_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Remainder assignment (<code>x %= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Remainder_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/right_shift_assignment.json
+++ b/javascript/operators/right_shift_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "right_shift_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Right shift assignment (<code>x &gt;&gt;= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/subtraction_assignment.json
+++ b/javascript/operators/subtraction_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "substraction_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Subtraction assignment (<code>x -= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {

--- a/javascript/operators/unsigned_right_shift_assignment.json
+++ b/javascript/operators/unsigned_right_shift_assignment.json
@@ -1,10 +1,10 @@
 {
   "javascript": {
     "operators": {
-      "assignment": {
+      "unsigned_right_shift_assignment": {
         "__compat": {
-          "description": "Assignment (<code>x = y</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
+          "description": "Unsigned right shift assignment (<code>x &gt;&gt;&gt;= y</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
           "support": {
             "chrome": {


### PR DESCRIPTION
We'd like to have separate pages for assignment operators as well.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators 