### PR TITLE
Fix data for allowFullscreen on HTMLIFrameElement

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -142,66 +142,62 @@
           }
         }
       },
-      "allowFullScreen": {
+      "allowFullscreen": {
         "__compat": {
           "support": {
             "chrome": {
-              "prefix": "webkit",
-              "version_added": "17",
-              "notes": "Daily test builds only."
+              "version_added": "38"
             },
             "chrome_android": {
-              "prefix": "webkit",
-              "version_added": "18",
-              "notes": "Daily test builds only."
+              "version_added": "38"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤15"
             },
             "firefox": [
               {
-                "version_added": "18"
+                "version_added": "22"
               },
               {
-                "prefix": "moz",
-                "version_added": "9"
+                "alternative_name": "mozAllowFullScreen",
+                "version_added": "9",
+                "version_removed": "18"
               }
             ],
             "firefox_android": [
               {
-                "version_added": "18"
+                "version_added": "22"
               },
               {
-                "prefix": "moz",
-                "version_added": "9"
+                "alternative_name": "mozAllowFullScreen",
+                "version_added": "9",
+                "version_removed": "18"
               }
             ],
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "25"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "prefix": "webkit",
-              "version_added": true,
-              "notes": "Daily test builds only."
+              "version_added": "38"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -152,7 +152,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": "≤15"
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -184,10 +184,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This is messy because there's also a content attribute, and prefixed
variants of both, but the content attributes and IDL attributes didn't
always change at the same time. No webkit-prefixed variant of the IDL
attribute was ever exposed, and the moz-prefixed IDL attribute had a
different capitalization.

Version numbers found by bisecting on BrowserStack with this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/saved/8300

The commits that added the final unprefixed form in each engine:
https://chromium.googlesource.com/chromium/src/+/9206c8a832a4ead0c9129fc110727f9155228d0c
https://hg.mozilla.org/mozilla-central/rev/91d78336d372
https://trac.webkit.org/changeset/205686/webkit

Because these changes are in bindings only, it's safe to assume that
these were supported at the same time in different browsers using the
same engine, including desktop/mobile.

The miscapitalized variant "allowfullscreen" that Gecko briefly had was
not added to the data.
