### PR TITLE
Add BigInt in Safari

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -34,10 +34,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -86,10 +86,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -138,10 +138,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -190,10 +190,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -242,10 +242,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -291,10 +291,10 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -341,10 +341,10 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -394,10 +394,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -446,10 +446,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"


### PR DESCRIPTION
Safari supports BigInt in 14.0.

https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes

We can also check BigInt support in test262.
https://test262.report/browse/built-ins/BigInt

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
