### PR TITLE
Remove inaccurate notes about basic Attr support

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -5,12 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Attr",
         "support": {
           "chrome": {
-            "version_added": "1",
-            "notes": "As of Chrome 45, this property no longer inherits from Node."
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "18",
-            "notes": "As of Chrome 45, this property no longer inherits from Node."
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -25,12 +23,10 @@
             "version_added": "8"
           },
           "opera": {
-            "version_added": "8",
-            "notes": "As of Opera 32, this property no longer inherits from Node."
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": "10.1",
-            "notes": "As of Opera 32, this property no longer inherits from Node."
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "1.3"
@@ -39,12 +35,10 @@
             "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "notes": "As of Samsung Internet 5.0, this property no longer inherits from Node."
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1",
-            "notes": "As of Chrome 45, this property no longer inherits from Node."
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
These notes and those for the attributes were added in
https://github.com/mdn/browser-compat-data/pull/1727.

The notes on api.Attr (basic support) don't make sense, because the
prototype chain (inheritance) of Attr never changed. What did change was
which prototype the 3 attributes localName/namespaceURI/prefix are on.

See https://github.com/mdn/browser-compat-data/issues/6545 for context.