### PR TITLE
Update SVG <discard> support data (only implementation removed)

### DIFF
--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -6,15 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/discard",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "34",
               "version_removed": "81"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "34",
               "version_removed": "81"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79",
+              "version_removed": "81"
             },
             "firefox": {
               "version_added": false
@@ -26,22 +27,25 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "21",
+              "version_removed": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "21",
+              "version_removed": "58"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "version_removed": false
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "37",
               "version_removed": "81"
             }
           },
@@ -49,100 +53,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "begin": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "href": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -42,7 +42,6 @@
             },
             "samsunginternet_android": {
               "version_added": "2.0",
-              "version_removed": false
             },
             "webview_android": {
               "version_added": "37",

--- a/svg/elements/discard.json
+++ b/svg/elements/discard.json
@@ -41,7 +41,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "2.0",
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "37",


### PR DESCRIPTION
This was removed in Chromium 81: https://github.com/mdn/browser-compat-data/pull/5779

Using a simple `window.SVGDiscardElement` test, I determined that the
interface object was added in Chrome 34. It's possible that the markup
was supported earlier than that, but it's not important.

Since it's not possible for anyone to depend on this feature and the
data in BCD should be removed in ~2 years, just delete the subfeatures
which had no useful data, rather than researching the attribute support
in similar detail.