### PR TITLE
Add missing mdn_url for background-image/element()"

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -52,6 +52,7 @@
         },
         "element": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element",
             "description": "<code>element()</code>",
             "support": {
               "chrome": {


### PR DESCRIPTION
It looks like the `mdn_url` was correctly filled in `css/types/image.json` but was not in `css/properties/background-image.json`

I was looking to fill in the "multiple background" entry with a link to that page https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds but I was unsure whether this was appropriate. Any guidance on that front?