### PR TITLE
updating Fx version info, now Fx 79 has been released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -574,28 +574,28 @@
         "78": {
           "release_date": "2020-06-30",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/78",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "78"
         },
         "79": {
           "release_date": "2020-07-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/79",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "79"
         },
         "80": {
           "release_date": "2020-08-25",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "80"
         },
         "81": {
           "release_date": "2020-09-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "81"
         }


### PR DESCRIPTION
Firefox 79 is released today, 20200728. Bumping the Fx version details to suit.
