### PR TITLE
Update Alternative Stylesheet From MDN Article Itself

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -625,7 +625,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "≤48"
                 },
                 "chrome_android": {
                   "version_added": null
@@ -640,7 +640,7 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": true

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -625,7 +625,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "support": {
                 "chrome": {
-                  "version_added": "1"
+                  "version_added": "1",
                   "version_removed": "48"
                 },
                 "chrome_android": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -625,6 +625,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "support": {
                 "chrome": {
+                  "version_added": "1"
                   "version_removed": "48"
                 },
                 "chrome_android": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -625,7 +625,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "support": {
                 "chrome": {
-                  "version_added": "≤48"
+                  "version_removed": "48"
                 },
                 "chrome_android": {
                   "version_added": null


### PR DESCRIPTION
Brings in compatibility information given at the top of [the article](https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets) with `Internet Explorer also supports this feature (beginning with IE 8),` and `Chrome requires an extension to use the feature (as of version 48).`
