### PR TITLE
COOP is in Chromium 83

### DIFF
--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "83"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "83"
             },
             "edge": {
-              "version_added": false
+              "version_added": "83"
             },
             "firefox": [
               {
@@ -58,7 +58,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "83"
             }
           },
           "status": {


### PR DESCRIPTION
"COOP also shipped in Chrome 83." says @arturjanc in https://github.com/mdn/sprints/issues/3492