### PR TITLE
cancel event is now supported in Firefox

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -78,7 +78,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": 78
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This was added in Firefox 78, see the [bug tracker](https://bugzilla.mozilla.org/show_bug.cgi?id=1322947).
I have tested it using Firefox 78.0.2 on Ubuntu 20.04.
