### PR TITLE
add a note about buggy behaviour of Number#toLocaleString in IE11

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -961,7 +961,8 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "5"
+                "version_added": "5",
+                "notes": "In IE 11 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -952,7 +952,8 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "firefox": {
                 "version_added": "1"
@@ -962,7 +963,7 @@
               },
               "ie": {
                 "version_added": "5",
-                "notes": "In IE 11 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -953,7 +953,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "Before Edge 79, numbers are rounded to 15 decimal digits. For example, <code>(1000000000000005).toLocaleString('en-US')</code> returns <code>\"1,000,000,000,000,010\"</code>."
+                "notes": "Before Edge 18, numbers are rounded to 15 decimal digits. For example, <code>(1000000000000005).toLocaleString('en-US')</code> returns <code>\"1,000,000,000,000,010\"</code>."
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -953,7 +953,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In IE 11 and Edge 17 numbers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "firefox": {
                 "version_added": "1"
@@ -963,7 +963,7 @@
               },
               "ie": {
                 "version_added": "5",
-                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In IE 11 and Edge 17 numbers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -953,7 +953,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In IE 11 and Edge 17 numbers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "Before Edge 79, numbers are rounded to 15 decimal digits. For example, <code>(1000000000000005).toLocaleString('en-US')</code> returns <code>\"1,000,000,000,000,010\"</code>."
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -963,7 +963,7 @@
               },
               "ie": {
                 "version_added": "5",
-                "notes": "In IE 11 and Edge 17 numbers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In Internet Explorer 11, numbers are rounded to 15 decimal digits. For example, <code>(1000000000000005).toLocaleString('en-US')</code> returns <code>\"1,000,000,000,000,010\"</code>."
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -953,7 +953,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "firefox": {
                 "version_added": "1"
@@ -963,7 +963,7 @@
               },
               "ie": {
                 "version_added": "5",
-                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000001).toLocaleString('en-US') gives '1,000,000,000,000,010'."
+                "notes": "In IE 11 and Edge 17 integers are rounded to the 15 decimal digits: (1000000000000005).toLocaleString('en-US') gives '1,000,000,000,000,010'."
               },
               "nodejs": {
                 "version_added": "0.1.100"

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -432,7 +432,8 @@
                   "version_added": "25"
                 },
                 "edge": {
-                  "version_added": "12"
+                  "version_added": "12",
+                  "notes": "Before Edge 18, numbers are rounded to 15 decimal digits. For example, <code>new Intl.NumberFormat('en-US').format(1000000000000005)</code> returns <code>\"1,000,000,000,000,010\"</code>."
                 },
                 "firefox": {
                   "version_added": "29"
@@ -441,7 +442,8 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": "11"
+                  "version_added": "11",
+                  "notes": "In Internet Explorer 11, numbers are rounded to 15 decimal digits. For example, <code>new Intl.NumberFormat('en-US').format(1000000000000005)</code> returns <code>\"1,000,000,000,000,010\"</code>."
                 },
                 "nodejs": {
                   "version_added": "0.12",


### PR DESCRIPTION
Tested manually in IE11, Windows 10.
Btw, IE 11 supports the locales and options arguments and Intl.NumberFormat as well. The Inlt.NumberFormat#format has the same bug.
