### PR TITLE
adding firefox data for allow-top-navigation-by-user-activation token

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1031,7 +1031,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1359867

This is just about updating Firefox's support — added in 79.