### PR TITLE
Rename the "Slotable" mixin to "Slottable"

### DIFF
--- a/api/Slottable.json
+++ b/api/Slottable.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "Slotable": {
+    "Slottable": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Slotable",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Slottable",
         "support": {
           "chrome": {
             "version_added": "53"
@@ -107,7 +107,7 @@
       },
       "assignedSlot": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Slotable/assignedSlot",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Slottable/assignedSlot",
           "support": {
             "chrome": {
               "version_added": "53"


### PR DESCRIPTION
https://github.com/whatwg/dom/pull/845 renamed the `Slotable` mixin to `Slottable`.

I already made the corresponding changes to the relevant MDN articles.