### PR TITLE
Firefox 78 doesn't ship Intl.DisplayNames

### DIFF
--- a/javascript/builtins/intl/DisplayNames.json
+++ b/javascript/builtins/intl/DisplayNames.json
@@ -17,7 +17,7 @@
                 "version_added": "81"
               },
               "firefox": {
-                "version_added": "78"
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -69,7 +69,7 @@
                   "version_added": "81"
                 },
                 "firefox": {
-                  "version_added": "78"
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false
@@ -121,7 +121,7 @@
                   "version_added": "81"
                 },
                 "firefox": {
-                  "version_added": "78"
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false
@@ -173,7 +173,7 @@
                   "version_added": "81"
                 },
                 "firefox": {
-                  "version_added": "78"
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false
@@ -225,7 +225,7 @@
                   "version_added": "81"
                 },
                 "firefox": {
-                  "version_added": "78"
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
I was wrong in https://github.com/mdn/browser-compat-data/pull/6268.

https://bugzilla.mozilla.org/show_bug.cgi?id=1557727#c21