### PR TITLE
Mark methods unavailable in Manifest V3 deprecated

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -56,9 +56,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage",
             "support": {
               "chrome": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": true
               },
               "edge": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "14"
               },
               "firefox": {
@@ -68,11 +70,17 @@
                 "version_added": "48"
               },
               "opera": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": true
               },
               "safari": {
                 "version_added": "14"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },
@@ -81,9 +89,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs",
             "support": {
               "chrome": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": true
               },
               "edge": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "79"
               },
               "firefox": {
@@ -93,6 +103,7 @@
                 "version_added": false
               },
               "opera": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": false
               },
               "safari": {
@@ -141,9 +152,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews",
             "support": {
               "chrome": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": true
               },
               "edge": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "14"
               },
               "firefox": {
@@ -155,11 +168,17 @@
                 "version_added": "48"
               },
               "opera": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": true
               },
               "safari": {
                 "version_added": "14"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -410,9 +410,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBackgroundPage",
             "support": {
               "chrome": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "22"
               },
               "edge": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "14"
               },
               "firefox": {
@@ -424,11 +426,17 @@
                 "version_added": "48"
               },
               "opera": {
+                "notes": "Not supported within service workers (Manifest V3).",
                 "version_added": "15"
               },
               "safari": {
                 "version_added": "14"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
Chrome Manifest V3 deprecates a few methods that allow synchronous DOM access and thus are not compatible with asynchronous service workers. [The documentation](https://developer.chrome.com/extensions/migrating_to_manifest_v3#api_removals) explicitly asks extension developers to migrate to asynchronous alternatives.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
