### PR TITLE
Fix balance-all support versions for column-fill property

### DIFF
--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -84,17 +84,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12",
-                "version_removed": "79"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "14"
+                "version_added": false
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": false
@@ -103,10 +102,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "8"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "8"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -116,7 +115,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Hi, a Firefox layout developer here. To the best of my knowledge, no browsers have implemented balance-all value.

* Firefox doesn't support parsing `column-fill: balance-all` per https://searchfox.org/mozilla-central/rev/f66f5a235e7d74c29b951316f73001126a056734/layout/style/nsStyleConsts.h#179-182
* I checked Safari and IE in their inspectors on my macOS laptop and https://www.browserling.com/, respectively.
