### PR TITLE
Update -moz-outline-radius and add longhand properties

### DIFF
--- a/css/properties/-moz-outline-radius-bottomleft.json
+++ b/css/properties/-moz-outline-radius-bottomleft.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-outline-radius-bottomleft": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-outline-radius-bottomleft",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-moz-outline-radius-bottomright.json
+++ b/css/properties/-moz-outline-radius-bottomright.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-outline-radius-bottomright": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-outline-radius-bottomright",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-moz-outline-radius-topleft.json
+++ b/css/properties/-moz-outline-radius-topleft.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-outline-radius-topleft": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-outline-radius-topleft",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-moz-outline-radius-topright.json
+++ b/css/properties/-moz-outline-radius-topright.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-moz-outline-radius-topright": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-outline-radius-topright",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-moz-outline-radius.json
+++ b/css/properties/-moz-outline-radius.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
This updates `-moz-outline-radius` and adds its longhand properties.

This has been [suggested for removal since before Firefox 1.0 was released](https://bugzilla.mozilla.org/show_bug.cgi?id=315209), implying that it's been supported since at least then. I think the original value here was the Gecko engine version.

The longhand properties never had data. I copied from the shorthand.

Part of https://github.com/mdn/sprints/issues/3436.