### PR TITLE
Update Alternative Stylesheet Compatibility

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -625,7 +625,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "1",
+                  "version_removed": "48"
                 },
                 "chrome_android": {
                   "version_added": null
@@ -640,7 +641,7 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
Brings in information given at the top of [the article](https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets) with `Internet Explorer also supports this feature (beginning with IE 8)` and `Chrome requires an extension to use the feature (as of version 48).`

Also uses chromium git to get the `version_added`. Version 1 is obtained from [this commit](https://github.com/chromium/chromium/commit/35966c45ba1f945a22b8c595ccbcef78eab39b4c#diff-4c591ff55c0f69ab06ee96e3eba41428). In this commit it talks about meeting specs for alternate stylesheets in webkit in 2002, so this would have come into the first version of chrome. 