### PR TITLE
add `export * as ns` support data

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -799,7 +799,7 @@
         },
         "namespace": {
           "__compat": {
-            "description": "<code>export * as ns</code>",
+            "description": "<code>export * as namespace</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
             "spec_url": "https://tc39.es/ecma262/#sec-exports",
             "support": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -813,7 +813,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "80"
               },
               "firefox_android": {
                 "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -821,22 +821,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.2.0",
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                },
-                {
-                  "version_added": "12.0.0",
-                  "flags": [
-                    {
-                      "name": "--experimental-modules",
-                      "type": "runtime_flag"
-                    }
-                  ],
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                }
-              ],
+              "nodejs": {
+                "version_added": "12.0.0"
+              },
               "opera": {
                 "version_added": "60"
               },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -796,6 +796,72 @@
               "deprecated": false
             }
           }
+        },
+        "namespace": {
+          "__compat": {
+            "description": "<code>export * as ns</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
+            "spec_url": "https://tc39.es/ecma262/#sec-exports",
+            "support": {
+              "chrome": {
+                "version_added": "72"
+              },
+              "chrome_android": {
+                "version_added": "72"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": [
+                {
+                  "version_added": "13.2.0",
+                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+                },
+                {
+                  "version_added": "12.0.0",
+                  "flags": [
+                    {
+                      "name": "--experimental-modules",
+                      "type": "runtime_flag"
+                    }
+                  ],
+                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+                }
+              ],
+              "opera": {
+                "version_added": "60"
+              },
+              "opera_android": {
+                "version_added": "51"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "11.0"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "for": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)

**Context**
Babel 7.11 will detect whether `export * as ns` should be transformed according to compat-data here: https://github.com/babel/babel/pull/11849

**Sources:**
V8: https://v8.dev/blog/v8-release-72#module-namespace-exports
SM: https://bugzilla.mozilla.org/show_bug.cgi?id=1496852, https://groups.google.com/g/mozilla.dev.platform/c/NSzWY92Ut0o?pli=1
JSC: https://bugs.webkit.org/show_bug.cgi?id=214379

Environments Mapping: https://github.com/mdn/browser-compat-data/tree/master/browsers