### PR TITLE
Add PeriodicSyncManager/PeriodicSyncEvent APIs

### DIFF
--- a/api/PeriodicSyncEvent.json
+++ b/api/PeriodicSyncEvent.json
@@ -41,8 +41,8 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": true,
+          "experimental": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -88,8 +88,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -135,8 +135,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/PeriodicSyncEvent.json
+++ b/api/PeriodicSyncEvent.json
@@ -1,0 +1,146 @@
+{
+  "api": {
+    "PeriodicSyncEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "80"
+          },
+          "chrome_android": {
+            "version_added": "80"
+          },
+          "edge": {
+            "version_added": "80"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "67"
+          },
+          "opera_android": {
+            "version_added": "57"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "PeriodicSyncEvent": {
+        "__compat": {
+          "description": "<code>PeriodicSyncEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "tag": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PeriodicSyncManager.json
+++ b/api/PeriodicSyncManager.json
@@ -41,8 +41,8 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": true,
+          "experimental": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -88,8 +88,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -135,8 +135,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -182,8 +182,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -229,8 +229,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/PeriodicSyncManager.json
+++ b/api/PeriodicSyncManager.json
@@ -46,54 +46,6 @@
           "deprecated": false
         }
       },
-      "PeriodicSyncManager": {
-        "__compat": {
-          "description": "<code>PeriodicSyncManager()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": "80"
-            },
-            "chrome_android": {
-              "version_added": "80"
-            },
-            "edge": {
-              "version_added": "80"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "67"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "getTags": {
         "__compat": {
           "support": {

--- a/api/PeriodicSyncManager.json
+++ b/api/PeriodicSyncManager.json
@@ -1,0 +1,240 @@
+{
+  "api": {
+    "PeriodicSyncManager": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "80"
+          },
+          "chrome_android": {
+            "version_added": "80"
+          },
+          "edge": {
+            "version_added": "80"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "67"
+          },
+          "opera_android": {
+            "version_added": "57"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "PeriodicSyncManager": {
+        "__compat": {
+          "description": "<code>PeriodicSyncManager()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getTags": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "register": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unregister": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds data for the APIs of the [Web Periodic Background Synchronization WICG spec](https://wicg.github.io/background-sync/spec/PeriodicBackgroundSync-index.html#periodicsyncmanager-interface) as a part of Google's API focus.  All data was determined via manual testing.  Data is as follows:

PeriodicSyncManager:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncManager.register:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncManager.getTags:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncManager.unregister:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncEvent:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncEvent():
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false

PeriodicSyncEvent.tag:
	- Chrome: 80
	- Firefox: false (no flag)
	- Safari: false (no flag)
	- WebView: false