### PR TITLE
Add inputmode for Firefox Mobile

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1108,7 +1108,14 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.forms.inputmode",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This adds data for Firefox Mobile's support of the inputmode attribute's usage as of Version 68, with a flag change.

Sourced from: [https://caniuse.com/#feat=input-inputmode](https://caniuse.com/#feat=input-inputmode)