### PR TITLE
HTMLImageElement.currentSrc Safari

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
`HTMLImageElement.currentSrc` is now supported in Safari and Safari iOS.

https://developer.apple.com/documentation/webkitjs/htmlimageelement/1777757-currentsrc

Tested on Safari Version 12.1.1 (14607.2.6.1.1)
Tested on Safari iOS version 13.1.2
