### PR TITLE
Update MediaQueryList with details about Safari

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -175,10 +175,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5.1",
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5",
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -372,6 +374,7 @@
               "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": {
+              "version_added": "5",
               "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "samsunginternet_android": {

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -29,10 +29,12 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "5.1",
+            "notes": "In Safari, <code>MediaQueryList</code> is not based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>remoteListener()</code> to observe media query lists. This is expected to change in macOS 11 Big Sur."
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "5",
+            "notes": "In Safari, <code>MediaQueryList</code> is not based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>remoteListener()</code> to observe media query lists. This is expected to change in iOS 14."
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -42,7 +44,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -97,7 +99,7 @@
       },
       "EventTarget_inheritance": {
         "__compat": {
-          "description": "<code>MediaQueryList</code> inheriting from <code>EventTarget</code>",
+          "description": "<code>MediaQueryList</code> is based on <code>EventTarget</code>",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -146,6 +148,7 @@
       "addListener": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/addListener",
+          "description": "<code>addListener()</code>",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -338,6 +341,7 @@
       "removeListener": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/removeListener",
+          "description": "<code>removeListener()</code>",
           "support": {
             "chrome": {
               "version_added": "9"

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -192,7 +192,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -387,7 +387,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -30,11 +30,11 @@
           },
           "safari": {
             "version_added": "5.1",
-            "notes": "In Safari, <code>MediaQueryList</code> is not based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>remoteListener()</code> to observe media query lists. This is expected to change in macOS 11 Big Sur."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "safari_ios": {
             "version_added": "5",
-            "notes": "In Safari, <code>MediaQueryList</code> is not based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>remoteListener()</code> to observe media query lists. This is expected to change in iOS 14."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -99,7 +99,7 @@
       },
       "EventTarget_inheritance": {
         "__compat": {
-          "description": "<code>MediaQueryList</code> is based on <code>EventTarget</code>",
+          "description": "<code>MediaQueryList</code> inherits <code>EventTarget</code>",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -190,7 +190,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -368,10 +368,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5.1",
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": {
-              "version_added": "5"
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -383,7 +384,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -30,11 +30,11 @@
           },
           "safari": {
             "version_added": "5.1",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "safari_ios": {
             "version_added": "5",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -30,11 +30,11 @@
           },
           "safari": {
             "version_added": "5.1",
-            "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "safari_ios": {
             "version_added": "5",
-            "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -176,11 +176,11 @@
             },
             "safari": {
               "version_added": "5.1",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": {
               "version_added": "5",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -371,11 +371,11 @@
             },
             "safari": {
               "version_added": "5.1",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": {
               "version_added": "5",
-              "notes": "Prior to Safari 14, <code>MediaQueryList</code> was not based on <code>EventTarget</code>, so you had to use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "notes": "Prior to Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This adds to MediaQueryList.json notes about the lack of
`EventTarget` support in the MQL implementation on Safari,
but also that this is coming in iOS 14 and macOS 11 Big Sur.
Also assorted other corrections including fixing an
experimental flag that was `true` by mistake and adding
description fields to the methods to show them properly in
the tables.

Sources:
* https://trac.webkit.org/changeset/261012/webkit
  - Changeset fixing this for WebKit
* https://bugs.webkit.org/show_bug.cgi?id=203288
  - WebKit bug
  