### PR TITLE
Fix parentheses mismatch in data guidelines

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -157,7 +157,7 @@ See [#3904](https://github.com/mdn/browser-compat-data/pull/3904#issuecomment-48
 
 Use version numbers to reflect which _release line_ (major or minor but not patch-level releases) first supported a feature, rather than absolute version numbers.
 
-Typically, BCD does not record absolute version numbers (such as Chrome 76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
+Typically, BCD does not record absolute version numbers, such as Chrome 76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
 
 For example, if the current release of browser X is version 10.2, but a new feature was backported to previous versions including a new 9.7.1 release, then the supported version is 9.7 (not 10.2 or 9.7.1).
 


### PR DESCRIPTION
This PR fixes a little typo in the data guidelines.