### PR TITLE
Add -webkit-tap-highlight-color

### DIFF
--- a/css/properties/-webkit-tap-highlight-color.json
+++ b/css/properties/-webkit-tap-highlight-color.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-tap-highlight-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-tap-highlight-color",
+          "support": {
+            "chrome": {
+              "version_added": "16"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤15"
+            },
+            "opera_android": {
+              "version_added": "≤14"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This feature has a complex history. It required quite a bit of research to track down. Part of https://github.com/mdn/sprints/issues/3436.

For posterity, I've cleaned up my notes below but here's the summary:

* Chrome: 16 (estimated from WebKit, see below)
* Other Chromium-based browsers: derived/first release, assuming from Chrome estimate is correct
* Edge: 12 (estimated, see below)
* Firefox: No
* IE: No
* Safari: No (see below)
* Safari for iOS: 4.0 (estimated, see below)

## The story

Apple appears to have implemented this as a wholly proprietary feature for Safari for iOS in mid-2010. I can find GitHub commits and [blog posts mentioning it](https://yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/) as far back as June 2010, but no earlier. This suggests the feature was first made public in iOS 4.0 or 4.1. I've gone with the older value. On macOS, I think the feature has never been enabled. It doesn't tab complete in the developer tools, it's not recognized if you type it out manually, and Apple has never shipped a touch-enabled macOS device anyway.

In October 2011, [the feature was added to WebKit proper](https://bugs.webkit.org/show_bug.cgi?id=48544), gated by a touch events flag that WebKit's downstream users could opt-in to. Based on some Chromium-specific commits to WebKit tweaking this feature, I think Chrome opted in to this very early on. Based on the date of the WebKit commit, I've guessed that this happened in Chrome 16 though it's possible this happened a little earlier or later (as early as 15, but no later than Chrome 26, the earliest I could check). This value is a guess, but it's pretty good one for a feature that's a decade old.

The other browsers were relatively easy. IE11 does not recognize the property nor provide tab completion for it in the inspector; Edge does from Edge 13 (the earliest I could test). Given that Edge added support for a number of `-webkit-` prefixed features from the outset (12), I'm inclined to think this was supported from Edge's beginning.

Firefox shows no evidence of having supported it. The remaining browsers I derived from Chrome.