### PR TITLE
Add immersive-ar and hit test

### DIFF
--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -767,7 +767,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -727,7 +727,6 @@
       "requestHitTestSource": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/requestHitTestSource",
-          "description": "<code>requestHitTestSource({space, offsetRay})</code>",
           "support": {
             "chrome": {
               "version_added": "81"

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -724,6 +724,55 @@
           }
         }
       },
+      "requestHitTestSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/requestHitTestSource",
+          "description": "<code>requestHitTestSource({space, offsetRay})</code>",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.1"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "requestReferenceSpace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/requestReferenceSpace",

--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -47,54 +47,6 @@
           "deprecated": false
         }
       },
-      "immersive-vr": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-vr",
-          "support": {
-            "chrome": {
-              "version_added": "79"
-            },
-            "chrome_android": {
-              "version_added": "79"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "11.2"
-            },
-            "webview_android": {
-              "version_added": "79"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "immersive-ar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-ar",
@@ -134,6 +86,54 @@
             },
             "webview_android": {
               "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "immersive-vr": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-vr",
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "79"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.2"
+            },
+            "webview_android": {
+              "version_added": "79"
             }
           },
           "status": {

--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -95,6 +95,54 @@
           }
         }
       },
+      "immersive-ar": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-ar",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.1"
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "inline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#inline",

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -170,6 +170,12 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "79"
+        },
+        "12.1": {
+          "release_date": "2020-07-07",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "79"
         }
       }
     }


### PR DESCRIPTION
This PR adds support for immersive-ar and hit-test.

Note: The hit-test page in mdn doesn't exist yet. The URL 404s.

I am not sure whether immersive-ar works in chrome webviews I have heard anecdotally that it does not but have not tested it for myself.

The source of this data is from the support table on https://immersiveweb.dev which is maintained by the W3C Immersive Web Groups.
