### PR TITLE
docs: update Intl.Locale support in Safari

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -36,10 +36,12 @@
                 "version_added": "53"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14",
+                "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation for the minimize and maximize methods where a string instead of a Locale object was returned."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14",
+                "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation for the minimize and maximize methods where a string instead of a Locale object was returned."
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -95,10 +97,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -148,10 +150,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -201,10 +203,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -254,10 +256,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -307,10 +309,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -360,10 +362,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -413,10 +415,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -466,10 +468,12 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14",
+                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14",
+                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -519,10 +523,12 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14",
+                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14",
+                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -572,10 +578,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -625,10 +631,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -678,10 +684,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -731,10 +737,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -784,10 +790,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -37,11 +37,11 @@
               },
               "safari": {
                 "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation for the minimize and maximize methods where a string instead of a Locale object was returned."
+                "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
               },
               "safari_ios": {
                 "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation for the minimize and maximize methods where a string instead of a Locale object was returned."
+                "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -469,11 +469,11 @@
                 },
                 "safari": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
+                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "safari_ios": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
+                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -524,11 +524,11 @@
                 },
                 "safari": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
+                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "safari_ios": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 had an incorrect implementation and returned a string instead of a Locale object."
+                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"


### PR DESCRIPTION
Safari 14 Technology Preview 107 added support for Intl.Locale and was enabled by default in Safari 14 TP 110.

Safari 14 is currently only in a beta phase and I do not use an Apple product/Safari myself, so I don't know how the Technology Previews map to actual Safari versions so they may need changing?

## Data

### Browser Support Verification

1. Intl.Locale added in Safari 14 TP 107 behind a flag on May 28 2020
   - https://webkit.org/blog/10585/release-notes-for-safari-technology-preview-107/
   - https://trac.webkit.org/changeset/261215/webkit/
   - https://bugs.webkit.org/show_bug.cgi?id=209772
2. Intl.Locale enabled by default in Safari 14 TP 110 (WebKit `263,214`-`263,988`) on July 16 2020
   - https://webkit.org/blog/10929/release-notes-for-safari-technology-preview-110/
   - https://trac.webkit.org/changeset/263227/webkit/
3. `minimize()` and `maximise()` implementation corrected in WebKit `264,275` on July 12 2020 (missed TP 110 window)
   - https://trac.webkit.org/changeset/264275/webkit
   - https://bugs.webkit.org/show_bug.cgi?id=214223
   - https://bugs.webkit.org/show_bug.cgi?id=214231

### Tested

The implementation was tested on iOS 14 Dev build 2 by someone else for me using https://6f6bm.csb.app. This revealed the implementation error on the Locale methods `maximise()` and `minimise()` which I reported and was promptly fixed. It missed the latest 14 TP 110 release by a couple of weeks and will likely land in 14 TP 111.

<details>
<summary>Screenshot of 6f6bm.csb.app on iOS 14 Dev build 2</summary>

![](https://cdn.discordapp.com/attachments/703392952289984563/731557230989803580/image0.png)

</details>