### PR TITLE
Update support data for Animation and KeyframeEffect

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -106,7 +106,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -180,7 +180,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -306,7 +306,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -374,13 +374,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/effect",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -418,10 +418,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -430,10 +430,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -454,7 +454,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -600,7 +600,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -674,7 +674,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -748,7 +748,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -872,7 +872,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -1046,7 +1046,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -1120,7 +1120,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -1196,7 +1196,7 @@
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -1449,7 +1449,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -1523,7 +1523,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "75"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "75"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "63"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "54"
           },
           "safari": {
             "version_added": false
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "11.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "75"
           }
         },
         "status": {
@@ -53,13 +53,13 @@
           "description": "<code>KeyframeEffect()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "75"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "75"
             }
           },
           "status": {
@@ -405,13 +405,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/target",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "75"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -423,10 +423,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -435,10 +435,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "75"
             }
           },
           "status": {


### PR DESCRIPTION
The AnimationEffect data is already good, but Animation's effect
attribute and KeyframeEffect with constructor and target attribute
weren't updated.

These changes landed together in Chromium M75:
https://chromium-review.googlesource.com/c/chromium/src/+/1564568

The Animation and KeyframeEffect interfaces were verified to not exist 
in Edge 18, so the Edge version was set/updated to "75". These data 
points support this as well:
https://caniuse.com/#feat=web-animation
https://developer.microsoft.com/en-us/microsoft-edge/status/webanimationsjavascriptapi/