### PR TITLE
Typo fix: api/CSSMathNegate/values->value

### DIFF
--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -94,7 +94,7 @@
           }
         }
       },
-      "values": {
+      "value": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR fixes a typo in the data added for `CSSMathNegate`.  An entry for `values` (plural form) was added into the file when it was created in #2244, however the MDN URL that was originally there pointed to `value` (singular form).  I couldn't find any compatibility for `values` in the API, but I did find compatibility for `value` (and have confirmed support since Chrome 66).