### PR TITLE
Atomics ships in Fx78, Wasm.Memory accepts 'shared'

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -33,6 +33,9 @@
             ],
             "firefox": [
               {
+                "version_added": "78"
+              },
+              {
                 "version_added": "57",
                 "flags": [
                   {
@@ -154,6 +157,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -278,6 +284,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "78"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -400,6 +409,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -524,6 +536,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "78"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -646,6 +661,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -770,6 +788,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "78"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -887,6 +908,9 @@
                 "version_added": "79"
               },
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "63",
                   "flags": [
@@ -1065,6 +1089,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "78"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -1187,6 +1214,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -1311,6 +1341,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "78"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -1433,6 +1466,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -1582,6 +1618,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "78"
+                },
                 {
                   "version_added": "57",
                   "flags": [

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -108,6 +108,58 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "shared": {
+              "__compat": {
+                "description": "<code>shared</code> flag",
+                "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#webassemblymemory-constructor",
+                "support": {
+                  "chrome": {
+                    "version_added": "74"
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.0.0"
+                  },
+                  "opera": {
+                    "version_added": "62"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "buffer": {


### PR DESCRIPTION
See https://github.com/mdn/sprints/issues/2219#issuecomment-631369668 for Firefox info.
See https://www.chromestatus.com/feature/5724132452859904 for desktop chromiums.
See https://v8.dev/blog/v8-release-74#webassembly-threads%2Fatomics-shipped for v8/nodejs.