### PR TITLE
Mark api.DOMMatrixReadOnly.scaleNonUniform as shipped in Edge 79

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1755,7 +1755,7 @@
               "version_added": "73"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "33",


### PR DESCRIPTION
This was overlooked in https://github.com/mdn/browser-compat-data/pull/6573
because the mirror script doesn't really work for Edge.