### PR TITLE
Add Intl.RelativeTimeFormat support in Safari

### DIFF
--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -36,10 +36,10 @@
                 "version_added": "50"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "10.0"
@@ -95,10 +95,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -148,10 +148,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -201,10 +201,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -254,10 +254,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -303,10 +303,10 @@
                     "version_added": "52"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14"
                   },
                   "samsunginternet_android": {
                     "version_added": false
@@ -363,10 +363,10 @@
                   "version_added": "50"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"


### PR DESCRIPTION
Safari 14.0 supports it. In STP, it is included in 110.
https://webkit.org/blog/10929/release-notes-for-safari-technology-preview-110/

test via
```javascript
console.log(Intl.RelativeTimeFormat);
```

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
