### PR TITLE
Firefox: Add missing flags to playbackState

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -123,7 +123,14 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "76"
+              "version_added": "76",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.media.mediasession.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
The entry for `playbackState` is missing its `flags`
object indicating that the media session API pref
needs to be enabled to use it, as is true for the
entire API.

