### PR TITLE
Fix the Safari versions for api.Response.clone

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -386,10 +386,10 @@
               }
             ],
             "safari": {
-              "version_added": "11.1"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/6515#issuecomment-676752274
for how this was tested in BrowserStack and Sauce, for macOS only.

Additional evidence is https://trac.webkit.org/changeset/197049/webkit,
where the whole Response interface was added, controlled by a single
flag. For the attributes/methods included in that commit, they were
almost certainly first shipped in the same version of Safari that
shipped Response and the overall Fetch API. This was 10.1 / 10.3 per
other existing compat data:
https://wiki.developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/API/Request#Browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/API/Response#Browser_compatibility

There's still a lot clearly wrong with the data for Safari, but this
fixes one small piece of it.