### PR TITLE
Added in support for nowrap in white-space CSS

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -134,7 +134,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "1"
               }
             },
             "status": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -134,7 +134,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "37"
               }
             },
             "status": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -110,31 +110,31 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "3.5"
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "8"
+                "version_added": "5.5"
               },
               "opera": {
-                "version_added": "9.5"
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "10.1"
               },
               "safari": {
-                "version_added": "3"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": "11.2"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "1"
               }
             },
             "status": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -96,6 +96,54 @@
             }
           }
         },
+        "nowrap": {
+          "__compat": {
+            "description": "<code>nowrap</code>",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": "9.5"
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": "3"
+              },
+              "samsunginternet_android": {
+                "version_added": "11.2"
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "pre": {
           "__compat": {
             "description": "<code>pre</code>",

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -122,7 +122,7 @@
                 "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": "9.5"
+                "version_added": "46"
               },
               "safari": {
                 "version_added": "3"


### PR DESCRIPTION
# 
# Overview
This resolves issue #6389 
It doesn't resolve it completely just adding in `nowrap`
# Data
Data was received from w3schools: https://www.w3schools.com/cssref/pr_text_white-space.asp
Also, other data was received from css-tricks.com: https://css-tricks.com/almanac/properties/w/whitespace/
# Issue
The issue was that there were => "Missing white-space values"
The missing values were `white-space`, `normal`, and `nowrap`. The issue is tagged as `data:css`.
Here is the issue: #6389 
# Testing
I tested and all browsers listed support the `white-space`'s `nowrap` option.

# Checklist
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests if any
# 
