### PR TITLE
Add the RTCRemoteOutboundRtpStreamStats dictionary

### DIFF
--- a/api/RTCRemoteOutboundRtpStreamStats.json
+++ b/api/RTCRemoteOutboundRtpStreamStats.json
@@ -17,7 +17,7 @@
             "version_added": "68"
           },
           "firefox_android": {
-              "version_added": "68"
+            "version_added": "68"
           },
           "ie": {
             "version_added": false

--- a/api/RTCRemoteOutboundRtpStreamStats.json
+++ b/api/RTCRemoteOutboundRtpStreamStats.json
@@ -1,0 +1,196 @@
+{
+  "api": {
+    "RTCRemoteOutboundRtpStreamStats": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRemoteOutboundRtpStreamStats",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "68"
+          },
+          "firefox_android": {
+              "version_added": "68"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "localId": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRemoteOutboundRtpStreamStats/localId",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "remoteTimestamp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRemoteOutboundRtpStreamStats/remoteTimestamp",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reportsSent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRemoteOutboundRtpStreamStats/reportsSent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This dictionary provides WebRTC statistics giving info
sourced from the remote peer's outbound data stream (that is,
the stream leaving the remote peer and coming to the local one).

## Sources
### Specification
* https://www.w3.org/TR/webrtc-stats/#dom-rtcremoteoutboundrtpstreamstats

### Firefox
* https://bugzilla.mozilla.org/show_bug.cgi?id=1515716
* https://bugzilla.mozilla.org/show_bug.cgi?id=1615191
* https://searchfox.org/mozilla-central/source/dom/webidl/RTCStatsReport.webidl

### Chrome
* Unable to find any information so far. This may be partially
  implemented but Chrome doesn't define the stats using WebIDL.
I've asked for Joe's help.

### Safari
* No support yet; see https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Modules/mediastream/RTCStatsReport.idl