### PR TITLE
Mark APIs (interfaces) as suppported in Edge 12 if any subfeature is

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -11,7 +11,7 @@
             "version_added": "28"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "17",

--- a/api/CSSNamespaceRule.json
+++ b/api/CSSNamespaceRule.json
@@ -11,7 +11,7 @@
             "version_added": "47"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "59"

--- a/api/CSSRuleList.json
+++ b/api/CSSRuleList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "34"

--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -8,7 +8,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "12",

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "50"

--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "50"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "6"

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -18,7 +18,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18",
+            "version_added": "12",
             "version_removed": "79"
           },
           "firefox": {

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -18,7 +18,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18",
+            "version_added": "12",
             "version_removed": "79"
           },
           "firefox": {

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -13,7 +13,7 @@
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "6",

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -18,7 +18,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "4"

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -13,7 +13,7 @@
             "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "39"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -11,7 +11,7 @@
             "version_added": "47"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "33"

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -11,7 +11,7 @@
             "version_added": "55"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "50"

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -11,7 +11,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "58",

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "4"

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -11,7 +11,7 @@
             "version_added": "27"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "52"

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -11,7 +11,7 @@
             "version_added": "59"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "34"

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -12,7 +12,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -11,7 +11,7 @@
             "version_added": "41"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "37"

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "31"

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"

--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true

--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true


### PR DESCRIPTION
For all of these, some subfeature is already marked as supported in Edge
12. The feature itself must then also be, although the interface object
might not be exposed.

This is a mechanical change, none of them were verified in Edge. If the
subfeature support statement is incorrect, the main feature will now
also be incorrectly marked as supported.