### PR TITLE
Update support for getBytesInUse

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -87,7 +87,8 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false
+                  "notes": "Only supported by the <code>sync</code> storage area.",
+                  "version_added": "78"
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
This updates the compat data for [`storage.getBytesInUse()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse) to indicate that it is supported from Firefox 78, but only for the [`sync`](https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync) storage area.

https://bugzilla.mozilla.org/show_bug.cgi?id=1637166#c6

@rpl , would you mind having a look at this?