### PR TITLE
showing composite operations as enabled in Firefox 80

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -739,7 +739,11 @@
               },
               "firefox": [
                 {
+                  "version_added": "80"
+                },
+                {
                   "version_added": "63",
+                  "version_removed": "79",
                   "flags": [
                     {
                       "type": "preference",
@@ -932,7 +936,11 @@
               },
               "firefox": [
                 {
+                  "version_added": "80"
+                },
+                {
                   "version_added": "63",
+                  "version_removed": "79",
                   "flags": [
                     {
                       "type": "preference",

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -109,16 +109,22 @@
             "edge": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.compositing.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.compositing.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "63",
               "flags": [
@@ -219,16 +225,22 @@
             "edge": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.compositing.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.compositing.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "63",
               "flags": [


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1652676

I know this is enabled in Firefox 80; I'm not sure about other browsers.