### PR TITLE
Updates edge browser data to version 84

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -77,19 +77,26 @@
         "83": {
           "release_date": "2020-05-21",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-83047837-may-21",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
         },
         "84": {
-          "status": "beta",
+          "release_date": "2020-07-16",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-84052240-july-16",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "84"
         },
         "85": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "85"
+        },
+        "86": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "86"
         }
       }
     }


### PR DESCRIPTION
In this PR, I updated the Edge version to 84.

Where a release was made in July.

The beta version is at 85, where you can see it [here](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-beta-channel#version-85056418-july-28). 