### PR TITLE
Update Window.json - onbeforeinstallprompt

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4584,10 +4584,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Hi.

onbeforeinstallprompt isn't working on firefox desktop and firefox mobile. I've tested on desktop and mobile, while working on PWA.

I just changed null to false for this compatibility.

On https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent it's said that onbeforeinstallprompt event doesn't work with firefox desktop and mobile.
