### PR TITLE
Add note about AddSearchProvider() becoming a no-op

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -55,6 +55,7 @@
               "version_added": "≤79"
             },
             "firefox": {
+              "notes": "From Firefox 78 this function does nothing, as the specification requires.",
               "version_added": true
             },
             "firefox_android": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -9023,6 +9023,7 @@
               "version_added": false
             },
             "firefox": {
+              "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires.",
               "version_added": true
             },
             "firefox_android": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2189,6 +2189,7 @@
               "version_added": "12"
             },
             "firefox": {
+              "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires.",
               "version_added": true
             },
             "firefox_android": {


### PR DESCRIPTION
This PR updates BCD to say that the `addSearchProvider()` function of both [`window.external`](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Window/external) and [`window.sidebar`](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Window/sidebar) are no-ops from Firefox 78 onwards.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1632447.