### PR TITLE
Make the 'subfeature_earlier_implementation' lint stricter

### DIFF
--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -319,10 +319,14 @@ class ConsistencyChecker {
       typeof a_version_added === 'string' &&
       typeof b_version_added === 'string'
     ) {
-      if (a_version_added.startsWith('≤') || b_version_added.startsWith('≤')) {
+      if (b_version_added.startsWith('≤')) {
         return false;
       }
-      return compareVersions.compare(a_version_added, b_version_added, '<');
+      return compareVersions.compare(
+        a_version_added.replace('≤', ''),
+        b_version_added,
+        '<',
+      );
     }
 
     return false;


### PR DESCRIPTION
Previously it wouldn't compare versions if either was a ranged value
starting with '≤'. However, '≤18' is definitely earlier than '79', to
take Edge numbers as an example, so the comparison can be made in one
direction.

There are no violations of this tighter check.