### PR TITLE
Update Safari/iOS version_added for navigator.maxTouchPoints

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1267,10 +1267,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "13.0"
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13.0"
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1267,10 +1267,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Sources:
https://trac.webkit.org/changeset/246070/webkit/ --> Feature added
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=246070 --> 608.1.28
https://en.wikipedia.org/wiki/Safari_version_history#Safari_13 --> 13.0 (Mac/iOS)

Data: 
Visited this page: https://patrickhlauke.github.io/touch/tests/pointer-multitouch-detect.html
Version: 12.1.1 --> unsupported
Version: 13.1.1 --> supported
Version: 13.1.2 --> supported