### PR TITLE
Update data for GamepadHapticActuator API

### DIFF
--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -97,7 +97,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -201,7 +201,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -5,14 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "68"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "68"
           },
           "edge": {
-            "version_added": "15",
-            "version_removed": "79"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": true,
@@ -32,10 +31,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "55"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "48"
           },
           "safari": {
             "version_added": false
@@ -44,7 +43,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -54,6 +53,53 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "playEffect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "55"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "pulse": {
@@ -113,19 +159,65 @@
           }
         }
       },
+      "reset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "55"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator/type",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "edge": {
-              "version_added": "15",
-              "version_removed": "79"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": true,
@@ -145,10 +237,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -157,7 +249,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates the GamepadHapticActuator API in two ways:

1) Fixes Chrome data for the API and the `type` feature.  This was determined via manual testing.
2) Adds `playEffect` and `reset` features.  Versions were determined via manual testing.