### PR TITLE
Update Chromium versions for DOMRect + DOMRectReadOnly

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -38,7 +38,7 @@
             "version_added": "48"
           },
           "opera_android": {
-            "version_added": "48"
+            "version_added": "45"
           },
           "safari": {
             "version_added": "10.1"
@@ -86,7 +86,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -134,7 +134,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -4,34 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRect",
         "support": {
-          "chrome": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "61"
+          },
           "edge": [
             {
               "version_added": "79"
@@ -56,34 +34,12 @@
               "version_added": true
             }
           ],
-          "opera": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "48"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -109,10 +65,10 @@
           "description": "<code>DOMRect()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -127,10 +83,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -157,10 +113,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -175,10 +131,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -4,12 +4,34 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRect",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "edge": [
             {
               "version_added": "79"
@@ -34,12 +56,34 @@
               "version_added": true
             }
           ],
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "10.1"
           },
@@ -47,10 +91,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "61"
           }
         },
         "status": {
@@ -65,10 +109,10 @@
           "description": "<code>DOMRect()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -83,10 +127,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -95,10 +139,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -143,10 +187,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -157,10 +157,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/bottom",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -176,10 +176,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -188,10 +188,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -255,10 +255,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/height",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -274,10 +274,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -286,10 +286,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -304,10 +304,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/left",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -323,10 +323,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -335,10 +335,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -353,10 +353,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/right",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -372,10 +372,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -384,10 +384,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -402,10 +402,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/top",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -421,10 +421,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -433,10 +433,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -451,10 +451,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -470,10 +470,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -482,10 +482,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -548,10 +548,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -566,10 +566,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -578,10 +578,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {
@@ -596,10 +596,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -614,10 +614,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -626,10 +626,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -74,7 +74,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "62"
+              "version_added": true
             },
             "firefox_android": {
               "version_added": true

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -38,7 +38,7 @@
             "version_added": "48"
           },
           "opera_android": {
-            "version_added": "48"
+            "version_added": "45"
           },
           "safari": {
             "version_added": "10.1"
@@ -86,7 +86,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -135,7 +135,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -184,7 +184,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -233,7 +233,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -282,7 +282,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -331,7 +331,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -380,7 +380,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -429,7 +429,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -477,7 +477,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -525,7 +525,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"
@@ -573,7 +573,7 @@
               "version_added": "48"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -237,10 +237,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "61"
             }
           },
           "status": {
@@ -530,10 +530,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -4,12 +4,34 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "edge": [
             {
               "version_added": "79"
@@ -34,12 +56,34 @@
               "version_added": true
             }
           ],
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "10.1"
           },
@@ -47,10 +91,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "61"
           }
         },
         "status": {
@@ -65,10 +109,10 @@
           "description": "<code>DOMRectReadOnly()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -83,10 +127,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10.1"
@@ -95,10 +139,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -4,34 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly",
         "support": {
-          "chrome": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "61"
+          },
           "edge": [
             {
               "version_added": "79"
@@ -56,34 +34,12 @@
               "version_added": true
             }
           ],
-          "opera": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "48"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -109,16 +65,16 @@
           "description": "<code>DOMRectReadOnly()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "62"
             },
             "firefox_android": {
               "version_added": true
@@ -127,10 +83,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -157,10 +113,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/bottom",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -176,10 +132,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -207,10 +163,10 @@
           "description": "<code>fromRect()</code> static function",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -225,10 +181,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -255,10 +211,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/height",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -274,10 +230,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -304,10 +260,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/left",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -323,10 +279,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -353,10 +309,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/right",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -372,10 +328,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -402,10 +358,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/top",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -421,10 +377,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -451,10 +407,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/width",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -470,10 +426,10 @@
               "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -500,10 +456,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -518,10 +474,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -548,10 +504,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/x",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -566,10 +522,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"
@@ -596,10 +552,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/y",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -614,10 +570,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "10.1"


### PR DESCRIPTION
This PR updates the Chromium versions for DOMRect and DOMRectReadOnly.  When working on results from mdn-bcd-collector. I found some discrepancies with the reported data, which said the interfaces were implemented in 61, even though its subfeatures mentioned earlier implementation.  I remember a similar situation in #4902, so I tracked it down, finding it was the same case.  This API was implemented in [Chrome 45](https://storage.googleapis.com/chromium-find-releases-static/cbf.html#cbfb8e068dc4f423f3c710ce0dd2a96caddb6d16) behind a runtime flag, of which was enabled by default in Chrome 61.  This, and the subfeatures mentioned below, were proven in testing via SauceLabs (with a little tweaking to enable the flag).

Sources:

https://storage.googleapis.com/chromium-find-releases-static/cbf.html#cbfb8e068dc4f423f3c710ce0dd2a96caddb6d16 (Chrome 45)
api.DOMRect
api.DOMRect.DOMRect
api.DOMRectReadOnly
api.DOMRectReadOnly.DOMRectReadOnly
api.DOMRectReadOnly.x
api.DOMRectReadOnly.y
api.DOMRectReadOnly.width
api.DOMRectReadOnly.height
api.DOMRectReadOnly.top
api.DOMRectReadOnly.right
api.DOMRectReadOnly.bottom
api.DOMRectReadOnly.left