### PR TITLE
Add missing preference info to playbackState

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -123,7 +123,14 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "76"
+              "version_added": "76",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.media.mediasession.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This follows up on my initial PR for playbackState in
Firefox 80 by adding the missing information that
you have to enable the preference to make it work.
This is global across the entire API (kind of makes
you wish you could do this in just one place), and
I previously missed adding it here.
