### PR TITLE
Remove the api.Response.trailer entry

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -917,54 +917,6 @@
           }
         }
       },
-      "trailer": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/trailer",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",


### PR DESCRIPTION
It was added in https://github.com/mdn/browser-compat-data/pull/1400
because it was then in https://fetch.spec.whatwg.org/.

It was removed from the spec in https://github.com/whatwg/fetch/pull/979
and apparently never implemented.

There's no MDN page for this so nothing more to clean up.