### PR TITLE
Complete nodejs data for Symbol

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.12"
             },
             "opera": {
               "version_added": "25"
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "25"
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "27"
@@ -465,7 +465,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "27"
@@ -945,7 +945,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "25"
@@ -1059,7 +1059,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": "37"
@@ -1164,7 +1164,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "25"


### PR DESCRIPTION
Part of #6249. This fills in the `true` values for Node in `Symbol`.

Data source: https://node.green/#ES2015-built-ins-Symbol and local testing

I also changed the value on `Symbol.toStringTag.dom-objects` from `true` to `false`. Node.js doesn't support any DOM prototype objects, so it can't support `Symbol.toStringTag` on them. If that change is erroneous, I'm happy to revert it.