### PR TITLE
Mark all HTMLElement.p.offset* experimental:false

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1908,7 +1908,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1956,7 +1956,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2004,7 +2004,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2052,7 +2052,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2100,7 +2100,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This change marks all `HTMLElement.p.offset\*` properties `experimental:false`. They had been marked `experimental:true` when they were first added, but it’s not clear why — because they’ve been supported in all engines for quite some time.

Fixes https://github.com/mdn/browser-compat-data/issues/6274