### PR TITLE
Add more accuracy to notes on document.readyState support for IE

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9212,11 +9212,17 @@
             },
             "ie": [
               {
+                "version_added": "11"
+              },
+              {
                 "version_added": "9",
+                "version_removed": "11",
                 "notes": "Internet Explorer 9 and 10 have bugs where the 'interactive' state can be fired too early before the document has finished parsing."
               },
               {
                 "version_added": "8",
+                "version_removed": "9",
+                "partial_implementation": true,
                 "notes": "Only supports 'complete'."
               }
             ],


### PR DESCRIPTION
Hey look, my first BCD PR. :)

This is in response to a [caniuse issue](https://github.com/Fyrd/caniuse/issues/5489) which I investigated and came to the conclusion that the data seems ambiguous on which versions the notes refer to. As a result the assumption (on caniuse) is that the the notes refer to these versions and beyond, resulting in incorrect information shown on the [caniuse support table](https://caniuse.com/#feat=mdn-api_document_readystate).

Also took the liberty of flagging IE8's support as partial, which I think matches what the note describes.

Happy to discuss this further if my understanding is incorrect and this does not seem like the correct change to make.