### PR TITLE
Update allowfullscreen/webkitallowfullscreen data for Chromium

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -155,7 +155,8 @@
                 },
                 {
                   "prefix": "webkit",
-                  "version_added": "17"
+                  "version_added": "17",
+                  "version_removed": "38"
                 }
               ],
               "chrome_android": [
@@ -164,13 +165,20 @@
                 },
                 {
                   "prefix": "webkit",
-                  "version_added": "18"
+                  "version_added": "18",
+                  "version_removed": "38"
                 }
               ],
-              "edge": {
-                "prefix": "ms",
-                "version_added": "12"
-              },
+              "edge": [
+                {
+                  "version_added": "≤79"
+                },
+                {
+                  "prefix": "ms",
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "18"
@@ -193,12 +201,26 @@
                 "prefix": "ms",
                 "version_added": "11"
               },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": [
+                {
+                  "version_added": "≤15"
+                },
+                {
+                  "prefix": "webkit",
+                  "version_added": "15",
+                  "version_removed": "25"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "≤14"
+                },
+                {
+                  "prefix": "webkit",
+                  "version_added": "14",
+                  "version_removed": "25"
+                }
+              ],
               "safari": [
                 {
                   "version_added": "7"
@@ -223,7 +245,8 @@
                 },
                 {
                   "prefix": "webkit",
-                  "version_added": "1.0"
+                  "version_added": "1.0",
+                  "version_removed": "3.0"
                 }
               ],
               "webview_android": [
@@ -232,7 +255,8 @@
                 },
                 {
                   "prefix": "webkit",
-                  "version_added": "37"
+                  "version_added": "37",
+                  "version_removed": "38"
                 }
               ]
             },


### PR DESCRIPTION
The important part is making it clear that Edge now supports the
unprefixed allowfullscreen attribute.

Both of these attributes were added in the distant past, before Blink
forked from WebKit. The version_added dates were not confirmed or
changed.

Commit where the webkitallowfullscreen attribute was removed:
https://chromium.googlesource.com/chromium/src/+/bc6619f6cb0a8e2bad1b9721cbc63b8ee1909aa0

Based on the date this must have been M38.

All Chromium-based browsers were updated based on this removal time, and
where the unprefixed allowfullscreen wasn't represented in the data it
was added. In the case of Edge and Opera, it's somewhat plausible they
had support for the unprefixed attribute before the switch to Chromium,
so a ranged version was used to avoid having to confirm that.
