### PR TITLE
Note that sync storage limits were not enforced before Firefox 79

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -270,6 +270,7 @@
                 "version_added": "15"
               },
               "firefox": {
+                "notes": "Before version 79, storage quota limits are not enforced.",
                 "version_added": "53"
               },
               "firefox_android": {


### PR DESCRIPTION
This PR adds a note to the compat data for storage.sync to say that before version 79, storage limits were not enforced in Firefox.

This is part of the documentation updates for https://blog.mozilla.org/addons/2020/07/09/changes-to-storage-sync-in-firefox-79/. There seem to be three pieces to this:

* this, to note that `sync` quotas are now enforced in Firefox
* https://github.com/mdn/browser-compat-data/pull/6398, which says that `storage.getBytesInUse()` is supported from Firefox 78, but only for `sync`.
* an update to the `sync` page (not yet done) that should document the actual quotas, from https://searchfox.org/mozilla-central/rev/8d55e18875b89cdf2a22a7cba60dc40999c18356/toolkit/components/extensions/schemas/storage.json#314-325.

@caitmuenster , does that include everything we need? 
