### PR TITLE
Safari 14 support for public class fields

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -560,10 +560,10 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Updated 'public class field' support for Safari and Safari on iOS, as Apple implemented support in current beta version of Safari 14 shipped with macOS Big Sur.

Is related to the merged pull request #6339 .
As stated in [Apple's release notes](https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes) for Safari 14, public class fields are supported.

I've already tested this in a project on macOS, iOS and iPadOS.

WebKit changeset: [https://trac.webkit.org/changeset/254653/webkit](https://trac.webkit.org/changeset/254653/webkit)
Test: [https://repl.it/@jonasjelonek/Safari-14-public-class-fields#script.js](https://repl.it/@jonasjelonek/Safari-14-public-class-fields#script.js)

In Safari versions below 14, the test code will run into a Syntax error, otherwise a message is display in console.