### PR TITLE
Chromium 85 adds support for CSS @property

### DIFF
--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -7,13 +7,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": 85
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": 85
             },
             "edge": {
-              "version_added": false
+              "version_added": 85
             },
             "firefox": {
               "version_added": false
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": 71
             },
             "opera_android": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": 85
             }
           },
           "status": {

--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -7,13 +7,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property",
           "support": {
             "chrome": {
-              "version_added": 85
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": 85
+              "version_added": "85"
             },
             "edge": {
-              "version_added": 85
+              "version_added": "85"
             },
             "firefox": {
               "version_added": false
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": 71
+              "version_added": "71"
             },
             "opera_android": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": 85
+              "version_added": "85"
             }
           },
           "status": {


### PR DESCRIPTION
Chrome / Chromium 85 is out today, and with it comes support for the CSS `@property` rule 🥳

I have manually created CSS `@property` rules in Chrome 85.0.4183.83 and Opera 71.0.3770.50, and tested that their fallback, inheritance and syntax worked.
Support in Chrome and Edge 85 is confirmed [on web-platform-tests](https://wpt.fyi/results/css/css-properties-values-api).
Support in Chrome, Chrome for Android and Android WebView is claimed [on Chromestatus](https://chromestatus.com/feature/5193698449031168).

The `@property` rule is completely embedded in the engine, so i see no reason that any branch of Chromium should disable this. I think the above testing and validation is adequate to mark all Chromium-based browsers supported (except those which don't have the right version tracked yet).
