### PR TITLE
Add -moz-float-edge

### DIFF
--- a/css/properties/-moz-float-edge.json
+++ b/css/properties/-moz-float-edge.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-float-edge": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the first several PRs to add some data to complete CSS reference pages. See https://github.com/mdn/sprints/issues/3436 for details. I'll try to group these thematically, but they're mostly a random assortment, so there will be some one-offs, like this one.

## `-moz-float-edge`

There are a number of very old mentions of this property in Bugzilla, several of which predate Firefox 1.0 ([example](https://bugzilla.mozilla.org/show_bug.cgi?id=57882#c5)). I found no evidence that it was supported in any other browser, at any time, under any name.
