### PR TITLE
Update data for when href (not xlink:href) can be used in SVG

### DIFF
--- a/svg/attributes/href.json
+++ b/svg/attributes/href.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/href",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "edge": {
               "version_added": "12"
@@ -24,10 +24,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "12.1"
@@ -36,10 +36,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -99,10 +99,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": "12"
@@ -117,10 +117,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "12.1"
@@ -129,10 +129,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -24,10 +24,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": "3"
@@ -52,10 +52,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
                 "version_added": null
@@ -70,10 +70,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": false
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "12.1"
@@ -82,10 +82,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "50"
               }
             },
             "status": {

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -52,10 +52,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": "12"
@@ -70,7 +70,7 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
                 "version_added": null
@@ -82,10 +82,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -99,10 +99,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "edge": {
                 "version_added": null
@@ -117,10 +117,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "12.1"
@@ -129,10 +129,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "50"
               }
             },
             "status": {

--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -54,11 +54,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "50",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "50",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "edge": {
@@ -74,10 +74,12 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "37",
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37",
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "safari": {
                 "version_added": "12.1",
@@ -88,11 +90,11 @@
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "samsunginternet_android": {
-                "version_added": true,
+                "version_added": "5.0",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "50",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               }
             },

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -197,10 +197,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": "12"
@@ -215,10 +215,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "12.1"
@@ -227,10 +227,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {


### PR DESCRIPTION
Test case used for `<image href>`:

```svg
<svg width="400" height="200"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
  <image xlink:href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" x="0" height="200" width="200"/>
  <image href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" x="200" height="200" width="200"/>
</svg>
```

Test case used for `<use href>`:

```svg
<svg viewBox="0 0 30 10"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
  <circle id="myCircle" cx="5" cy="5" r="4" stroke="black"/>
  <use xlink:href="#myCircle" x="10" fill="green"/>
  <use href="#myCircle" x="20" fill="green"/>
</svg>
```

Based on these tests, the change was narrowed down to Chrome 50, and
this commit pinpointed:
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411

At the time, SVGURIReference was used in these C++ classes:

https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGAElement.h#32
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGCursorElement.h#35
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGFEImageElement.h#35
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGPatternElement.h#40
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGTextPathElement.h#46
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGUseElement.h#37

The following classes are the same, but for these there's no BCD entry
for the namespaceless href attribute, so they're not updated:
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGFilterElement.h#42
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGGradientElement.h#44
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGImageElement.h#36
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGMPathElement.h#34
https://chromium.googlesource.com/chromium/src/+/2f0b655515af2df03d41d4f894e0dd59d5cb6411/third_party/WebKit/Source/core/svg/SVGScriptElement.h#38

Data is mirror for Chromium browsers expect Edge, which is mostly set to
"12" already and where it's null would require additional testing.