### PR TITLE
Fix incorrect spec URL for AggregateError

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -4,7 +4,7 @@
       "AggregateError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError",
-          "spec_url": "https://tc39.es/proposal-promise-any/#sec-nativeerror-object-structure",
+          "spec_url": "https://tc39.es/proposal-promise-any/#sec-aggregate-error-objects",
           "support": {
             "chrome": {
               "version_added": "85"


### PR DESCRIPTION
This change updates the `spec_url` value for `AggregateError` to reference the correct section of this spec (without this change, it references the section for `NativeError`).