### PR TITLE
Fix getter/setter support in firefox

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -595,7 +595,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1041,7 +1041,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1.5"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
getter/setter already available in firefox 1.5
I've tested the following code in firefox 1.5:
```
        const obj = {
            log: ['a', 'b', 'c'],
            get latest() {
                if (this.log.length === 0) {
                    return undefined;
                }
                return this.log[this.log.length - 1];
            },
            set latest(v) {
                alert(v);
                this.log.push(v);
            }
        };

        alert(obj.latest);
        obj.latest = 'd';
        alert(obj.log);
```

