### PR TITLE
fix opera version on import/export

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -662,10 +662,10 @@
               }
             ],
             "opera": {
-              "version_added": "47"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -772,10 +772,10 @@
                 }
               ],
               "opera": {
-                "version_added": "47"
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": "44"
+                "version_added": "45"
               },
               "safari": {
                 "version_added": "10.1"
@@ -1586,10 +1586,10 @@
               }
             ],
             "opera": {
-              "version_added": "47"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

Opera 47 is based on Chromium 60 ([source](https://dev.opera.com/blog/opera-47/)), and ESModules support is [merged](https://bugs.chromium.org/p/v8/issues/detail?id=1569) in Chromium 61. It is very unlikely that Opera 47 will support `import/export`. Likewise for Opera Android 44.

I didn't test on Opera 47 due to lack of historical version installs.

**Context**

`@babel/preset-env` will align its `esmodules: true` targets to `browser-compat-data` ([PR](https://github.com/babel/babel/pull/11838)), when reviewing the compat table changes, I guess that `Opera 47` may not support `import/export`.
