### PR TITLE
Add separate entries for unified Intl.NumberFormat additions

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -76,9 +76,7 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": "The <code>style</code> option only supports the values <code>'decimal'</code>, <code>'percent'</code>, and <code>'currency'</code>."
+                  "version_added": "11"
                 },
                 "nodejs": [
                   {
@@ -113,6 +111,312 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              }
+            },
+            "compactDisplay": {
+              "__compat": {
+                "description": "<code>compactDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "currencySign": {
+              "__compat": {
+                "description": "<code>currencySign</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "notation": {
+              "__compat": {
+                "description": "<code>notation</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "signDisplay": {
+              "__compat": {
+                "description": "<code>signDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "unit": {
+              "__compat": {
+                "description": "<code>style: 'unit'</code> and <code>unit</code> options",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "unitDisplay": {
+              "__compat": {
+                "description": "<code>unitDisplay</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
               }
             }
           },


### PR DESCRIPTION
There was recently a note added for `Intl.NumberFormat` saying that IE didn't support the `style: 'unit'` option (#6193). I saw similar behaviour in some other environments and went digging.

The `unit`, `notation`, `currencySign`, `compactDisplay`, `signDisplay`, and `unitDisplay` options were all added to the `NumberFormat` spec in the "unified NumberFormat" proposal: https://github.com/tc39/proposal-unified-intl-numberformat

Since these options are fairly new I've added separate entries for each one under the `NumberFormat` constructor (copying the convention of `DateTimeFormat` options). I thought about adding just a single entry to combine all the options, but I couldn't think of a description that wasn't terribly cumbersome. Separate entries per option should make it far more obvious for developers who don't know exactly which options were added in a separate spec update.

* Chrome/Android support data comes from https://www.chromestatus.com/feature/5430420699086848 and https://v8.dev/features/intl-numberformat
* Edge, Opera, Samsung Internet, and Node data comes from matching the Chromium and/or V8 version to the release version. I also manually tested Edge, Samsung, and Node to confirm.
* Safari data comes from https://bugs.webkit.org/show_bug.cgi?id=209774
* Firefox desktop data comes from manual testing. Firefox Android I wasn't able to test, but I followed the lead of other `Intl`-related changes in Firefox 78. Although I noticed that the [pending release notes for v78](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/78) mention adding `ListFormat` and `DisplayNames`, but don't currently mention adding support for these `NumberFormat` options.
