### PR TITLE
Add CSSTransition API data

### DIFF
--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -46,6 +46,54 @@
           "deprecated": false
         }
       },
+      "CSSTransition": {
+        "__compat": {
+          "description": "<code>CSSTransition()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transitionProperty": {
         "__compat": {
           "support": {

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -22,10 +22,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "65"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "56"
           },
           "safari": {
             "version_added": "13.1"
@@ -34,7 +34,7 @@
             "version_added": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "12.0"
           },
           "webview_android": {
             "version_added": "78"
@@ -68,10 +68,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": "13.1"
@@ -80,7 +80,7 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": "78"

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -4,13 +4,13 @@
       "__compat": {
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "78"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "78"
           },
           "edge": {
-            "version_added": false
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": "75"
@@ -37,7 +37,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "78"
           }
         },
         "status": {
@@ -50,13 +50,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "78"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "75"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "78"
             }
           },
           "status": {

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -1,0 +1,146 @@
+{
+  "api": {
+    "CSSTransition": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "75"
+          },
+          "firefox_android": {
+            "version_added": "75"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "13.1"
+          },
+          "safari_ios": {
+            "version_added": "13.4"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CSSTransition": {
+        "__compat": {
+          "description": "<code>CSSTransition()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionProperty": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": "75"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.4"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -16,7 +16,7 @@
             "version_added": "75"
           },
           "firefox_android": {
-            "version_added": "75"
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": "75"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -41,7 +41,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -88,7 +88,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -135,7 +135,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -46,54 +46,6 @@
           "deprecated": false
         }
       },
-      "CSSTransition": {
-        "__compat": {
-          "description": "<code>CSSTransition()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "transitionProperty": {
         "__compat": {
           "support": {

--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -51,13 +51,13 @@
           "description": "<code>CSSTransition()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "78"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "78"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds data for the CSSTransition API based upon manual testing.  This API is a part of a [W3C draft](https://drafts.csswg.org/css-transitions-2/#the-CSSTransition-interface).