### PR TITLE
Fix mistakes in the Chromium data for DOMMatrix/DOMMatrixReadOnly

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -4,48 +4,15 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrix",
         "support": {
-          "chrome": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "edge": [
-            {
-              "version_added": "79"
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "61"
+          },
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": "33"
           },
@@ -55,34 +22,12 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "48"
+          },
+          "opera_android": {
+            "version_added": "45"
+          },
           "safari": {
             "version_added": "11"
           },
@@ -108,10 +53,10 @@
           "description": "<code>DOMMatrix()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -126,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "11"
@@ -157,10 +102,10 @@
           "description": "<code>scale3dSelf()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -177,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "11"
@@ -208,10 +153,10 @@
           "description": "<code>scaleSelf()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -229,10 +174,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "11"
@@ -259,10 +204,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -277,10 +222,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "11"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -4,48 +4,15 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly",
         "support": {
-          "chrome": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "version_added": "45",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "edge": [
-            {
-              "version_added": "79"
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "61"
+          },
+          "chrome_android": {
+            "version_added": "61"
+          },
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": "33"
           },
@@ -55,34 +22,12 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "48"
-            },
-            {
-              "version_added": "32",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features=GeometryInterfaces"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "48"
+          },
+          "opera_android": {
+            "version_added": "45"
+          },
           "safari": {
             "version_added": "11"
           },
@@ -108,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/DOMMatrixReadOnly",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -126,7 +71,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -156,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/a",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -174,7 +119,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -204,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/b",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -222,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -252,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/c",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -270,7 +215,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -300,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/d",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -318,7 +263,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -348,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/e",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -366,7 +311,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -396,10 +341,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/f",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -414,7 +359,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -445,10 +390,10 @@
           "description": "<code>flipX()</code>",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -463,7 +408,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -494,10 +439,10 @@
           "description": "<code>flipY()</code>",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -512,7 +457,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -543,10 +488,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/fromMatrix",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -561,10 +506,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "11"
@@ -592,10 +537,10 @@
           "description": "<code>inverse()</code>",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -610,7 +555,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -640,10 +585,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/is2D",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -658,7 +603,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -688,10 +633,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/isIdentity",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -706,7 +651,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -736,10 +681,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m11",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -754,7 +699,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -784,10 +729,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m12",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -802,7 +747,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -832,10 +777,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m13",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -850,7 +795,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -880,10 +825,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m14",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -898,7 +843,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -928,10 +873,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m21",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -946,7 +891,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -976,10 +921,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m22",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -994,7 +939,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1024,10 +969,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m23",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1042,7 +987,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1072,10 +1017,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m24",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1090,7 +1035,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1120,10 +1065,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m31",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1138,7 +1083,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1168,10 +1113,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m32",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1186,7 +1131,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1216,10 +1161,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m33",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1234,7 +1179,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1264,10 +1209,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m34",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1282,7 +1227,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1505,10 +1450,10 @@
           "description": "<code>multiply()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1523,7 +1468,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1554,10 +1499,10 @@
           "description": "<code>rotate()</code>",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1572,7 +1517,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1603,10 +1548,10 @@
           "description": "<code>rotateAxisAngle()</code>",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1621,7 +1566,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1652,10 +1597,10 @@
           "description": "<code>rotateFromVector()</code>",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1670,7 +1615,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1701,10 +1646,10 @@
           "description": "<code>scale()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1722,7 +1667,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1753,10 +1698,10 @@
           "description": "<code>scale3d()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1773,7 +1718,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1804,12 +1749,10 @@
           "description": "<code>scaleNonUniform()</code>",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "56"
+              "version_added": "73"
             },
             "chrome_android": {
-              "version_added": "45",
-              "version_removed": "56"
+              "version_added": "73"
             },
             "edge": {
               "version_added": false
@@ -1825,11 +1768,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32",
-              "version_removed": "43"
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "52"
             },
             "safari": {
               "version_added": false
@@ -1838,10 +1780,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "73"
             }
           },
           "status": {
@@ -1857,12 +1799,10 @@
           "description": "<code>scaleNonUniformSelf()</code>",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "45",
-              "version_removed": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -1878,11 +1818,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32",
-              "version_removed": "43"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1910,10 +1849,10 @@
           "description": "<code>skewX()</code>",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1930,7 +1869,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -1961,10 +1900,10 @@
           "description": "<code>skewY()</code>",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -1981,7 +1920,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2012,10 +1951,10 @@
           "description": "<code>toFloat32Array()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2030,7 +1969,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2061,10 +2000,10 @@
           "description": "<code>toFloat64Array()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2079,7 +2018,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2110,10 +2049,10 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2128,7 +2067,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2159,10 +2098,10 @@
           "description": "<code>toString()</code>",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2177,7 +2116,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2259,10 +2198,10 @@
           "description": "<code>transformPoint()</code>",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2277,7 +2216,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2308,10 +2247,10 @@
           "description": "<code>translate()</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2326,7 +2265,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"
@@ -2356,10 +2295,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2374,7 +2313,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "45"


### PR DESCRIPTION
First, remove the GeometryInterfaces flag, removed over 2 years ago:
https://chromium.googlesource.com/chromium/src/+/3e51c4becac41fe61dbd02a68bd875cc4a340457

Lint errors made it apparent that a lot of the versions were wrong.

The support data here comes mainly from the following:
https://github.com/mdn/browser-compat-data/pull/1617
https://github.com/mdn/browser-compat-data/pull/3644
https://github.com/mdn/browser-compat-data/pull/3743
https://github.com/mdn/browser-compat-data/pull/4902
https://github.com/mdn/browser-compat-data/pull/4936

The root mistake was looking at commits which added/updated these APIs
while it was still behind a flag, and some BCD entries using those
releases without documenting it as behind a flag.

In short, all of this shipped together in M61:
https://storage.googleapis.com/chromium-find-releases-static/065.html#06592e080fd1cf4a188265ed4f9bcf826952671a

The only exceptions are scaleNonUniform which shipped in M73:
https://storage.googleapis.com/chromium-find-releases-static/57f.html#57f350e070536c7870cad53b3edf74f58cc51d50

And scaleNonUniformSelf isn't in the spec and was never in Chromium:
https://github.com/w3c/fxtf-drafts/issues/214
https://github.com/whatwg/compat/issues/19

The data for opera, opera_android, samsung_internet and webview_android
was mirrored.