### PR TITLE
Fix data for File() constructor

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -67,28 +67,28 @@
           "description": "<code>File()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "7"
+              "version_added": "28"
             },
             "firefox_android": {
-              "version_added": "7"
+              "version_added": "28"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "11.5"
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": "11.5"
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/File.json
+++ b/api/File.json
@@ -97,10 +97,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "38"
             }
           },
           "status": {

--- a/api/File.json
+++ b/api/File.json
@@ -91,10 +91,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
I tested it myself in Opera 12 and Opera Mini; the constructor throws `DomException: NOT_SUPPORTED_ERR`

The addition of the API was mentioned in [Opera 25 release notes](https://dev.opera.com/blog/opera-25), so it wasn't available in earlier Chromium-based versions of Opera as well.

[Can I use...](https://caniuse.com/#feat=fileapi) seems to have more clarified data, so I copied them there, for Opera and some other browsers too, as the MDN data for the constructor seem to be just derived from the whole File API.