### PR TITLE
Add :-moz-broken CSS pseudo-class

### DIFF
--- a/css/selectors/-moz-broken.json
+++ b/css/selectors/-moz-broken.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "-moz-broken": {
+        "__compat": {
+          "description": "<code>:-moz-broken</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-broken",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This one is pretty straight forward for such an old feature. [Bug 11011](https://bugzilla.mozilla.org/show_bug.cgi?id=11011) tells the main story. This doesn't appear to have ever been supported in other browsers and it doesn't appear that there's been an effort to remove it from Firefox.

Part of https://github.com/mdn/sprints/issues/3436