### PR TITLE
Fix `-webkit-` prefix typos

### DIFF
--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -89,7 +89,7 @@
               },
               {
                 "version_added": "6",
-                "prefix": "-webkit"
+                "prefix": "-webkit-"
               }
             ],
             "safari_ios": [
@@ -98,7 +98,7 @@
               },
               {
                 "version_added": "6",
-                "prefix": "-webkit"
+                "prefix": "-webkit-"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -34,7 +34,7 @@
                 "version_added": "12.1"
               },
               {
-                "prefix": "-webkit",
+                "prefix": "-webkit-",
                 "version_added": "9"
               }
             ],


### PR DESCRIPTION
Noticed in https://github.com/frenic/csstype that some prefixes wasn't like the others so my conclusion was that they are simple typos.

Related https://github.com/mdn/browser-compat-data/pull/5788 https://github.com/mdn/browser-compat-data/pull/5950