### PR TITLE
Update BudgetService/BudgetState to reflect that they're gone

### DIFF
--- a/api/BudgetService.json
+++ b/api/BudgetService.json
@@ -5,34 +5,39 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetService",
         "support": {
           "chrome": {
-            "version_added": "55"
+            "version_added": "60",
+            "version_removed": "70"
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": "60",
+            "version_removed": "70"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": "42"
+            "version_added": "47",
+            "version_removed": "57"
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": "44",
+            "version_removed": "49"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "8.0",
+            "version_removed": "10.0"
           },
           "webview_android": {
-            "version_added": "55"
+            "version_added": false
           }
         },
         "status": {
@@ -46,34 +51,34 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetService/getBudget",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": false
             }
           },
           "status": {
@@ -88,34 +93,34 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetService/getCost",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": false
             }
           },
           "status": {
@@ -130,34 +135,39 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetService/reserve",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "60",
+              "version_removed": "70"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "60",
+              "version_removed": "70"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "47",
+              "version_removed": "57"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "44",
+              "version_removed": "49"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "8.0",
+              "version_removed": "10.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BudgetState.json
+++ b/api/BudgetState.json
@@ -5,19 +5,19 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetState",
         "support": {
           "chrome": {
-            "version_added": "60"
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": "60"
+            "version_added": false
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "8.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -46,19 +46,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetState/budgetAt",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -67,10 +67,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -88,19 +88,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BudgetState/time",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -109,10 +109,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Only the reserve() method was shipped, and later removed:
https://groups.google.com/a/chromium.org/d/msg/blink-dev/yBtmc-4xl_o/GE0vneAVDQAJ
https://groups.google.com/a/chromium.org/d/msg/blink-dev/18r3whCBv0I/b8qrtFTsDAAJ

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8362 was
tested on Chrome and Opera on Windows to verify the ranges. Android
WebView was never supported per the blink-dev intent, and the other data
was mirrored.