### PR TITLE
Correct support for File.name in safari_ios and firefox_android

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -224,7 +224,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": "≤68.10.1"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/File.json
+++ b/api/File.json
@@ -224,7 +224,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤68.10.1"
             },
             "ie": {
               "version_added": "10"
@@ -239,7 +239,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤13.1.2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/File.json
+++ b/api/File.json
@@ -239,7 +239,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": "≤13.1.2"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
The `File.name` API (accessed through `$('input[type="file"]').files[0].name`) works both in Safari on iOS and Firefox on Android; the current browser compat data table claims the contrary. This pull request just adds the browser versions I tested, I don't know when this was added.

See also #6414 for a PoC that is similar to what I tested in the versions added in this pull request. The real test was with my site https://dro.pm which uses this API.