### PR TITLE
Fix Chrome versions for DOMTokenList API

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "8"
           },
           "chrome_android": {
             "version_added": "18"
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/add",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,10 +82,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/contains",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -178,10 +178,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -292,10 +292,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/item",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -322,10 +322,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/length",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -418,10 +418,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -436,10 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/remove",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -466,10 +466,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -729,10 +729,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/toggle",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -759,10 +759,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "3"
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {
@@ -421,7 +421,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {
@@ -469,7 +469,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {
@@ -762,7 +762,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "3"
             }
           },
           "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR fixes version numbers for the DOMTokenList API based upon manual testing.  The API was actually implemented in Chrome 8; this PR corrects the data to match.  All the features listed as supported in Chrome 1 were tested in Chrome 8 and confirmed functional.

Found during the creation of PRs from mdn-bcd-collector.