### PR TITLE
Add note about new cookie behavior value

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -297,7 +297,10 @@
                 },
                 "firefox": {
                   "version_added": "59",
-                  "notes": "The <code>behavior</code> property value \"reject_trackers\" was introduced in version 64."
+                  "notes": [
+                    "The <code>behavior</code> property value \"reject_trackers_and_partition_foreign\" was introduced in version 78.",
+                    "The <code>behavior</code> property value \"reject_trackers\" was introduced in version 64."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": "59",


### PR DESCRIPTION
This PR adds compat data for a new value for the [`behavior` property of the `cookieConfig` browser setting](https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/websites), as added in https://bugzilla.mozilla.org/show_bug.cgi?id=1634306.
