### PR TITLE
Update vrdisplaypointer(un)restricted for Edge 15-18

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5530,7 +5530,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -5578,7 +5579,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -10375,7 +10377,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -10424,7 +10427,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This was discovered via Confluence:
http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Edge_12.10240_Windows_10.0%22,%22Edge_13.10586_Windows_10.0%22,%22Edge_14.14393_Windows_10.0%22,%22Edge_15.15063_Windows_10.0%22,%22Edge_16.16299_Windows_10.0%22,%22Edge_17.17134_Windows_10.0%22,%22Edge_18.17763_Windows_10.0%22%5D&q=%22vrdisplaypointer%22

The event handler attributes were confirmed with
https://software.hixie.ch/utilities/js/live-dom-viewer/saved/8373 in
Edge 14-79 on Sauce Labs.

The event itself is assumed to be fired, not tested. (Support for the
event and the event handler attribute can come apart, but rarely.)