### PR TITLE
Chrome 83+ supports CSS selector: :where() behind a flag

### DIFF
--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -16,7 +16,7 @@
                     "value_to_set": "enabled"
                   }
                 ]
-              },
+              }
             ],
             "chrome_android": {
               "version_added": false

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -11,7 +11,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform Features",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
               ]

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -17,7 +17,14 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": false

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -6,9 +6,18 @@
           "description": "<code>:where()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+            ],
             "chrome_android": {
               "version_added": false
             },

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
           "support": {
             "chrome": {
-              "version_added": "83",
+              "version_added": "72",
               "flags": [
                 {
                   "type": "preference",

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -15,7 +15,7 @@
                   "value_to_set": "enabled"
                 }
               ]
-            }
+            },
             "chrome_android": {
               "version_added": false
             },

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -12,7 +12,7 @@
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -6,18 +6,16 @@
           "description": "<code>:where()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
           "support": {
-            "chrome": [
-              {
-                "version_added": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
             "chrome_android": {
               "version_added": false
             },


### PR DESCRIPTION
Fixes Fyrd/caniuse#5481.

I've tested using <https://jsfiddle.net/simevidas/d1tLszx9/> from <https://bugs.chromium.org/p/chromium/issues/detail?id=808904#c7>:

![image](https://user-images.githubusercontent.com/2644614/85213214-97e53c00-b35b-11ea-9dee-7014d8bdad4a.png)

Chromestatus: https://www.chromestatus.com/feature/4600991135563776