### PR TITLE
Fix safari Request.mode compat data.

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1211,10 +1211,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1258,10 +1258,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
This file had the correct data under navigate_mode in one place, but was missing from other instances mode and navigate_mode.  I copied the version numbers from line 272.

I verified Request.mode is set correctly in a FetchEvent handler in safari by using fetch-event-echo.glitch.me and then opening the console for the service worker.  I tested as far back as 11.1 since it appears safari 10.1 devtools cannot show the web console for the service worker.

Given that Request.mode was in the spec from the beginning I am confident safari has supported this since they first implemented service workers.