### PR TITLE
Fix Proxy for Safari

### DIFF
--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -451,10 +451,10 @@
                   "version_added": "36"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"


### PR DESCRIPTION
Proxy getPrototypeOf is supported in Safari 10
https://trac.webkit.org/changeset/197711/webkit

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
