### PR TITLE
Update DisplayNames spec URL to correct section

### DIFF
--- a/javascript/builtins/intl/DisplayNames.json
+++ b/javascript/builtins/intl/DisplayNames.json
@@ -5,7 +5,7 @@
         "DisplayNames": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames",
-            "spec_url": "https://tc39.es/proposal-intl-displaynames/#sec-intl-displaynames",
+            "spec_url": "https://tc39.es/proposal-intl-displaynames/#intl-displaynames-objects",
             "support": {
               "chrome": {
                 "version_added": "81"


### PR DESCRIPTION
This change updates the fragment ID in the `spec_url` value for `DisplayNames` to reference the right section of the spec (without this change, the `spec_url` value has a broken fragment ID that references a non-existent ID).