### PR TITLE
Update Edge data to version 83

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -70,19 +70,26 @@
         "81": {
           "release_date": "2020-04-13",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-81041653-april-13",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
+          "release_date": "2020-05-21",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-83047837-may-21",
           "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
         },
         "84": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "84"
+        },
+        "85": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "85"
         }
       }
     }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -77,7 +77,7 @@
         "83": {
           "release_date": "2020-05-21",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-83047837-may-21",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "83"
         },


### PR DESCRIPTION
Looks like Edge 83 was released back in May.
I linked to the initial milestone release note 

Seems that milestone 84 is still in beta according to https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-beta-channel