### PR TITLE
Results from mdn-bcd-collector for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -677,19 +677,24 @@
             "opera_android": {
               "version_added": "24"
             },
-            "safari": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Web Animations"
-                },
-                {
-                  "type": "preference",
-                  "name": "CSS Animations via Web Animations"
-                }
-              ]
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "safari_ios": {
               "version_added": "13.4"
             },
@@ -3311,6 +3316,9 @@
           "support": {
             "chrome": [
               {
+                "version_added": "84"
+              },
+              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -3359,6 +3367,9 @@
             ],
             "chrome_android": [
               {
+                "version_added": "84"
+              },
+              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -3405,15 +3416,20 @@
                 ]
               }
             ],
-            "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "firefox": [
               {
                 "version_added": "75"
@@ -3540,6 +3556,9 @@
               "version_added": false
             },
             "opera": [
+              {
+                "version_added": "71"
+              },
               {
                 "version_added": "66",
                 "flags": [
@@ -3746,10 +3765,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -3785,7 +3804,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -3833,7 +3852,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -4209,11 +4228,11 @@
             },
             "edge": [
               {
-                "version_added": "18"
+                "version_added": "16"
               },
               {
                 "version_added": "12",
-                "version_removed": "18",
+                "version_removed": "16",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -4539,7 +4558,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -4627,7 +4646,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -4660,7 +4679,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "42"
@@ -4800,11 +4819,11 @@
             },
             "edge": [
               {
-                "version_added": "18"
+                "version_added": "17"
               },
               {
                 "version_added": "12",
-                "version_removed": "18",
+                "version_removed": "17",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -4856,11 +4875,11 @@
             },
             "edge": [
               {
-                "version_added": "18"
+                "version_added": "17"
               },
               {
                 "version_added": "12",
-                "version_removed": "18",
+                "version_removed": "17",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -4915,10 +4934,11 @@
             },
             "edge": [
               {
-                "version_added": "18"
+                "version_added": "17"
               },
               {
                 "version_added": "12",
+                "version_removed": "17",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -5189,7 +5209,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤18"
+                "version_added": "15"
               },
               {
                 "version_added": "≤18",
@@ -5810,7 +5830,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "17"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48",
@@ -5820,7 +5840,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true,
@@ -5874,7 +5894,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -5897,7 +5917,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -5906,7 +5926,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -5954,7 +5974,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -5977,7 +5997,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -6326,7 +6346,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "13"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48",
@@ -6337,7 +6357,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -6623,7 +6643,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -6671,7 +6691,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -6980,7 +7000,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -7227,10 +7247,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "ie": {
               "version_added": false
@@ -7386,12 +7406,12 @@
             },
             "edge": [
               {
-                "version_added": "18",
+                "version_added": "17",
                 "notes": "The only parameter supported is <code>alignToTop</code>."
               },
               {
                 "version_added": "12",
-                "version_removed": "18",
+                "version_removed": "17",
                 "notes": [
                   "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function.",
                   "No support for <code>smooth</code> behavior."
@@ -8013,7 +8033,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -8111,7 +8131,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -8402,7 +8422,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -8411,7 +8431,7 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -5212,7 +5212,7 @@
                 "version_added": "15"
               },
               {
-                "version_added": "≤18",
+                "version_added": "12",
                 "alternative_name": "webkitMatchesSelector"
               },
               {

--- a/api/Element.json
+++ b/api/Element.json
@@ -5830,7 +5830,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "48",
@@ -5840,7 +5840,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": null
             },
             "opera": {
               "version_added": true,
@@ -5894,7 +5894,7 @@
               }
             ],
             "edge": {
-              "version_added": "79"
+              "version_added": "≤79"
             },
             "firefox": [
               {
@@ -5917,7 +5917,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
               "version_added": true
@@ -5926,7 +5926,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
@@ -5974,7 +5974,7 @@
               }
             ],
             "edge": {
-              "version_added": "79"
+              "version_added": "≤79"
             },
             "firefox": [
               {
@@ -5997,7 +5997,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
               "version_added": true
@@ -6346,7 +6346,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "48",
@@ -6357,7 +6357,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "ie": {
-              "version_added": true
+              "version_added": null
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR provides results collected from [mdn-bcd-collector](https://github.com/foolip/mdn-bcd-collector) for the `Element` API.  All versions have been verified manually in SauceLabs and local VMs.  (All invalid data was removed from this PR and either corrected on the collector or separated into a new PR.)

_Note: although the collector has more results, I stripped it down to about half to keep the changeset down._