### PR TITLE
Complete nodejs data for grammar

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -140,7 +140,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -192,7 +192,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -244,7 +244,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "62"
@@ -296,7 +296,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -348,7 +348,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -400,7 +400,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -451,9 +451,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "12.5.0"
+              },
+              {
+                "version_added": "10.4.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "62"
             },
@@ -503,9 +514,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "28"
             },
@@ -556,7 +578,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "5"
@@ -608,7 +630,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -660,7 +682,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -712,7 +734,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "4.0.0"
             },
             "opera": {
               "version_added": "31"
@@ -763,7 +785,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "4.0.0"
             },
             "opera": {
               "version_added": "30"
@@ -865,9 +887,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "8.10.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "8.10.0"
+                },
+                {
+                  "version_added": "8.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "49"
               },
@@ -919,7 +952,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "9.5"
@@ -1020,7 +1053,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"


### PR DESCRIPTION
Part of #6249. This fills in `true` values for Node in `grammar`, and clarifies one existing versioned entry by adding `--harmony` flag info.

Most of the grammar was supported in the first version of Node, and for the rest the data comes from https://node.green and local testing.