### PR TITLE
Map[@@toStringTag] is supporeted in Safari 9.1

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -1086,10 +1086,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
This is added https://trac.webkit.org/changeset/191815/webkit.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
