### PR TITLE
@font-face/font-variation-settings is enabled by default since Firefox 62

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -492,26 +492,38 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "60",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-variations.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "60",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-variations.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates when is @font-face/font-variation-settings is enabled in Firefox.

https://bugzilla.mozilla.org/show_bug.cgi?id=1447163 enabled the flag layout.css.font-variations.enabled.

Though the bug says Firefox 61 enabled it, Firefox 62 enabled it in fact (see https://github.com/mdn/browser-compat-data/pull/2360).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
