### PR TITLE
Mention lack of support for SVG elements in WebKit for Element.classList

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1474,12 +1474,28 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/classList",
           "support": {
-            "chrome": {
-              "version_added": "8"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
+            "chrome": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "8",
+                "version_removed": "22",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "22",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
             "edge": [
               {
                 "version_added": "16"
@@ -1508,18 +1524,50 @@
             "opera_android": {
               "version_added": "11.5"
             },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "5"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "safari": [
+              {
+                "version_added": "6.1"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "6.1",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "5",
+                "version_removed": "7",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "version_added": "1.0",
+                "version_removed": "1.5",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "≤37",
+                "notes": "Not supported for SVG elements.",
+                "partial_implementation": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/Element.json
+++ b/api/Element.json
@@ -1559,11 +1559,11 @@
             ],
             "webview_android": [
               {
-                "version_added": "≤37"
+                "version_added": "4.4"
               },
               {
                 "version_added": "3",
-                "version_removed": "≤37",
+                "version_removed": "4.4",
                 "notes": "Not supported for SVG elements.",
                 "partial_implementation": true
               }

--- a/api/Element.json
+++ b/api/Element.json
@@ -1487,11 +1487,11 @@
             ],
             "chrome_android": [
               {
-                "version_added": "22"
+                "version_added": "25"
               },
               {
                 "version_added": "18",
-                "version_removed": "22",
+                "version_removed": "25",
                 "notes": "Not supported for SVG elements.",
                 "partial_implementation": true
               }


### PR DESCRIPTION
This PR mentions that in WebKit, `api.Element.classList` also had no support for SVG elements at first.  Data is sourced from https://github.com/mdn/browser-compat-data/pull/6564#issuecomment-681891026 and https://github.com/mdn/browser-compat-data/pull/6564#discussion_r478278571.