### PR TITLE
Update 308 HTTP status with support start versions

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -486,41 +486,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/308",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
-              "version_added": true,
-              "notes": "Does not work on Windows 7 and Windows 8.1."
+              "version_added": "11",
+              "notes": "Does not work below Windows 10."
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "36"
             }
           },
           "status": {

--- a/http/status.json
+++ b/http/status.json
@@ -520,7 +520,7 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "36"
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
Tested using this test: http://webdbg.com/test/308/

Did specific tests for Firefox, Chrome, IE, Safari and Safari iOS, other mobile browsers were derived from results for the desktop version. 

Also updated note for IE to be a bit more accurate.  Note that IE versions before 11 don't run on Windows 10 so automatically don't have support.

Here's some screenshots of the tests I did:
![Screen Shot 2020-07-11 at 1 11 43 PM](https://user-images.githubusercontent.com/432336/87233821-c0bb8880-c37f-11ea-9d0b-75fea9469395.png)
![Screen Shot 2020-07-11 at 1 12 34 PM](https://user-images.githubusercontent.com/432336/87233823-c4e7a600-c37f-11ea-8e5f-7f3af5bdfe7c.png)

![Screen Shot 2020-07-11 at 1 19 34 PM](https://user-images.githubusercontent.com/432336/87233826-ca44f080-c37f-11ea-83ba-5d37060b999f.png)
![Screen Shot 2020-07-11 at 1 18 15 PM](https://user-images.githubusercontent.com/432336/87233824-c74a0000-c37f-11ea-9bd0-71d850e27a57.png)

![Screen Shot 2020-07-11 at 1 29 10 PM](https://user-images.githubusercontent.com/432336/87233828-cd3fe100-c37f-11ea-9589-db86995211bf.png)
![Screen Shot 2020-07-11 at 1 30 04 PM](https://user-images.githubusercontent.com/432336/87233829-d03ad180-c37f-11ea-8dc2-2e5bf70fc5d3.png)
