### PR TITLE
Mark Event constructor as supported in Edge 12

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤13"
             },
             "firefox": {
               "version_added": "11"

--- a/api/Event.json
+++ b/api/Event.json
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤13"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"


### PR DESCRIPTION
Confirmed by running `new Event('type')` in Edge 13 in Sauce Labs. Edge
12 isn't available and therefore not tested.