### PR TITLE
Update versions for the initial WebKit implementation of Request

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -496,10 +496,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -636,10 +636,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -972,10 +972,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -1021,10 +1021,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1162,10 +1162,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -1307,10 +1307,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1388,10 +1388,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1436,10 +1436,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.2"


### PR DESCRIPTION
This is fixing issues similar to these recent PRs:
https://github.com/mdn/browser-compat-data/pull/6544
https://github.com/mdn/browser-compat-data/pull/6574

Fix the versions for those parts that were in WebKit's initial
implementation:
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Modules/fetch/FetchRequest.idl?rev=195954

That the updated members were present in Safari 10.1 for macOS and
Safari for iOS 10.3 was confirmed with an ad-hoc test in BrowserStack:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8385

Note that `keepalive` wasn't in the initial implementation and added
some time later. It's not updated in this change for ease of review.