### PR TITLE
Fx81 adds forced-colors with pref

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -608,7 +608,14 @@
                 "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
               },
               "firefox": {
-                "version_added": false
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.forced-colors.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Refer to https://bugzilla.mozilla.org/show_bug.cgi?id=1591204

We recently added `forced-colors` behind the `layout.css.forced-colors.enabled` pref. I thought I'd take a shot at updating the information here as well. Please let me know if there additional changes or procedures that I need to make.