### PR TITLE
Add ClipboardItem.json.

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -1,0 +1,245 @@
+{
+  "api": {
+    "ClipboardItem": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem",
+        "support": {
+          "chrome": {
+            "version_added": "66"
+          },
+          "chrome_android": {
+            "version_added": "66"
+          },
+          "edge": {
+            "version_added": "≤79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": "66"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ClipboardItem": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/ClipboardItem",
+          "description": "<code>ClipboardItem()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/getType",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "raw": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/raw",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "types": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/types",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -144,54 +144,6 @@
           }
         }
       },
-      "raw": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/raw",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "types": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/types",


### PR DESCRIPTION
Based on the flag attached to this interface in the source code, I believe this to have shipped in Chrome 66 with the first land of Aysnc Clipboard features.