### PR TITLE
Update supports CSS timing function jump keywords for steps

### DIFF
--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -185,16 +185,16 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "64"
               },
               "opera_android": {
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -183,16 +183,16 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "64"
               },
               "opera_android": {
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Safari 14.0 supports it. In STP, it is included in 106:
https://webkit.org/blog/10580/release-notes-for-safari-technology-preview-106/
https://trac.webkit.org/changeset/261046/webkit/