### PR TITLE
Note non-support of windowId and tabId filter properties before version 78

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -51,6 +51,7 @@
                 "version_added": false
               },
               "firefox": {
+                "notes": "Before version 78, the <code>tabId</code> and <code>windowId</code> filter properties are ignored.",
                 "version_added": "60"
               },
               "firefox_android": {


### PR DESCRIPTION
This PR is for https://bugzilla.mozilla.org/show_bug.cgi?id=1641269, in which it was realized that Firefox didn't support the `tabId` or `windowId` filter properties, and support was added in version 78.