### PR TITLE
Chrome supports gap for flex starting in 84

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -8,10 +8,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "84"
               },
               "edge": {
                 "version_added": false
@@ -50,7 +50,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "84"
               }
             },
             "status": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [ ] Summarize your changes

Update CSS/gap to show that Chrome supports it for flexboxes starting in Chrome 84.

- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

https://bugs.chromium.org/p/chromium/issues/detail?id=762679

- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
