### PR TITLE
Add info regarding support of module workers

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -178,7 +178,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "80"
               }
             },
             "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -288,56 +288,56 @@
               "deprecated": false
             }
           }
-        }
-      },
-      "type": {
-        "__compat": {
-          "description": "Constructor <code>type</code> option",
-          "support": {
-            "chrome": {
-              "version_added": "80"
+        },
+        "type": {
+          "__compat": {
+            "description": "Constructor <code>type</code> option",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": {
+                "version_added": "80"
+              },
+              "edge": {
+                "version_added": "80"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "67"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "80"
+              }
             },
-            "chrome_android": {
-              "version_added": "80"
-            },
-            "edge": {
-              "version_added": "80"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "67"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "80"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       },

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -28,7 +28,7 @@
               "partial_implementation": true,
               "notes": [
                 "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>.",
-                "Worker script environment expects CommonJS modules or ECMAScript2015 modules.",
+                "Worker script environment expects CommonJS modules or ECMAScript modules.",
                 "Must be imported from the <code>worker_threads</code> module."
               ]
             },
@@ -135,9 +135,9 @@
             "deprecated": false
           }
         },
-        "es2015_module": {
+        "ecmascript_modules": {
           "__compat": {
-            "description": "Support for ECMAScript2015 module worker",
+            "description": "Support for ECMAScript modules",
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -160,13 +160,13 @@
               "nodejs": {
                 "version_added": "12.17.0",
                 "partial_implementation": true,
-                "notes": "ES2015 is enabled based on file extension rather than type option."
+                "notes": "ECMAScript modules are enabled based on the file extension <code>.mjs</code> rather than the <code>type</code> option."
               },
               "opera": {
-                "version_added": null
+                "version_added": "67"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "57"
               },
               "safari": {
                 "version_added": false
@@ -175,7 +175,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "80"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -160,7 +160,7 @@
               "nodejs": {
                 "version_added": "12.17.0",
                 "partial_implementation": true,
-                "notes": "ECMAScript modules are enabled for files ending with <code>.mjs</code> and for files ending with <code>.js</code> when the nearest parent <code>package.json</code> file contains a top-level field <code>"type"</code> with a value of <code>"module"</code>."
+                "notes": "ECMAScript modules are enabled for files ending with <code>.mjs</code> and for files ending with <code>.js</code> when the nearest parent <code>package.json</code> file contains a top-level field <code>\"type\"</code> with a value of <code>\"module\"</code>."
               },
               "opera": {
                 "version_added": "67"
@@ -287,6 +287,57 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "description": "Constructor <code>type</code> option",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -160,7 +160,7 @@
               "nodejs": {
                 "version_added": "12.17.0",
                 "partial_implementation": true,
-                "notes": "ECMAScript modules are enabled based on the file extension <code>.mjs</code> rather than the <code>type</code> option."
+                "notes": "ECMAScript modules are enabled for files ending with <code>.mjs</code> and for files ending with <code>.js</code> when the nearest parent <code>package.json</code> file contains a top-level field <code>"type"</code> with a value of <code>"module"</code>."
               },
               "opera": {
                 "version_added": "67"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -24,6 +24,15 @@
           },
           "nodejs": [
             {
+              "version_added": "12.17.0",
+              "partial_implementation": true,
+              "notes": [
+                "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>.",
+                "Worker script environment expects CommonJS modules or ECMAScript2015 modules.",
+                "Must be imported from the <code>worker_threads</code> module."
+              ]
+            },
+            {
               "version_added": "11.7.0",
               "partial_implementation": true,
               "notes": [
@@ -124,6 +133,59 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "es2015_module": {
+          "__compat": {
+            "description": "Support for ECMAScript2015 module worker",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": {
+                "version_added": "80"
+              },
+              "edge": {
+                "version_added": "80"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "12.17.0",
+                "partial_implementation": true,
+                "notes": "ES2015 is enabled based on file extension rather than type option."
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "mime_checks": {

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -227,6 +227,13 @@
           "engine": "V8",
           "engine_version": "7.7"
         },
+        "12.17.0": {
+          "release_date": "2020-05-26",
+          "release_notes": "https://nodejs.org/en/blog/release/v12.17.0/",
+          "status": "esr",
+          "engine": "V8",
+          "engine_version": "7.8"
+        },
         "13.0.0": {
           "release_date": "2019-10-10",
           "release_notes": "https://nodejs.org/en/blog/release/v13.0.0/",


### PR DESCRIPTION
That's the `type` option (defined in the [HTML living standard](https://html.spec.whatwg.org/multipage/workers.html#workertype)), and more precisely the support for `"module"` value. I have also updated the Node.js section to add ES modules support (in addition to CJS modules).

Ressources:
- [Chomium 80 changelog](https://blog.chromium.org/2019/12/chrome-80-content-indexing-es-modules.html)
- [Webkit ticket](https://bugs.webkit.org/show_bug.cgi?id=164860)
- [Firefox ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1247687)

