### PR TITLE
Update autocapitalize attribute support for Safari.

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
According to https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html,
Safari/iOS supports this attribute on iOS5+. But Safari/macOS doesn't.

Also, sample is https://googlechrome.github.io/samples/autocapitalize/.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
