### PR TITLE
Add -moz-force-broken-image-icon

### DIFF
--- a/css/properties/-moz-force-broken-image-icon.json
+++ b/css/properties/-moz-force-broken-image-icon.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-force-broken-image-icon": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-force-broken-image-icon",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
For https://github.com/mdn/sprints/issues/3436.

This property has been supported [since before Firefox 1.0](https://bugzilla.mozilla.org/show_bug.cgi?id=58646), though before Firefox 57, [you could use values other than zero and one](https://bugzilla.mozilla.org/show_bug.cgi?id=1361044
) (mod 256?!). This seems sufficiently obscure and weird that I didn't bother with a note.