### PR TITLE
Add data for ContentIndex and ContentIndexEvent APIs

### DIFF
--- a/api/ContentIndex.json
+++ b/api/ContentIndex.json
@@ -4,7 +4,7 @@
       "__compat": {
         "support": {
           "chrome": {
-            "version_added": "84"
+            "version_added": false
           },
           "chrome_android": {
             "version_added": "84"
@@ -22,7 +22,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "71"
+            "version_added": false
           },
           "opera_android": {
             "version_added": false
@@ -50,7 +50,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "84"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "84"
@@ -68,7 +68,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "71"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -97,7 +97,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "84"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "84"
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "71"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -144,7 +144,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "84"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "84"
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "71"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/ContentIndex.json
+++ b/api/ContentIndex.json
@@ -1,0 +1,192 @@
+{
+  "api": {
+    "ContentIndex": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "84"
+          },
+          "chrome_android": {
+            "version_added": "84"
+          },
+          "edge": {
+            "version_added": "84"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "71"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "84"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "add": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": "84"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "71"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "delete": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": "84"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "71"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAll": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": "84"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "71"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ContentIndexEvent.json
+++ b/api/ContentIndexEvent.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "ContentIndexEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "84"
+          },
+          "chrome_android": {
+            "version_added": "84"
+          },
+          "edge": {
+            "version_added": "84"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "71"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "84"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/ContentIndexEvent.json
+++ b/api/ContentIndexEvent.json
@@ -4,7 +4,7 @@
       "__compat": {
         "support": {
           "chrome": {
-            "version_added": "84"
+            "version_added": false
           },
           "chrome_android": {
             "version_added": "84"
@@ -22,7 +22,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "71"
+            "version_added": false
           },
           "opera_android": {
             "version_added": false


### PR DESCRIPTION
This PR adds the data for the new [Content Indexing APIs](https://wicg.github.io/content-index/spec).  Data comes from https://www.chromestatus.com/features/5658416729030656 and https://bugs.chromium.org/p/chromium/issues/detail?id=973844.

CC @jpmedley