### PR TITLE
Update WebExtensions compatibility for Firefox for Android 79

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -16,7 +16,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -41,7 +41,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -66,7 +66,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -91,7 +91,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -116,7 +116,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -169,7 +169,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -220,7 +220,7 @@
                 "version_added": "63"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": false
@@ -347,7 +347,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": false
@@ -421,7 +421,7 @@
                   "version_added": "72"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -485,7 +485,7 @@
                 "version_added": "57"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": false
@@ -517,7 +517,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -569,7 +569,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -595,7 +595,7 @@
                   "notes": "Before Firefox 59, invalid color strings behaved as <code>null</code>."
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -628,7 +628,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": true
@@ -652,7 +652,7 @@
                     "version_added": "62"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -678,7 +678,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -704,7 +704,7 @@
                 "version_added": "63"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": false
@@ -742,7 +742,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": "15"
@@ -766,7 +766,7 @@
                     "version_added": "62"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -791,7 +791,7 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": "15"
@@ -816,7 +816,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -880,7 +880,7 @@
                     "version_added": "62"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -906,7 +906,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -970,7 +970,7 @@
                     "version_added": "62"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -996,7 +996,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera": {
                   "version_added": false

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -16,7 +16,8 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -40,7 +41,8 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -64,7 +66,8 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -112,7 +115,8 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -136,7 +140,8 @@
                   "version_added": "53"
                 },
                 "firefox_android": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -404,7 +409,8 @@
                 },
                 "firefox_android": {
                   "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>.",
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -432,7 +438,8 @@
               },
               "firefox_android": {
                 "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers.",
-                "version_added": "57"
+                "version_added": "57",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -459,7 +466,8 @@
               },
               "firefox_android": {
                 "notes": "<code>removalOptions.since</code> is not supported.",
-                "version_added": "57"
+                "version_added": "57",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -484,7 +492,8 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "56"
+                "version_added": "56",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -509,7 +518,8 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "57"
+                "version_added": "57",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -534,7 +544,8 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "57"
+                "version_added": "57",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -560,7 +571,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead.",
+                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used up to Firefox for Android 79 instead.",
                 "version_added": false
               },
               "opera": {
@@ -587,7 +598,6 @@
                 "version_added": "57"
               },
               "firefox_android": {
-                "notes": "The method is defined but returns a rejected promise.",
                 "version_added": false
               },
               "opera": {
@@ -639,7 +649,6 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "notes": "See <a href='https://bugzil.la/1363012'>bug 1363012</a>.",
                 "version_added": false
               },
               "opera": {
@@ -690,7 +699,8 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "56"
+                "version_added": "56",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -571,7 +571,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used up to Firefox for Android 79 instead.",
+                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. Before Firefox for Android 79, <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead.",
                 "version_added": false
               },
               "opera": {

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -16,7 +16,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -41,7 +42,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -66,7 +68,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -91,7 +94,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -115,7 +119,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -139,7 +144,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -163,7 +169,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -237,7 +244,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -261,7 +269,8 @@
                   "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -285,7 +294,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -309,7 +319,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -333,7 +344,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -357,7 +369,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -381,7 +394,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -405,7 +419,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -429,7 +444,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -453,7 +469,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -477,7 +494,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -501,7 +519,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -525,7 +544,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -549,7 +569,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -575,7 +596,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -600,7 +622,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -625,7 +648,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -674,7 +698,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -699,7 +724,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -724,7 +750,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -774,7 +801,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -799,7 +827,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -846,7 +875,8 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": "52"
+                  "version_added": "52",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -870,7 +900,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -894,7 +925,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -919,7 +951,8 @@
                   "version_added": "47"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -943,7 +976,8 @@
                   "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -969,7 +1003,8 @@
                 },
                 "firefox_android": {
                   "notes": "POST is supported from version 52.",
-                  "version_added": "48"
+                  "version_added": "48",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -991,7 +1026,8 @@
                 },
                 "firefox": {
                   "notes": "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference.",
-                  "version_added": "52"
+                  "version_added": "52",
+                  "version_removed": "79"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -1045,7 +1081,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1095,7 +1132,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1120,7 +1158,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1145,7 +1184,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1170,7 +1210,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1195,7 +1236,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1220,7 +1262,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1245,7 +1288,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1270,7 +1314,8 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1320,7 +1365,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -1345,7 +1391,8 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -766,7 +766,8 @@
                   "version_added": "57"
                 },
                 "firefox_android": {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": "41"
@@ -838,7 +839,8 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "54"
+                  "version_added": "54",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": true
@@ -1586,7 +1588,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -1845,7 +1848,8 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": "58"
+                "version_added": "58",
+                "version_removed": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -2213,7 +2217,7 @@
                 "version_added": "77"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": "60"
@@ -2237,7 +2241,7 @@
                 "version_added": "77"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": {
                 "version_added": "60"
@@ -2873,7 +2877,8 @@
                     "version_added": "57"
                   },
                   "firefox_android": {
-                    "version_added": "57"
+                    "version_added": "57",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": true
@@ -2947,7 +2952,8 @@
                     "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": "54",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": true
@@ -3324,7 +3330,8 @@
                     "version_added": "57"
                   },
                   "firefox_android": {
-                    "version_added": "57"
+                    "version_added": "57",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": "41"
@@ -3351,7 +3358,8 @@
                   "firefox_android": [
                     {
                       "notes": "Treated as an alias for <code>queryInfo.active</code>.",
-                      "version_added": "61"
+                      "version_added": "61",
+                      "version_removed": "79"
                     },
                     {
                       "notes": "Treated as an alias for <code>queryInfo.active</code> except when an extension has a popup open. In this situation, <code>queryInfo.highlighted</code> will return the popup, while <code>queryInfo.active</code> will return the tab that was selected before the popup opened.",
@@ -3477,7 +3485,8 @@
                     "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": "54",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": true
@@ -4101,7 +4110,8 @@
                     "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": "54",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": true

--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -16,7 +16,8 @@
                 "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "52"
+                "version_added": "52",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -39,7 +40,8 @@
                   "version_added": "63"
                 },
                 "firefox_android": {
-                  "version_added": "63"
+                  "version_added": "63",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -71,7 +73,8 @@
                 }
               ],
               "firefox_android": {
-                "version_added": "52"
+                "version_added": "52",
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": true
@@ -94,7 +97,8 @@
                   "version_added": "63"
                 },
                 "firefox_android": {
-                  "version_added": "63"
+                  "version_added": "63",
+                  "version_removed": "79"
                 },
                 "opera": {
                   "version_added": false
@@ -117,7 +121,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -141,7 +146,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -213,7 +219,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -237,7 +244,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false
@@ -261,7 +269,8 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63"
+                    "version_added": "63",
+                    "version_removed": "79"
                   },
                   "opera": {
                     "version_added": false


### PR DESCRIPTION
With Firefox for Android 79, we're building on a new browser platform. As
such, many WebExtensions APIs needed to be re-implemented from scratch.
With the release of 79 we haven't yet achieved WebExtension API parity,
therefore this changeset is updating API compatibility. We are working
on restoring the remaining APIs. Note also we have added a few APIs that
were not supported before.

