### PR TITLE
Fix the data for fullscreen APIs for Chromium

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4114,19 +4114,19 @@
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "prefix": "webkit"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "webkit"
               }
             ],
@@ -4204,10 +4204,10 @@
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -4223,10 +4223,10 @@
             "description": "Returns a <code>Promise</code>",
             "support": {
               "chrome": {
-                "version_added": "71"
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": "71"
+                "version_added": "69"
               },
               "edge": {
                 "version_added": "79"
@@ -4256,7 +4256,7 @@
                 "version_added": "10.0"
               },
               "webview_android": {
-                "version_added": "71"
+                "version_added": "69"
               }
             },
             "status": {
@@ -4858,12 +4858,24 @@
           "description": "<code>fullscreenchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenchange_event",
           "support": {
-            "chrome": {
-              "version_added": "45"
-            },
-            "chrome_android": {
-              "version_added": "45"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -4928,9 +4940,15 @@
             "samsunginternet_android": {
               "version_added": "5.0"
             },
-            "webview_android": {
-              "version_added": "45"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -4945,7 +4963,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
                 "version_added": true,
@@ -4954,7 +4972,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
                 "version_added": true,
@@ -5033,7 +5051,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "71"
               },
               {
                 "version_added": true,
@@ -5053,12 +5071,24 @@
           "description": "<code>fullscreenerror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenerror_event",
           "support": {
-            "chrome": {
-              "version_added": "45"
-            },
-            "chrome_android": {
-              "version_added": "45"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -5123,9 +5153,15 @@
             "samsunginternet_android": {
               "version_added": "5.0"
             },
-            "webview_android": {
-              "version_added": "45"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -7157,12 +7193,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onfullscreenchange",
           "support": {
-            "chrome": {
-              "version_added": "45"
-            },
-            "chrome_android": {
-              "version_added": "45"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -7227,9 +7275,15 @@
             "samsunginternet_android": {
               "version_added": "5.0"
             },
-            "webview_android": {
-              "version_added": "45"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -7242,12 +7296,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onfullscreenerror",
           "support": {
-            "chrome": {
-              "version_added": "45"
-            },
-            "chrome_android": {
-              "version_added": "45"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -7312,9 +7378,15 @@
             "samsunginternet_android": {
               "version_added": "5.0"
             },
-            "webview_android": {
-              "version_added": "45"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "45",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -303,15 +303,28 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/fullscreenElement",
           "support": {
-            "chrome": {
-              "version_added": "53",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": "53",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ],
             "edge": [
+              {
+                "version_added": "≤79"
+              },
               {
                 "version_added": "≤18",
                 "prefix": "webkit"
@@ -389,10 +402,15 @@
               "version_added": "6.0",
               "prefix": "webkit"
             },
-            "webview_android": {
-              "version_added": "53",
-              "prefix": "webkit"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/Element.json
+++ b/api/Element.json
@@ -2945,12 +2945,24 @@
           "description": "<code>fullscreenchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/fullscreenchange_event",
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -2992,9 +3004,15 @@
             "samsunginternet_android": {
               "version_added": "7.0"
             },
-            "webview_android": {
-              "version_added": "57"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -3008,12 +3026,24 @@
           "description": "<code>fullscreenerror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/fullscreenerror_event",
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -3055,9 +3085,15 @@
             "samsunginternet_android": {
               "version_added": "7.0"
             },
-            "webview_android": {
-              "version_added": "57"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -5763,12 +5799,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onfullscreenchange",
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -5810,9 +5858,15 @@
             "samsunginternet_android": {
               "version_added": "7.0"
             },
-            "webview_android": {
-              "version_added": "57"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -5825,12 +5879,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/onfullscreenerror",
           "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -5872,9 +5938,15 @@
             "samsunginternet_android": {
               "version_added": "7.0"
             },
-            "webview_android": {
-              "version_added": "57"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "57",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -6577,7 +6649,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "69"
+                "version_added": "71"
               },
               {
                 "version_added": "15",
@@ -6586,7 +6658,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "69"
+                "version_added": "71"
               },
               {
                 "version_added": "18",
@@ -6703,7 +6775,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "69"
+                "version_added": "71"
               },
               {
                 "version_added": "≤37",
@@ -6770,10 +6842,10 @@
             "description": "Returns a <code>Promise</code>",
             "support": {
               "chrome": {
-                "version_added": "71"
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": "71"
+                "version_added": "69"
               },
               "edge": {
                 "version_added": "79"
@@ -6803,7 +6875,7 @@
                 "version_added": "10.0"
               },
               "webview_android": {
-                "version_added": "71"
+                "version_added": "69"
               }
             },
             "status": {


### PR DESCRIPTION
- The unprefixed API shipped in 71. Previously, events and APIs required using the prefixed version. This was only partially right
- Returning a promise for requestFullscreen shipped in 69 (for the prefixed API as the unprefixed one was not shipped yet)
- Some API were not properly marked as shipped unprefixed (`fullscreenElement` for instance)

See https://groups.google.com/u/1/a/chromium.org/g/blink-dev/c/ODzbWn-xRrQ/m/dhkJzD8-CgAJ?pli=1 for their Intent to Ship, https://chromium.googlesource.com/chromium/src.git/+/62898a131761fbeeac3f2b2f7c2c0512f7ca14a9 for the commit unprefixing the APIs and https://bugs.chromium.org/p/chromium/issues/detail?id=383813#c57 for the comment announcing the shipping in the issue tracker.

I also confirmed that Chromium 84 indeed exposes `document.fullscreenElement` unprefixed.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
