### PR TITLE
Add new unprefixed properties for Safari and WebView

### DIFF
--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -50,10 +50,15 @@
             "samsunginternet_android": {
               "version_added": "1.0"
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.1"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤30"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.1"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -52,7 +52,7 @@
             },
             "webview_android": [
               {
-                "version_added": "≤30"
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -138,7 +138,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "≤30"
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -136,10 +136,15 @@
                 "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤30"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -85,10 +85,15 @@
             "samsunginternet_android": {
               "version_added": "1.0"
             },
-            "webview_android": {
-              "version_added": "2",
-              "prefix": "-webkit-"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤30"
+              },
+              {
+                "version_added": "2",
+                "prefix": "-webkit-"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -87,7 +87,7 @@
             },
             "webview_android": [
               {
-                "version_added": "≤30"
+                "version_added": "≤37"
               },
               {
                 "version_added": "2",

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -61,6 +61,9 @@
             ],
             "safari": [
               {
+                "version_added": "11"
+              },
+              {
                 "version_added": "3",
                 "prefix": "-webkit-"
               },

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -55,10 +55,15 @@
             "opera_android": {
               "version_added": "24"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "10.1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "10.1"
+              }
+            ],
             "safari_ios": {
               "version_added": "10.3"
             },


### PR DESCRIPTION
The WebView changes were tested through [BrowserStack](https://www.browserstack.com/), using a Samsung Galaxy S5 Mini with Android 4.4 on it. For unprefixing `-webkit-line-break`, please see the notes of [the corresponding commit](https://github.com/mdn/browser-compat-data/commit/746a1be7fabebc5fd90e7e55dfe872e16b228ffc).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
