### PR TITLE
Safari 13 supports Intl.PluralRules

### DIFF
--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -36,10 +36,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -95,10 +95,10 @@
                   "version_added": "46"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0"
@@ -147,10 +147,10 @@
                   "version_added": "46"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0"
@@ -199,10 +199,10 @@
                   "version_added": "46"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0"
@@ -251,10 +251,10 @@
                   "version_added": "46"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13"
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0"


### PR DESCRIPTION
This PR adds support information of Intl.PluralRules in Safari 13.
bugzilla: https://bugs.webkit.org/show_bug.cgi?id=199288
caniuse: https://caniuse.com/#feat=intl-pluralrules