### PR TITLE
Add new NumberFormat options

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -76,9 +76,7 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": "The <code>style</code> option only supports the values <code>'decimal'</code>, <code>'percent'</code>, and <code>'currency'</code>."
+                  "version_added": "11"
                 },
                 "nodejs": [
                   {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -114,6 +114,312 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "compactDisplay": {
+              "__compat": {
+                "description": "<code>compactDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "currencySign": {
+              "__compat": {
+                "description": "<code>currencySign</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "notation": {
+              "__compat": {
+                "description": "<code>notation</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "signDisplay": {
+              "__compat": {
+                "description": "<code>signDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "unit": {
+              "__compat": {
+                "description": "<code>unit</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "unitDisplay": {
+              "__compat": {
+                "description": "<code>unitDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "format": {


### PR DESCRIPTION
This spec addition is called "unified intl numberformat", see https://github.com/tc39/proposal-unified-intl-numberformat. However, a subfeature called "unified_numberformat" doesn't say much. So, I think the correct thing to do here is to talk about all the new constructor options this spec adds. There are six of them.

Chromiums: https://www.chromestatus.com/features/5430420699086848
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1633836
Safari: https://bugs.webkit.org/show_bug.cgi?id=209774

MDN page: https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat