### PR TITLE
Drop "form" content attribute from label element

### DIFF
--- a/html/elements/label.json
+++ b/html/elements/label.json
@@ -94,55 +94,6 @@
               "deprecated": false
             }
           }
-        },
-        "form": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": true,
-                "version_removed": "49"
-              },
-              "firefox_android": {
-                "version_added": true,
-                "version_removed": "49"
-              },
-              "ie": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
The `label` element doesn’t have a `form` content attribute (even though the `HTMLLabelElement` DOM interface has a `form` IDL attribute); see https://html.spec.whatwg.org/multipage/#the-label-element%3Aattr-fae-form-2

> The `form` IDL attribute on the `label` element is different from the `form` IDL attribute on listed form-associated elements, and the `label` element does not have a `form` content attribute.