### PR TITLE
fix(css): no writing-mode prefixes needed for IE

### DIFF
--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -66,11 +66,17 @@
                 ]
               }
             ],
-            "ie": {
-              "prefix": "-ms-",
-              "version_added": "9",
-              "notes": "Internet Explorer's implementation differs from the specification."
-            },
+            "ie": [
+              {
+                "version_added": "9",
+                "notes": "Internet Explorer's implementation differs from the specification."
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "9",
+                "notes": "Internet Explorer's implementation differs from the specification."
+              }
+            ],
             "opera": [
               {
                 "version_added": "35"
@@ -248,7 +254,6 @@
                 "version_added": "43"
               },
               "ie": {
-                "prefix": "-ms-",
                 "version_added": "9"
               },
               "opera": {


### PR DESCRIPTION
- SVG1 writing mode values don't need any prefixes.
- The `writing-mode` property can be used without a prefix since IE 9.

These changes were tested manually with [BrowserStack](https://www.browserstack.com/).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
