### PR TITLE
Update Microsoft Edge support for forced-colors media feature

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -604,8 +604,7 @@
                 "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
               },
               "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "81",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -596,7 +596,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/forced-colors",
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#forced-colors",
+                    "value_to_set": "Enabled"
+                  }
+                ],
                 "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
               },
               "chrome_android": {


### PR DESCRIPTION
Update `forced-colors` media query support for Microsoft Edge, which shipped awhile back in 79.

For verification: our [feature availability announcement](https://www.microsoftedgeinsider.com/en-us/whats-new) for whatever reason does not have a version number on it, but I'm part of the feature team that contributed towards support for forced color modes in Microsoft Edge and in web standards.