### PR TITLE
IntersectionObserver() support for document as root

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -111,6 +111,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "document_as_root": {
+          "__compat": {
+            "description": "<code>root</code> option can be a <code>Document</code>",
+            "support": {
+              "chrome": {
+                "version_added": "81"
+              },
+              "chrome_android": {
+                "version_added": "81"
+              },
+              "edge": {
+                "version_added": "81"
+              },
+              "firefox": {
+                "version_added": "76"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "68"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "81"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "disconnect": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -91,7 +91,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "safari": {
               "version_added": "12.1"


### PR DESCRIPTION
This PR reconciles and supersedes #6066 and #6083.

* Chrome etc.: shipped in 81 ([bug 1015183](https://bugs.chromium.org/p/chromium/issues/detail?id=1015183) via #6066).
* Edge: derived from Chrome.
* Firefoxes: shipped in 76 ([bug 1623623](https://bugzilla.mozilla.org/show_bug.cgi?id=1623623) via #6083).
* IE: unsupported (inherited from parent feature)
* Operas: derived from Chrome.
* Safaris: implemented but not yet shipped ([changeset 258648](https://trac.webkit.org/changeset/258648/webkit)). Based on the date of the changeset, I couldn't be certain about Safari, so I tested to confirm that it is unsupported (13.1 throws a `TypeError` with `{ root: document }`).
* Samsung Internet: derived from Chrome.

Like #6083, I updated Opera's version number for the  `IntersectionObserver()` constructor because it was `null`. It needed a value to pass the consistency check.

Unlike #6083, I chose against duplicating the data to a subfeature of `IntersectionObserver.root` since the property is read-only.

Closes #6066; closes #6083.