### PR TITLE
Add Safari and Mobile Safari support for `<bdi>` since v6

### DIFF
--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -30,10 +30,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
It landed in WebKit in September 2011, which suggests that it's been in Safari since 6 (and iOS 6):

- https://trac.webkit.org/changeset/94822/webkit
- https://bugs.webkit.org/show_bug.cgi?id=50913

Fixes #6539

CC: @ddbeck 

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
- [ ] ~~Data: if you tested something, describe how you tested with details like browser and version~~
