### PR TITLE
Opera update to version 69

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -531,19 +531,26 @@
         "68": {
           "release_date": "2020-04-22",
           "release_notes": "https://blogs.opera.com/desktop/2020/04/opera-68-is-here-with-built-in-instagram-in-the-sidebar/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "81"
         },
         "69": {
-          "status": "beta",
+          "release_date": "2020-06-24",
+          "release_notes": "https://blogs.opera.com/desktop/2020/06/opera-69-comes-with-built-in-twitter/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "83"
         },
         "70": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "84"
+        },
+        "71": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "85"
         }
       }
     }


### PR DESCRIPTION
Opera desktop has a new version. 
It seems that Opera mobile operates on a different schedule and is still running version 58