### PR TITLE
Add Safari version for response.clone

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -389,7 +389,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/Response.json
+++ b/api/Response.json
@@ -386,10 +386,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
relevant links:
tag: 604.2.10 https://trac.webkit.org/timeline?from=2017-09-12T16%3A52%3A44-07%3A00&precision=second
exact commit: https://trac.webkit.org/changeset/221772/webkit
test code https://codesandbox.io/s/zealous-currying-wljo8?file=/src/index.js
verified in Safari version 13.0.5

Response.body Response.bodyUsed, Body may also need to be updated

