### PR TITLE
fix(css): safari order for 'max-inline-size'

### DIFF
--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -57,11 +57,11 @@
             },
             "safari": [
               {
-                "prefix": "-webkit-",
-                "version_added": "10.1"
+                "version_added": "12.1"
               },
               {
-                "version_added": "12.1"
+                "prefix": "-webkit-",
+                "version_added": "10.1"
               }
             ],
             "safari_ios": [


### PR DESCRIPTION
See: https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#the-support_statement-object

> If there is an array, the `simple_support_statement` objects should be sorted with the most relevant and general entries first. In other words, sort such arrays with entries applying to the most recent browser releases first and sort entries with prefixes or flags after those without.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
