### PR TITLE
Add Chrome file system data.

### DIFF
--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -4,28 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystem",
         "support": {
-          "chrome": [
-            {
-              "version_removed": true,
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "7",
-              "alternative_name": "DOMFileSystem"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_removed": true,
-              "version_added": "18",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "18",
-              "alternative_name": "DOMFileSystem"
-            }
-          ],
+          "chrome": {
+            "version_added": "7",
+            "alternative_name": "DOMFileSystem"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "alternative_name": "DOMFileSystem"
+          },
           "edge": {
             "version_added": "≤18",
             "prefix": "WebKit",
@@ -58,17 +44,10 @@
             "prefix": "webkit",
             "version_added": "1.0"
           },
-          "webview_android": [
-            {
-              "version_removed": true,
-              "version_added": "≤37",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "≤37",
-              "alternative_name": "DOMFileSystem"
-            }
-          ]
+          "webview_android": {
+            "version_added": "≤37",
+            "alternative_name": "DOMFileSystem"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -22,7 +22,7 @@
               "prefix": "webkit"
             },
             {
-              "version_added": "7",
+              "version_added": "18",
               "alternative_name": "DOMFileSystem"
             }
           ],

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -4,14 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystem",
         "support": {
-          "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
-          },
-          "chrome_android": {
-            "version_added": "18",
-            "prefix": "webkit"
-          },
+          "chrome": [
+            {
+              "version_removed": true,
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "7",
+              "alternative_name": "DOMFileSystem"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_removed": true,
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "7",
+              "alternative_name": "DOMFileSystem"
+            }
+          ],
           "edge": {
             "version_added": "≤18",
             "prefix": "WebKit",
@@ -44,10 +58,17 @@
             "prefix": "webkit",
             "version_added": "1.0"
           },
