### PR TITLE
Add Safari entry to WebAssembly.Global

### DIFF
--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -35,10 +35,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": "10.0"
@@ -87,10 +87,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -138,10 +138,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"
@@ -189,10 +189,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "13.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "13.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"


### PR DESCRIPTION
It is supported in 13.1, which is released at April 2010.

https://trac.webkit.org/changeset/253074/webkit

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
