### PR TITLE
adding data about implicit rel=noopener behavior

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -353,7 +353,7 @@
         },
         "implicit_noopener": {
           "__compat": {
-            "description": "Setting <code>target=\"_blank\"</code> also provides implicit <code>rel=\"noopener\"</code> behavior",
+            "description": "<code>target=\"_blank\"</code> implies <code>rel=\"noopener\"</code> behavior",
             "support": {
               "chrome": {
                 "version_added": false

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -351,6 +351,54 @@
             }
           }
         },
+        "implicit_noopener": {
+          "__compat": {
+            "description": "Setting <code>target=\"_blank\"</code> also provides implicit <code>rel=\"noopener\"</code> behavior",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "name": {
           "__compat": {
             "support": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -330,6 +330,54 @@
             }
           }
         },
+        "implicit_noopener": {
+          "__compat": {
+            "description": "Setting <code>target=\"_blank\"</code> also provides implicit <code>rel=\"noopener\"</code> behavior",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "media": {
           "__compat": {
             "support": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -332,7 +332,7 @@
         },
         "implicit_noopener": {
           "__compat": {
-            "description": "Setting <code>target=\"_blank\"</code> also provides implicit <code>rel=\"noopener\"</code> behavior",
+            "description": "<code>target=\"_blank\"</code> implies <code>rel=\"noopener\"</code> behavior",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1522083

Enabled for Firefox 79.

I got the data for Safari desktop and Chromiums from https://www.fxsitecompat.dev/en-CA/docs/2020/target-blank-on-anchors-now-implies-rel-noopener/