### PR TITLE
SAB returns in Firefox 79

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -492,7 +492,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -636,7 +636,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -732,7 +732,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -828,7 +828,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -972,7 +972,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -2172,7 +2172,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -3372,7 +3372,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -3564,7 +3564,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -4524,7 +4524,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -4620,7 +4620,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -4716,7 +4716,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -4812,7 +4812,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -4908,7 +4908,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5004,7 +5004,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5100,7 +5100,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5196,7 +5196,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5292,7 +5292,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5484,7 +5484,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -5628,7 +5628,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -873,7 +873,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -1699,7 +1699,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -1888,7 +1888,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -5956,7 +5956,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -6626,7 +6626,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -6959,7 +6959,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -7870,7 +7870,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -8013,7 +8013,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -8156,7 +8156,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": null
@@ -8397,7 +8397,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -8541,7 +8541,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -8685,7 +8685,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null
@@ -8829,7 +8829,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": null

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -179,6 +179,9 @@
                 },
                 "firefox": [
                   {
+                    "version_added": "79"
+                  },
+                  {
                     "version_added": "57",
                     "flags": [
                       {
@@ -336,7 +339,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "79"
                 },
                 "firefox_android": {
                   "version_added": "55"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -33,6 +33,9 @@
             ],
             "firefox": [
               {
+                "version_added": "79"
+              },
+              {
                 "version_added": "57",
                 "flags": [
                   {
@@ -155,6 +158,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "79"
+                },
                 {
                   "version_added": "57",
                   "flags": [
@@ -279,6 +285,9 @@
               ],
               "firefox": [
                 {
+                  "version_added": "79"
+                },
+                {
                   "version_added": "57",
                   "flags": [
                     {
@@ -401,6 +410,9 @@
                 }
               ],
               "firefox": [
+                {
+                  "version_added": "79"
+                },
                 {
                   "version_added": "57",
                   "flags": [


### PR DESCRIPTION
SharedArrayBuffer is back in Firefox 79
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
https://bugzilla.mozilla.org/show_bug.cgi?id=1619649#c0
https://groups.google.com/g/mozilla.dev.platform/c/-hYWoob95LI