### PR TITLE
Update CSS white-space:break-spaces

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -77,10 +77,10 @@
                 "version_added": "54"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
It landed in WebKit in December 2019, which suggests that it's been in Safari since 13.1 for macOS (10.15.4) and Safari since 13.4 for iOS (13.4):

https://trac.webkit.org/changeset/253524/webkit
https://bugs.webkit.org/show_bug.cgi?id=205234