### PR TITLE
Remove Chromium alt. name for ANGLE_instanced_arrays

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -5,23 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays",
         "support": {
           "chrome": {
-            "version_added": "30",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": "30",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "30"
           },
-          "edge": [
-            {
-              "version_added": "79",
-              "alternative_name": "ANGLEInstancedArrays"
-            },
-            {
-              "version_added": "12",
-              "version_removed": "79"
-            }
-          ],
+          "edge": {
+            "version_added": "12"
+          },
           "firefox": {
             "version_added": "33"
           },
@@ -32,12 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": "17",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "17"
           },
           "opera_android": {
-            "version_added": "18",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "18"
           },
           "safari": {
             "version_added": "7"
@@ -46,12 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": "2.0",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": "4.4",
-            "alternative_name": "ANGLEInstancedArrays"
+            "version_added": "4.4"
           }
         },
         "status": {


### PR DESCRIPTION
alternative name of `ANGLEInstancedArrays`.  However, this may be confusing for web developers, as this alternate name **only** applies to its [implementation within the IDL](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/webgl/angle_instanced_arrays.idl), and nothing that would matter to web developers.  To access the interface, a user must still use the original name when calling `gl.getExtension()` (AKA `gl.getExtension('ANGLE_instanced_arrays');`, see example below).

<img width="312" alt="Screen Shot 2020-08-19 at 17 10 07" src="https://user-images.githubusercontent.com/5179191/90701932-d6558500-e23e-11ea-973a-73b88003f1d7.png">

This PR resolves #6540 by removing the confusing alt. name for the interface.