### PR TITLE
Add data for tabs.warmup()

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -4167,6 +4167,31 @@
             }
           }
         }
+      },
+      "warmup": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/warmup",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This adds compat data for the `tabs.warmup()` API, which is new in Firefox 79.

https://bugzilla.mozilla.org/show_bug.cgi?id=1402256
https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/warmup
