### PR TITLE
Specify inert as hidden behind the flag

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1119,7 +1119,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -1128,7 +1129,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1124,7 +1124,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "60",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform features"
+                }
+              ]
             },
             "edge": {
               "version_added": "≤18"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1162,7 +1162,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1115,7 +1115,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "60",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform features"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": "60"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1135,7 +1135,14 @@
               ]
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": null
@@ -1147,10 +1154,24 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": null
@@ -1159,7 +1180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Currently Can I Use says that `inert` attribute is [supported in 70% of browsers](https://caniuse.com/#feat=mdn-api_htmlelement_inert). But it’s hidden behind the flag, which makes it 0% of support.

Here’s [Chrome Platform Status page](https://www.chromestatus.com/feature/5703266176335872) for inert:

>  **Behind a flag** (tracking bug) in:
>  Chrome for desktop release 60
>  Chrome for Android release 60
>  Android WebView release 60

It’s WIP, as I’d like to check if it’s hidden behind the flag in all browsers that support it.

Also I’m not 100% sure I did it the right way.