### PR TITLE
Add data for GamepadEvent API constructor

### DIFF
--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -81,6 +81,68 @@
           "deprecated": false
         }
       },
+      "GamepadEvent": {
+        "__compat": {
+          "description": "GamepadEvent()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadEvent/GamepadEvent",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "28",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.gamepad.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "gamepad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadEvent/gamepad",

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -83,7 +83,7 @@
       },
       "GamepadEvent": {
         "__compat": {
-          "description": "GamepadEvent()",
+          "description": "<code>GamepadEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadEvent/GamepadEvent",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adds data for the `GamepadEvent` API's constructor.  All data was confirmed in testing via SauceLabs/personal VMs.