### PR TITLE
fix(css): text-size-adjust prefix order in Firefox

### DIFF
--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -33,12 +33,12 @@
             },
             "firefox_android": [
               {
-                "prefix": "-moz-",
-                "version_added": "14"
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "14"
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
Using `-webkit-text-size-adjust: 100%` should be sufficient for modern browsers, the `-moz` prefix should not be preferred.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
