### PR TITLE
Safari 14 support private class fields of Javascript

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -507,7 +507,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
               "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -507,10 +507,12 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": false,
+              "notes": "Added in Safari Technology Preview 109 - Safari Beta 14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Added in Safari Technology Preview 109 - Safari Beta 14"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -507,12 +507,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false,
-              "notes": "Added in Safari Technology Preview 109 - Safari Beta 14"
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "Added in Safari Technology Preview 109 - Safari Beta 14"
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Safari Technology Preview 109 add support to private class fields. This is a beta version of Safari 14.

Add notes in Javascript Classes.

Release Note: https://webkit.org/blog/10875/release-notes-for-safari-technology-preview-109-with-safari-14-features/
Change set: https://trac.webkit.org/changeset/262613/webkit/
Test: https://repl.it/@JimmyCollazos/Javascript-private-class-fields#script.js 
