### PR TITLE
fix(css): align/justify grid property support note

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -486,7 +486,7 @@
                 "prefix": "-ms-",
                 "version_added": "10",
                 "partial_implementation": true,
-                "notes": "IE10 and 11 have the property -ms-grid-column-align which acts in a similar way to align-self."
+                "notes": "IE10 and 11 have the property -ms-grid-row-align which acts in a similar way to align-self."
               },
               "opera": {
                 "version_added": "44"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -72,7 +72,10 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": false
+                "prefix": "-ms-",
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "IE10 and 11 have the property -ms-grid-column-align which acts in a similar way to justify-self."
               },
               "opera": {
                 "version_added": "44"


### PR DESCRIPTION
Please see the IE Grid support table [on CSS-Tricks](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/#autoprefixer-has-new-super-powers) for further details.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
