### PR TITLE
docs: update Intl.Locale notes after Safari TP 111 release

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -37,11 +37,11 @@
               },
               "safari": {
                 "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
+                "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
               },
               "safari_ios": {
                 "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
+                "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -469,11 +469,11 @@
                 },
                 "safari": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "safari_ios": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -524,11 +524,11 @@
                 },
                 "safari": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "safari_ios": {
                   "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-110 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"


### PR DESCRIPTION
I tentatively put 111 in #6440 as I expected the patch revision for the minimize/maximize methods to be in the 111 release based on the number of revisions in previous releases. 

Unfortunately it missed the release by ~60 revisions.

https://webkit.org/blog/10967/release-notes-for-safari-technology-preview-111/