### PR TITLE
Add mdn_url for CSS selector referencing HTML elements

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -94,6 +94,7 @@
         },
         "dialog": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dialog",
             "description": "Support on <code>dialog</code> elements",
             "support": {
               "chrome": {

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -52,6 +52,7 @@
         },
         "a_elements": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/a",
             "description": "<code>&lt;a&gt;</code> element support",
             "support": {
               "chrome": {

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -51,7 +51,8 @@
         },
         "checkbox": {
           "__compat": {
-            "description": "<code>type=&quot;checkbox&quot;</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/checkbox",
+            "description": "<code>&lt;input type=&quot;checkbox&quot;&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -99,7 +100,8 @@
         },
         "progress": {
           "__compat": {
-            "description": "<a href='https://developer.mozilla.org/docs/Web/HTML/Element/progress'><code>&lt;progress&gt;</code></a>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/progress",
+            "description": "<code>&lt;progress&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -147,7 +149,8 @@
         },
         "radio": {
           "__compat": {
-            "description": "<code>type=&quot;radio&quot;</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/radio",
+            "description": "<code>&lt;input type=&quot;radio&quot;&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -51,7 +51,8 @@
         },
         "form": {
           "__compat": {
-            "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
+            "description": "<code>&lt;form&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "40"

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -51,7 +51,8 @@
         },
         "form": {
           "__compat": {
-            "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
+            "description": "<code>&lt;form&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "40"


### PR DESCRIPTION
This PR is scoped to `css/selectors/`.

I looked for all entries referencing an HTML element that were missing a `mdn_url`. 
Also had to update some description that had used an `<a>` tag as it is forbidden (explained in `schemas/compat-data-schema.md`