### PR TITLE
Add Firefox Android (Fenix) 79.0

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -378,7 +378,7 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
-          "status": "esr",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "60"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -434,9 +434,16 @@
         "68": {
           "release_date": "2019-07-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/68",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "68"
+        },
+        "79": {
+          "release_date": "2020-07-28",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/79",
+          "status": "current",
+          "engine": "Gecko",
+          "engine_version": "79"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -378,7 +378,7 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
-          "status": "retired",
+          "status": "esr",
           "engine": "Gecko",
           "engine_version": "60"
         },


### PR DESCRIPTION
The brand new Firefox Android browser is now out as of last month!  This PR adds it to the browser data -- a follow-up to mirror all the data will be coming in a separate PR.

Fenix-specific release notes: https://support.mozilla.org/en-US/kb/whats-new-firefox-android-79