### PR TITLE
fix(css): prefix order of user-select in Firefox

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -38,12 +38,12 @@
                 "version_added": "69"
               },
               {
-                "prefix": "-moz-",
-                "version_added": "1"
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -59,12 +59,12 @@
             ],
             "firefox_android": [
               {
-                "prefix": "-moz-",
-                "version_added": "4"
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
On Firefox for Android, `-webkit-user-select: none` takes effect, while `-moz-user-select: none` doesn't.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
