### PR TITLE
Move feature description links to mdn_url

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -1339,7 +1339,7 @@
       },
       "remove_filling_animation": {
         "__compat": {
-          "description": "Browsers automatically remove <a href='https://developer.mozilla.org/docs/Web/API/Animation#Automatically_removing_filling_animations'>indefinite filling animations</a>.",
+          "description": "Browsers automatically remove indefinite filling animations.",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation#Automatically_removing_filling_animations",
           "support": {
             "chrome": {

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -49,7 +49,8 @@
       },
       "ChildNode": {
         "__compat": {
-          "description": "Implements the <a href='https://developer.mozilla.org/docs/Web/API/ChildNode'><code>ChildNode</code></a> interface",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChildNode",
+          "description": "Implements the <code>ChildNode</code> interface",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -123,7 +123,8 @@
       },
       "documentorshadowroot": {
         "__compat": {
-          "description": "Features included from the <a href='https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot'><code>DocumentOrShadowRoot</code></a> mixin",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot",
+          "description": "Features included from the <code>DocumentOrShadowRoot</code> mixin",
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -940,7 +940,8 @@
         },
         "media_query_values": {
           "__compat": {
-            "description": "<a href='https://developer.mozilla.org/docs/Web/CSS/Media_Queries'>Media query</a> value support",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries",
+            "description": "Media query value support",
             "support": {
               "chrome": {
                 "version_added": "66"

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -99,7 +99,8 @@
         },
         "progress": {
           "__compat": {
-            "description": "<a href='https://developer.mozilla.org/docs/Web/HTML/Element/progress'><code>&lt;progress&gt;</code></a>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/progress",
+            "description": "<code>&lt;progress&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -51,7 +51,8 @@
         },
         "form": {
           "__compat": {
-            "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
+            "description": "Applies to <code>&lt;form&gt;</code> elements",
             "support": {
               "chrome": {
                 "version_added": "40"

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -51,7 +51,8 @@
         },
         "form": {
           "__compat": {
-            "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
+            "description": "Applies to <code>&lt;form&gt;</code> elements",
             "support": {
               "chrome": {
                 "version_added": "40"

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -99,7 +99,7 @@
         },
         "keyword_value_syntax": {
           "__compat": {
-            "description": "Syntax combining a keyword and <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a>",
+            "description": "Syntax combining a keyword and <code>&lt;length&gt;</code> or <code>&lt;percentage&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
The compat data schema (`schemas/compat-data-schema.md`) specifies the use of `<code>`, `<kbd>`, `<em>`, and `<strong>` HTML elements only.

A few `description` that contain `<a>` HTML elements lingered. I have moved all internal link to the preferred `mdn_url` entry.

However there are a few entries that reference external documentation. Would appreciate some guidance on how to change those. They are definitely relevant information but they probably should live inside MDN. The `notes` entry is not really applicable in this use case AFAIK

Below is a comprehensive list of all references to external documentations from a `description` entry

- `css/properties/display.json` references https://drafts.csswg.org/css-display/#unbox
- `css/selectors/visited.json` references https://groups.google.com/forum/#!msg/mozilla.dev.platform/1NP6oJzK6zg/ftAz_TajAAAJ
- `javascript/builtins/Function.json` references http://tc39.es/Function-prototype-toString-revision/
- `javascript/builtins/JSON.json` references https://github.com/tc39/proposal-well-formed-stringify