### PR TITLE
Update guideline for irrelevant features

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -174,6 +174,7 @@ This versioning scheme came at [Apple's request, in #2006](https://github.com/md
 Features can be removed from BCD if it is considered irrelevant. A feature can be considered irrelevant if any of these conditions are met:
 
 - a feature was never implemented in any browser and the specification has been abandoned.
-- a feature was implemented and has since been removed from all majors browsers dating back two or more years ago, or is unsupported in all major browsers released in the past five years.
+- a feature was implemented and has since been removed from all browsers dating back two or more years ago.
+- a feature is unsupported in all releases in the past five years.
 
 This guideline was proposed in [#6018](https://github.com/mdn/browser-compat-data/pull/6018).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -174,6 +174,6 @@ This versioning scheme came at [Apple's request, in #2006](https://github.com/md
 Features can be removed from BCD if it is considered irrelevant. A feature can be considered irrelevant if any of these conditions are met:
 
 - a feature was never implemented in any browser and the specification has been abandoned.
-- a feature was implemented and has since been removed from all browser releases dating back 2 years.
+- a feature was implemented and has since been removed from all majors browsers dating back two or more years ago, or is unsupported in all major browsers released in the past five years.
 
 This guideline was proposed in [#6018](https://github.com/mdn/browser-compat-data/pull/6018).


### PR DESCRIPTION
Adjust the irrelevancy guideline to take into account IE11.

Addresses https://github.com/mdn/browser-compat-data/pull/6407#issuecomment-660133836

Another example is https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear which we didn't archive but will archive with this new guideline.