### PR TITLE
Fix Function name configurable true

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -446,10 +446,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -651,10 +651,10 @@
                   "version_added": "30"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"


### PR DESCRIPTION
In #6479, I accidentally marked `displayName` = supported instead of name-configurable-true = supported in Safari.
This change fixes it.
https://trac.webkit.org/changeset/197205/webkit

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
