### PR TITLE
Set experimental to false for wasm shared memory

### DIFF
--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -124,7 +124,7 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "version_added": "79"
+                    "version_added": "78"
                   },
                   "firefox_android": {
                     "version_added": false

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -124,7 +124,7 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "version_added": "78"
+                    "version_added": "79"
                   },
                   "firefox_android": {
                     "version_added": false
@@ -155,7 +155,7 @@
                   }
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1648685

Looks like this was actually enabled in Firefox 79.

I also put experimental as false, as this is now enabled in multiple browsers (and firefox has its sharedarraybuffer story sorted out for 79)