### PR TITLE
Add api.HTMLVideoElement.cancel/requestVideoFrameCallback

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "cancelVideoFrameCallback": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "getVideoPlaybackQuality": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/getVideoPlaybackQuality",
@@ -538,6 +585,53 @@
           "status": {
             "experimental": false,
             "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestVideoFrameCallback": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This PR adds both `cancelVideoFrameCallback` and `requestVideoFrameCallback` to the HTMLVideoElement API, with data obtained from manual testing.  Since this is a part of a W3C Community Group spec, I didn't set `standard_track` to true -- see https://wicg.github.io/video-rvfc/#video-rvfc for the spec.