### PR TITLE
fix navigator.registerProtocolHandler mobile browser support

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1799,7 +1799,7 @@
               "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "≤79",
@@ -1809,7 +1809,7 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -1847,7 +1847,7 @@
                 "version_added": "80"
               },
               "chrome_android": {
-                "version_added": "80"
+                "version_added": false
               },
               "edge": {
                 "version_added": "≤79"
@@ -1856,7 +1856,7 @@
                 "version_added": "62"
               },
               "firefox_android": {
-                "version_added": "62"
+                "version_added": false
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
I tested `navigator.registerProtocolHandler` on Android against Chrome(83.0.4103.106) and Firefox (68.9.0) and neither worked.

I used some simple JS to test(https://github.com/Kukks/kukks.org/blob/648fd5dc97e348185cd762c7d104c638a5053c07/test.html):
Chrome reported that `navigator.registerProtocolHandler` is `undefined`
Firefox had the function set, but upon calling it to set a  `bitcoin:` scheme as per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler), nothing happens: (no exception thrown, no response given) 

CanIUse also reports that android support is absent: https://caniuse.com/#feat=registerprotocolhandler
