### PR TITLE
Fix capitalization of autocapitalize

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -369,9 +369,9 @@
           }
         }
       },
-      "autoCapitalize": {
+      "autocapitalize": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/autoCapitalize",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/autocapitalize",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
The HTMLElement instance property is spelled `autocapitalize`, not `autoCapitalize`.

- https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom
- https://chromium.googlesource.com/chromium/src/+/1de83967752e0cf4f36f3a013b4f1ab687b88e11/third_party/WebKit/Source/core/html/HTMLElement.idl
- https://developer.apple.com/documentation/webkitjs/htmlelement/2871133-autocapitalize