### PR TITLE
adding note about loadstart event firing async in Fx 79 onwards

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -371,6 +371,7 @@
                 "version_added": "79"
               },
               {
+                "version_added": true,
                 "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -368,11 +368,12 @@
             },
             "firefox": [
               {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "<code>loadstart</code> event originally dispatched synchronously (should be asynchronously as per spec)."
               },
               {
-                "version_added": "79",
-                "notes": "<code>loadstart</code> event dispatched asynchronously."
+                "version_added": "79"
               }
             ],
             "firefox_android": {

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -368,12 +368,12 @@
             },
             "firefox": [
               {
-                "version_added": true,
-                "partial_implementation": true,
-                "notes": "<code>loadstart</code> event originally dispatched synchronously (should be asynchronously as per spec)."
+                "version_added": "79"
               },
               {
-                "version_added": "79"
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."
               }
             ],
             "firefox_android": {

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -366,9 +366,15 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": "79",
+                "notes": "<code>loadstart</code> event dispatched asynchronously."
+              }
+            ],
             "firefox_android": {
               "version_added": true
             },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1502403