### PR TITLE
Browsers supports gap, row-gap, column-gap for flex

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -8,13 +8,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "84"
               },
               "edge": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "63"
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
                 "version_added": false
@@ -52,7 +52,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "84"
               }
             },
             "status": {

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -14,7 +14,7 @@
                 "version_added": "84"
               },
               "edge": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "63"
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -8,13 +8,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "84"
               },
               "edge": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "63"
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
                 "version_added": false
@@ -50,7 +50,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "84"
               }
             },
             "status": {


### PR DESCRIPTION
Update `CSS/gap`, `CSS/column-gap`, `CSS/row-gap` to show that some browsers supports it for flexboxes starting in Chrome 84, Edge 84, Opera 70

Related PR: #6370