### PR TITLE
fix(css): remove false Safari `column-gap` data

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -35,12 +35,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "2",
-                "prefix": "-webkit-"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

This fix removes the unusable `-webkit-` prefix for `column-gap` in a flex context for Safari.