### PR TITLE
Increase consistency for :is() notes

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -12,8 +12,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -25,8 +25,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -45,8 +45,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -63,8 +63,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -116,8 +116,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -129,8 +129,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -147,8 +147,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
@@ -160,8 +160,8 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Experimental Web Platform Features",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ],
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."


### PR DESCRIPTION
Per discussion in #6318 and in relation to #6009, increase consistency for `:is()` notes for Chromium browsers.