### PR TITLE
Update EffectTiming.json.

### DIFF
--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -5,13 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming",
         "support": {
           "chrome": {
-            "version_added": true
+            "alternative_name": "AnimationEffectTiming",
+            "version_added": "84"
           },
           "chrome_android": {
-            "version_added": true
+            "alternative_name": "AnimationEffectTiming",
+            "version_added": "84"
           },
           "edge": {
-            "version_added": "≤79"
+            "alternative_name": "AnimationEffectTiming",
+            "version_added": "84"
           },
           "firefox": {
             "version_added": "63"
@@ -23,9 +26,11 @@
             "version_added": null
           },
           "opera": {
+            "alternative_name": "AnimationEffectTiming",
             "version_added": true
           },
           "opera_android": {
+            "alternative_name": "AnimationEffectTiming",
             "version_added": true
           },
           "safari": {
@@ -35,10 +40,12 @@
             "version_added": null
           },
           "samsunginternet_android": {
+            "alternative_name": "AnimationEffectTiming",
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "alternative_name": "AnimationEffectTiming",
+            "version_added": "84"
           }
         },
         "status": {
@@ -52,13 +59,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/delay",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -85,7 +92,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -100,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/direction",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,7 +140,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -148,13 +155,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/duration",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -181,7 +188,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -196,13 +203,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/easing",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -229,7 +236,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -243,13 +250,13 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": "77"
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": "77"
+                "version_added": "84"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "65"
@@ -276,7 +283,7 @@
                 "version_added": "12.0"
               },
               "webview_android": {
-                "version_added": "77"
+                "version_added": "84"
               }
             },
             "status": {
@@ -292,13 +299,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/endDelay",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -325,7 +332,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -340,13 +347,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/fill",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -373,7 +380,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -388,13 +395,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/iterations",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -421,7 +428,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {
@@ -436,13 +443,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming/iterationStart",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -469,7 +476,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This [landed in Chrome 84](https://www.chromestatus.com/features/5126405660606464) under the name `AnimationEffectTiming`. You can't see this by looking at the IDLs. The relevant IDLs contain this line:

```
RuntimeEnabled=WebAnimationsAPI
```

`WebAnimationsAPI` resolves to an item in [runtime_enabled_features.json5](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/runtime_enabled_features.json5). The status of this changed from `experimental` to `stable` [in Chrome 84](https://storage.googleapis.com/chromium-find-releases-static/9cd.html#9cdcb106b0bcfee75cf3e94576fd48c055cc4bd6).

I do not have an ETA for when Chrome will be updated to match the spec.