### PR TITLE
Add -webkit-text-security CSS property

### DIFF
--- a/css/properties/-webkit-text-security.json
+++ b/css/properties/-webkit-text-security.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "-webkit-text-security": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-security",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is rather ancient, [landing in WebKit in 2006](https://trac.webkit.org/changeset/16045/webkit). I derived the Safari versions from the date this change landed and used that to derive Chrome and its derivatives.

I also tested old Edge and Firefox to confirm that they're unsupported there.

Finally, I checked to see if there was any effort to remove this property from WebKit or Chromium. [Chromium considered it](https://bugs.chromium.org/p/chromium/issues/detail?id=726623), but judged it unlikely.



Part of https://github.com/mdn/sprints/issues/3436