### PR TITLE
adding data about dommatrix support in CanvasPattern.setTransform()

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -89,9 +89,57 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "dommatrix": {
+          "__compat": {
+            "description": "<code>DOMMatrix</code> parameter supported",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1565997

Supported in Firefox 79

I tested it in Chromiums/Safari, and it worked as well, but I can't find the exact versions.

Also setting experimental to false for `setTransform()`, as it works in multiple browsers.
