### PR TITLE
Fix a typo in CSS.vmin

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1861,9 +1861,10 @@
           }
         }
       },
-      "vw": {
+      
+      "vmin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vw",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmin",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1909,9 +1910,9 @@
           }
         }
       },
-      "wmin": {
+      "vw": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/wmin",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vw",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1861,7 +1861,6 @@
           }
         }
       },
-      
       "vmin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmin",


### PR DESCRIPTION
The `vmin` method of the `CSS` API was accidentally typed as `wmin` instead.  This PR corrects that.

<img width="202" alt="Screen Shot 2020-08-09 at 18 35 01" src="https://user-images.githubusercontent.com/5179191/89746545-0cd91600-da6f-11ea-9c44-fd6cb2d05d3c.png">

(Diff view is a bit off 'cause of sorting as well.)