### PR TITLE
ParentNode.prototype.replaceChildren supported in Chrome 86

### DIFF
--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -727,13 +727,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ParentNode/replaceChildren",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": "78"
@@ -745,7 +745,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -760,7 +760,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "86"
             }
           },
           "status": {


### PR DESCRIPTION
Chrome 86 just branched with support for this enabled.
https://chromestatus.com/feature/6143552666992640
https://crbug.com/1067384