### PR TITLE
appinstalled was mistakenly added

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4557,7 +4557,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- Removes appinstalled from Samsung Internet,

This feature has it's endpoints accidentally added for one version but were never hooked up. They were removed but mdn was not updated to reflect this, this PR rectifies that.

An upcoming Samsung Internet version will correctly add this feature I will make a new PR then.