### PR TITLE
Fix copy/paste errors.

### DIFF
--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -6,11 +6,11 @@
         "support": {
           "chrome": {
             "version_added": "8",
-            "alternative_name": "DOMFileSystem"
+            "alternative_name": "DirectoryEntry"
           },
           "chrome_android": {
             "version_added": "18",
-            "alternative_name": "DOMFileSystem"
+            "alternative_name": "DirectoryEntry"
           },
           "edge": {
             "version_added": "79",


### PR DESCRIPTION
Correct copy/paste errors introduced when adding Chrome's alternative names for file/directory interfaces.