### PR TITLE
ParentNode.p.replaceChildren supported in Safari

### DIFF
--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -751,10 +751,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
https://trac.webkit.org/changeset/262381/webkit, 2020-06-01, added `ParentNode.prototype.replaceChildren` support to WebKit. That means it’s going into Safari 14.