### PR TITLE
Safari does not support copyToChannel

### DIFF
--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -179,10 +179,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Running the following piece of javascript works in Firefox and Chrome:
```
audioContext = new (window.AudioContext || window.webkitAudioContext)();
audioBuffer = audioContext.createBuffer(1, 4, audioContext.sampleRate);
floatArray = Float32Array.from([0,0,0,0]);
audioBuffer.copyToChannel(floatArray, 0);
```

In Safari, it fails with the following error:
```
TypeError: audioBuffer.copyToChannel is not a function. (In 'audioBuffer.copyToChannel(floatArray, 0)', 'audioBuffer.copyToChannel' is undefined)
```