### PR TITLE
Textarea autocomplete atrribute support in Chromium 66

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -108,11 +108,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/758078'>issue 758078</a>."
+                "version_added": "66"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "edge": {
                 "version_added": false,
@@ -144,7 +143,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "66"
               }
             },
             "status": {


### PR DESCRIPTION
TextArea autocomplete attribute got supported in Chromium 66.

Commit: https://chromium.googlesource.com/chromium/src/+/e1c977ab2790547a3bab3aca362e137ab976e885
First merged: https://storage.googleapis.com/chromium-find-releases-static/e1c.html#e1c977ab2790547a3bab3aca362e137ab976e885