### PR TITLE
Add matchAll information for Safari

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1878,10 +1878,10 @@
                 "version_added": "52"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -578,10 +578,10 @@
                 "version_added": "52"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
It is added in Safari 13.

https://trac.webkit.org/changeset/246567/webkit
https://webkit.org/blog/9375/release-notes-for-safari-technology-preview-86/

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
