### PR TITLE
Update Safari 13.1 and 14 release notes

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -162,12 +162,13 @@
         },
         "13.1": {
           "release_date": "2020-03-24",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },
         "14": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
           "status": "beta",
           "engine": "WebKit"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -146,12 +146,13 @@
         },
         "13.4": {
           "release_date": "2020-03-24",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },
         "14": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
           "status": "beta",
           "engine": "WebKit"
         }


### PR DESCRIPTION
After WWDC 2020, Safari has updated some of their release notes.
This PR aims to update the browser entries for both desktop and iOS