### PR TITLE
Update availability of the `revert` keyword

### DIFF
--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -53,13 +53,13 @@
             "description": "<code>revert</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "84"
               },
               "edge": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "67"

--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -71,7 +71,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
                 "version_added": false
@@ -86,7 +86,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "84"
               }
             },
             "status": {


### PR DESCRIPTION
[bug 579788](https://bugs.chromium.org/p/chromium/issues/detail?id=579788) was fixed and shipped on Chrome, Chrome Android and Edge

Added version info based on [caniuse support table](https://caniuse.com/#feat=css-revert-value)