### PR TITLE
Revert "Bring location.json->hostname inline with HTMLHyperlinkElemen…

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -262,10 +262,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This reverts #3482 which doesn't seem to make any sense. Location.hostname IS supported by all of those browsers, even old versions of IE.