### PR TITLE
Update when WeakSet.clear was removed from Chromium

### DIFF
--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -265,11 +265,11 @@
             "support": {
               "chrome": {
                 "version_added": "36",
-                "version_removed": "43"
+                "version_removed": "41"
               },
               "chrome_android": {
                 "version_added": "36",
-                "version_removed": "43"
+                "version_removed": "41"
               },
               "edge": {
                 "version_added": false
@@ -289,12 +289,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "25",
-                "version_removed": "30"
+                "version_added": "23",
+                "version_removed": "28"
               },
               "opera_android": {
-                "version_added": "25",
-                "version_removed": "30"
+                "version_added": "24",
+                "version_removed": "28"
               },
               "safari": {
                 "version_added": false
@@ -308,7 +308,7 @@
               },
               "webview_android": {
                 "version_added": "37",
-                "version_removed": "43"
+                "version_removed": "41"
               }
             },
             "status": {


### PR DESCRIPTION
Extracted from https://github.com/mdn/browser-compat-data/pull/6526

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8359 was
tested in Chrome 35-44 and Opera 22-31 on Windows 8.1 on BrowserStack
to confirm, and the mobile browser data was mirrored.