### PR TITLE
Mark Response interface and constructor as added in Edge 14

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -33,7 +33,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": [
             {
@@ -147,7 +147,7 @@
               }
             ],
             "edge": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "firefox": [
               {


### PR DESCRIPTION
Confirmed using
https://software.hixie.ch/utilities/js/live-dom-viewer/saved/8367 in
Edge 13 and 14 on Sauce Labs.

This makes perfect sense, as the Response interface goes together with
fetch(), also introduced in Edge 14.