### PR TITLE
preservesPitch property is supported by Safari

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2792,7 +2792,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2789,10 +2789,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "prefix": "webkit",
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "prefix": "webkit",
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2789,7 +2789,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Just a minor change: 
The property `perservesPitch` of the HTMLMediaElement API was incorrectly labeled in the [browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement#Browser_compatibility) to not be supported by Safari and Safari for iOS. I changed the regarding entry to `true`.

That the property is supported can be checked by toggling it to `false` via the console for a currently played back video for example by entering:
`Array.from(document.getElementsByTagName("VIDEO")).forEach(video => video.webkitPreservesPitch = false);`
(Thanks for pointing me to that, @ritamsarmah)

I tested this on Safari 13.1.2 for macOS, but it is safe to assume that the property is supported since many earlier versions on both macOS and iOS. The change is quite noticeable if the property is set to `false`. There would have been a plethora of complaints about the high pitched voices in video playback at increased speeds otherwise.

Thanks a lot!