### PR TITLE
Complete nodejs data for SharedArrayBuffer

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -237,7 +237,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "8.10.0"
                 },
                 "opera": {
                   "version_added": false
@@ -345,7 +345,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "8.10.0"
                 },
                 "opera": {
                   "version_added": "47"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -214,7 +214,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
Part of #6249. This fills in the `null` value for Node in `DataView`, and corrects some erroneous `false` values.

All `SharedArrayBuffer` support was added in Node 8.10.0. This is _mostly_ reflected in the current data (apart from these corrected values), and backed up by https://node.green and my local testing.