### PR TITLE
Drop incorrect note about XHR via ActiveXObject for Edge

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -10,16 +10,9 @@
           "chrome_android": {
             "version_added": "18"
           },
-          "edge": [
-            {
-              "version_added": "12"
-            },
-            {
-              "version_added": "12",
-              "version_removed": "79",
-              "notes": "Implemented via <code>ActiveXObject('Microsoft.XMLHTTP')</code>"
-            }
-          ],
+          "edge": {
+            "version_added": "12"
+          },
           "firefox": {
             "version_added": "1"
           },


### PR DESCRIPTION
This source of this information is mirroring in
https://github.com/mdn/browser-compat-data/pull/5568.

ActiveXObject isn't supported in Edge per archived documentation:
https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/Microsoft_Extensions/ActiveXObject

Also tested manually, there's no ActiveXObject global.