### PR TITLE
Add api.Gamepad.vibrationActuator

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -1062,6 +1062,53 @@
             "deprecated": false
           }
         }
+      },
+      "vibrationActuator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "55"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds the `vibrationActuator` feature to the Gamepad API data.  This feature was implemented in Chrome 68 (confirmed via manual testing), and is currently pending a PR merge into standard spec (see https://github.com/w3c/gamepad/pull/68).