### PR TITLE
Update CredentialsContainer.json

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -186,7 +186,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -189,7 +189,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
Document the `NotSupportedError: Not implemented` thrown by iOS Safari

Tested the following snippet:

```js

// This check passes for iOS Safari -- all fine
if (navigator.credentials && navigator.credentials.preventSilentAccess) {
    // This throws NotSupportedError: Not implemented -- as if the method was added (therefore detected) but never implemented
    await navigator.credentials.preventSilentAccess()
}
```

```
Mobile Safari 13.1.1
iOS 13.5.1
```


A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
