### PR TITLE
Note dropped support for "xbl" ResourceType value

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -445,7 +445,8 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": "45",
+                  "version_removed": "78"
                 },
                 "firefox_android": {
                   "version_added": "48"


### PR DESCRIPTION
This PR is for the first part of https://bugzilla.mozilla.org/show_bug.cgi?id=1638581#c9, in which we remove support for `"xbl"` as a value for [`webRequest.ResourceType`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType).

Rather than mark it as deprecated, I have marked it as unsupported from Firefox 78, which seems to capture the case more accurately (deprecated I would expect to mean "works but complains and will eventually stop working").