-          "webview_android": {
-            "version_added": "37",
-            "prefix": "webkit"
-          }
+          "webview_android": [
+            {
+              "version_removed": true,
+              "version_added": "≤37",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "≤37",
+              "alternative_name": "DOMFileSystem"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -60,7 +81,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystem/name",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "7"
             },
             "chrome_android": {
               "version_added": "18"
@@ -93,7 +114,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -108,7 +129,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystem/root",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "7"
             },
             "chrome_android": {
               "version_added": "18"
@@ -141,7 +162,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -4,14 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry",
         "support": {
-          "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
-          },
-          "chrome_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          },
+          "chrome": [
+            {
+              "version_removed": true,
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "DirectoryEntry"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_removed": true,
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "DirectoryEntry"
+            }
+          ],
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -42,10 +56,17 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          }
+          "webview_android": [
+            {
+              "version_removed": "≤37",
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "≤37",
+              "alternative_name": "DirectoryEntry"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -61,7 +82,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -91,7 +112,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -106,10 +127,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry/getDirectory",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -141,7 +162,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -156,10 +177,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry/getFile",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -191,7 +212,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -206,10 +227,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry/removeRecursively",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -243,7 +264,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -22,7 +22,7 @@
               "prefix": "webkit"
             },
             {
-              "version_added": "8",
+              "version_added": "18",
               "alternative_name": "DirectoryEntry"
             }
           ],

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -4,28 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry",
         "support": {
-          "chrome": [
-            {
-              "version_removed": true,
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "8",
-              "alternative_name": "DirectoryEntry"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_removed": true,
-              "version_added": "18",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "18",
-              "alternative_name": "DirectoryEntry"
-            }
-          ],
+          "chrome": {
+            "version_added": "8",
+            "alternative_name": "DOMFileSystem"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "alternative_name": "DOMFileSystem"
+          },
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -56,17 +42,10 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": [
-            {
-              "version_removed": "≤37",
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "≤37",
-              "alternative_name": "DirectoryEntry"
-            }
-          ]
+          "webview_android": {
+            "version_added": "≤37",
+            "alternative_name": "DirectoryEntry"
+          }
         },
         "status": {
           "experimental": true,

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -22,7 +22,7 @@
               "prefix": "webkit"
             },
             {
-              "version_added": "8",
+              "version_added": "18",
               "alternative_name": "DirectoryReader"
             }
           ],

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -4,14 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader",
         "support": {
-          "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
-          },
-          "chrome_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          },
+          "chrome": [
+            {
+              "version_removed": true,
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "DirectoryReader"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_removed": true,
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "DirectoryReader"
+            }
+          ],
           "edge": {
             "version_added": "≤18",
             "alternative_name": "WebKitDirectoryReader"
@@ -42,10 +56,17 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          }
+          "webview_android": [
+            {
+              "version_removed": true,
+              "version_added": "≤37",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "≤37",
+              "alternative_name": "DirectoryReader"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -58,10 +79,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader/readEntries",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -91,7 +112,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -4,28 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader",
         "support": {
-          "chrome": [
-            {
-              "version_removed": true,
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "8",
-              "alternative_name": "DirectoryReader"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_removed": true,
-              "version_added": "18",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "18",
-              "alternative_name": "DirectoryReader"
-            }
-          ],
+          "chrome": {
+            "version_added": "8",
+            "alternative_name": "DirectoryReader"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "alternative_name": "DirectoryReader"
+          },
           "edge": {
             "version_added": "≤18",
             "alternative_name": "WebKitDirectoryReader"
@@ -56,17 +42,10 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": [
-            {
-              "version_removed": true,
-              "version_added": "≤37",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "≤37",
-              "alternative_name": "DirectoryReader"
-            }
-          ]
+          "webview_android": {
+            "version_added": "≤37",
+            "alternative_name": "DirectoryReader"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -4,28 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry",
         "support": {
-          "chrome": [
-            {
-              "version_removed": true,
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "8",
-              "alternative_name": "Entry"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_removed": true,
-              "version_added": "18",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "18",
-              "alternative_name": "Entry"
-            }
-          ],
+          "chrome": {
+            "version_added": "8",
+            "alternative_name": "Entry"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "alternative_name": "Entry"
+          },
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -55,17 +41,10 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": [
-            {
-              "version_removed": true,
-              "version_added": "≤37",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "≤37",
-              "alternative_name": "Entry"
-            }
-          ]
+          "webview_android": {
+            "version_added": "≤37",
+            "alternative_name": "Entry"
+          }
         },
         "status": {
           "experimental": true,

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -4,14 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry",
         "support": {
-          "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
-          },
-          "chrome_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          },
+          "chrome": [
+            {
+              "version_removed": true,
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "Entry"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_removed": true,
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "Entry"
+            }
+          ],
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -41,10 +55,17 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          }
+          "webview_android": [
+            {
+              "version_removed": true,
+              "version_added": "≤37",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "≤37",
+              "alternative_name": "Entry"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -57,10 +78,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/copyTo",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -90,7 +111,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -105,10 +126,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/filesystem",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -138,7 +159,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -153,10 +174,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/fullPath",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -186,7 +207,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -201,10 +222,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/getMetadata",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -234,7 +255,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -249,10 +270,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/getParent",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -282,7 +303,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -297,10 +318,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/isDirectory",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -330,7 +351,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -345,10 +366,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/isFile",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -378,7 +399,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -393,10 +414,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/moveTo",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -426,7 +447,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -441,10 +462,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/name",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -474,7 +495,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -489,10 +510,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/remove",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -522,7 +543,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -537,10 +558,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemEntry/toURL",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -570,7 +591,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -22,7 +22,7 @@
               "prefix": "webkit"
             },
             {
-              "version_added": "8",
+              "version_added": "18",
               "alternative_name": "Entry"
             }
           ],

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -4,28 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry",
         "support": {
-          "chrome": [
-            {
-              "version_removed": true,
-              "version_added": "13",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "8",
-              "alternative_name": "FileEntry"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_removed": true,
-              "version_added": "18",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "18",
-              "alternative_name": "FileEntry"
-            }
-          ],
+          "chrome": {
+            "version_added": "8",
+            "alternative_name": "FileEntry"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "alternative_name": "FileEntry"
+          },
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -55,17 +41,10 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": [
-            {
-              "version_removed": true,
-              "version_added": "≤37",
-              "prefix": "webkit"
-            },
-            {
-              "version_added": "8",
-              "alternative_name": "FileEntry"
-            }
-          ]
+          "webview_android": {
+            "version_added": "≤37",
+            "alternative_name": "FileEntry"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -4,14 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry",
         "support": {
-          "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
-          },
-          "chrome_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          },
+          "chrome": [
+            {
+              "version_removed": true,
+              "version_added": "13",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "FileEntry"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_removed": true,
+              "version_added": "18",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "FileEntry"
+            }
+          ],
           "edge": {
             "version_added": "79",
             "prefix": "webkit"
@@ -41,10 +55,17 @@
             "prefix": "webkit",
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true,
-            "prefix": "webkit"
-          }
+          "webview_android": [
+            {
+              "version_removed": true,
+              "version_added": "≤37",
+              "prefix": "webkit"
+            },
+            {
+              "version_added": "8",
+              "alternative_name": "FileEntry"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -57,10 +78,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry/createWriter",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -94,7 +115,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -109,10 +130,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry/file",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -142,7 +163,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -22,7 +22,7 @@
               "prefix": "webkit"
             },
             {
-              "version_added": "8",
+              "version_added": "18",
               "alternative_name": "FileEntry"
             }
           ],


### PR DESCRIPTION
* I got the alternative names from the Chrome product manager working on the new Native File System API.
* I cannot confirm that the existing prefix version number are correct, nor can I find a when the prefixes were removed. 
* I know it's suspect that the unprefixed versions are older than the prefixed versions, but I can find nothing that disproves it.