### PR TITLE
Add a note about the effect on topSites.get() of disabling topsites

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -55,9 +55,15 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "52"
-              },
+              "firefox": [
+                {
+                  "notes": "A user may disable the browser's \"Top Sites\" feature by toggling the \"browser.newtabpage.activity-stream.feeds.system.topsites\" preference. In this case, <code>topSites.get()</code> will always return a list of the most-visited sites, regardless of the value of the <code>newtab</code> parameter.",
+                  "version_added": "78"
+                },
+                {
+                  "version_added": "52"
+                }
+              ],
               "firefox_android": {
                 "version_added": "52"
               },


### PR DESCRIPTION
This update to BCD is prompted by https://bugzilla.mozilla.org/show_bug.cgi?id=1634279 and in particular https://bugzilla.mozilla.org/show_bug.cgi?id=1634279#c9:

> Firefox 78 introduces a new preference to enable Top Sites, which is on by default. If the user disables this preference, the newtab parameter passed to topSites.get() will be ignored. A list of most-visited sites – rather than a list of Top Sites as they appear on about:newtab – will be returned regardless of the value of the newtab parameter.

In general we want to keep browser-specific information like this in BCD, so I have tried to capture it as a note attached to the BCD for `topSites.get()`.

@htwyford , could you please let me know if this captures the change properly and is enough to complete the documentation update for https://bugzilla.mozilla.org/show_bug.cgi?id=1634279 ? Thanks!