### PR TITLE
adding data about outerHeight and outerWidth removal

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5778,6 +5778,55 @@
               "deprecated": false
             }
           }
+        },
+        "outerwidth_outerheight": {
+          "__compat": {
+            "description": "<code>outerHeight</code> and <code>outerWidth</code> features",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "80"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       },
       "openDialog": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1623826

These features were only in Firefox, and are no longer exposed to the web as of Firefox 80.