### PR TITLE
Update DataTransfer contructor support in IE

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -70,7 +70,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"


### PR DESCRIPTION
When trying to use the constructor (new DataTransfer), IE (11) informs that it does not support it. Look at the image below!

Run in IE console

` var dataTransfer = new DataTransfer(); `

![image](https://user-images.githubusercontent.com/29788908/87988330-84da9e80-cab6-11ea-88a7-70f3e2506c75.png)



