### PR TITLE
Document behavior when unrecognized resource types are present

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -127,7 +127,7 @@
               "firefox": {
                 "notes": [
                   "From Firefox 78 onwards, if a filter contains unrecognized values in its <code>types</code> property, then these values will be ignored and <code>addListener()</code> will proceed.",
-                  "Before Firefox 78, if a filter contained unrecognized values in its <code>types</code> property, <code>addListener()</code> threw an exception."
+                  "Before Firefox 78, if a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
                 ],
                 "version_added": "45"
               },

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -117,18 +117,29 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter",
             "support": {
               "chrome": {
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
                 "version_added": true
               },
               "edge": {
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
                 "version_added": "14"
               },
-              "firefox": {
-                "version_added": "45"
-              },
+              "firefox": [
+                {
+                  "version_added": "45"
+                },
+                {
+                  "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
+                  "version_added": "45",
+                  "version_removed": "78"
+                }
+              ],
               "firefox_android": {
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
                 "version_added": "48"
               },
               "opera": {
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
                 "version_added": true
               }
             }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -117,7 +117,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter",
             "support": {
               "chrome": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
                 "version_added": true
               },
               "edge": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -121,7 +121,7 @@
                 "version_added": true
               },
               "edge": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
                 "version_added": "14"
               },
               "firefox": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -117,29 +117,26 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter",
             "support": {
               "chrome": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
                 "version_added": true
               },
               "edge": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
                 "version_added": "14"
               },
-              "firefox": [
-                {
-                  "version_added": "45"
-                },
-                {
-                  "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
-                  "version_added": "45",
-                  "version_removed": "78"
-                }
-              ],
+              "firefox": {
+                "notes": [
+                  "From Firefox 78 onwards, if a filter contains unrecognized values in its <code>types</code> property, then these values will be ignored and <code>addListener()</code> will proceed.",
+                  "Before Firefox 78, if a filter contained unrecognized values in its <code>types</code> property, <code>addListener()</code> threw an exception."
+                ],
+                "version_added": "45"
+              },
               "firefox_android": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
                 "version_added": "48"
               },
               "opera": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, this is treated as an error.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
                 "version_added": true
               }
             }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -126,7 +126,7 @@
               },
               "firefox": {
                 "notes": [
-                  "From Firefox 78 onwards, if a filter contains unrecognized values in its <code>types</code> property, then these values will be ignored and <code>addListener()</code> will proceed.",
+                  "From Firefox 78 onwards, if a filter contains unrecognized values in its <code>types</code> property, then these values are ignored and <code>addListener()</code> proceeds.",
                   "Before Firefox 78, if a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
                 ],
                 "version_added": "45"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -132,7 +132,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
                 "version_added": "48"
               },
               "opera": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -136,7 +136,7 @@
                 "version_added": "48"
               },
               "opera": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> will throw an exception.",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
                 "version_added": true
               }
             }


### PR DESCRIPTION
This PR updates BCD for the second part of https://bugzilla.mozilla.org/show_bug.cgi?id=1638581#c9:

> in WebRequest/RequestFilterWebRequest/RequestFilter API doc page on MDN, mention on the types property description that an invalid/unsupported value is going to log a warning starting from Firefox 78 (but it does throw a validation error in Firefox < 78)

I believe the situation is: in Firefox < 78, and other browsers (although I have only tested in Chrome), if you pass unrecognized values in the `types` property of [`RequestFilter`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/WebRequest/RequestFilter), then this is treated as an error and the operation in which you try to use the filter fails.

For example, if you try to redirect web requests with some code like:

```js
browser.webRequest.onBeforeRequest.addListener(
  redirect,
  {urls:[pattern], types:["bibble", "image"]},
  ["blocking"]
);
```

...this will fail because `"bibble"` is not a valid value for [`ResourceType`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType).

But from Firefox 78 onwards, if unrecognized values are found, Firefox will log a warning and just discard the unrecognized values, applying the rest of them.

It's tricky to know how to document things like this. In general, it seems we should document the standard behavior in the main MDN page, and document browser-specific deviations from that in BCD. But with WebExtensions, there is no standard, so which do we choose as the standard behavior? I've chosen to describe the new Firefox behavior as the standard here, because Firefox is really the main driver of the WebExtension APIs.

The BCD for Firefox in this PR will render like:

<img width="861" alt="Screen Shot 2020-06-16 at 5 13 28 PM" src="https://user-images.githubusercontent.com/432915/84841248-a1d30c00-aff6-11ea-84d7-7263b40579db.png">

@rpl , please let me know if you think this is good, and if you do I'll update the [`RequestFilter`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/WebRequest/RequestFilter) page to describe the "standard" behavior (logging a warning and discarding unrecognized types).

