### PR TITLE
removal of no-preference value of prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1326,6 +1326,60 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "no-preference": {
+            "__compat": {
+              "description": "<code>no-preference</code> value",
+              "support": {
+                "chrome": {
+                  "version_added": "76",
+                  "version_removed": "85"
+                },
+                "chrome_android": {
+                  "version_added": "76",
+                  "version_removed": "85"
+                },
+                "edge": {
+                  "version_added": "79",
+                  "version_removed": "85"
+                },
+                "firefox": {
+                  "version_added": "67",
+                  "version_removed": "79"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "62",
+                  "version_removed": "71"
+                },
+                "opera_android": {
+                  "version_added": "54"
+                },
+                "safari": {
+                  "version_added": "12.1"
+                },
+                "safari_ios": {
+                  "version_added": "13"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "76",
+                  "version_removed": "85"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "prefers-contrast": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1376,7 +1376,7 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
+                "standard_track": false,
                 "deprecated": true
               }
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1377,7 +1377,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "deprecated": false
+                "deprecated": true
               }
             }
           }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1643656

Removed in Firefox 79, and Chome 85.