### PR TITLE
Samsung 12.0 is stable

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -170,6 +170,12 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "79"
+        },
+        "12.1": {
+          "release_date": "2020-06-19",
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "79"
         }
       }
     }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -166,7 +166,7 @@
           "engine_version": "75"
         },
         "12.0": {
-          "release_date": "2020-05-07",
+          "release_date": "2020-06-19",
           "status": "current",
           "engine": "Blink",
           "engine_version": "79"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -170,12 +170,6 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "79"
-        },
-        "12.1": {
-          "release_date": "2020-06-19",
-          "status": "beta",
-          "engine": "Blink",
-          "engine_version": "79"
         }
       }
     }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -161,13 +161,13 @@
         },
         "11.2": {
           "release_date": "2020-03-22",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "75"
         },
         "12.0": {
           "release_date": "2020-05-07",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "79"
         }


### PR DESCRIPTION
My phones updated to samsung 12.0 on the stable channel 13 days ago, and Samsung has also [published a release note](https://developer.samsung.com/internet/release-note.html).

This PR retires Samsung Internet 11.2 and makes 12.0 `current`.

I have never made this kind of contribution before, but based on prior commits, i assume that i:
- Should not update `release_date` to the release date of the stable build
- Should not add data for Samsung Internet 12.1 beta, but instead wait for the highly probable release of 12.2 in a few months

Let me know if those assumptions are wrong. Thanks :)