### PR TITLE
Remove `FinalizationRegistry.prototype.cleanupSome`

### DIFF
--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -117,64 +117,6 @@
             }
           }
         },
-        "cleanupSome": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/cleanupSome",
-            "spec_url": "https://tc39.es/proposal-weakrefs/#sec-finalization-registry.prototype.cleanupSome",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "register": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register",


### PR DESCRIPTION
This is in light of https://github.com/codehag/proposal-cleanup-some/issues/6. The page has been removed from MDN. More: https://discourse.mozilla.org/t/should-the-finalizationregistry-prototype-cleanupsome-page-be-removed/64309