### PR TITLE
Add WebGL extension KHR_parallel_shader_compile

### DIFF
--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "KHR_parallel_shader_compile": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/KHR_parallel_shader_compile",
+        "support": {
+          "chrome": {
+            "version_added": "76"
+          },
+          "chrome_android": {
+            "version_added": null
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": "80"
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "63"
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": null
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=849576 which has this revision https://chromium.googlesource.com/chromium/src.git/+/477330f0968f56d5f3a74605a769c31ef5ba6c83 which is 79 according to https://storage.googleapis.com/chromium-find-releases-static/477.html#477330f0968f56d5f3a74605a769c31ef5ba6c83

Other Desktop Chromiums derived from this, but I set mobile browsers to `null`, because graphics stuff is quite environment and driver dependent.

Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1536674