### PR TITLE
Update AnimationEvent contructor support for earlier Edge

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -129,7 +129,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "23"


### PR DESCRIPTION
Found by testing
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8357 in
Edge 13-16 on Sauce Labs.