### PR TITLE
Fix Travis NodeJS matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: 'lts/carbon'
+node_js:
+  - 8
+  - 'lts/dubnium'
 sudo: false
 notifications:
   email: false


### PR DESCRIPTION
This seems to be affecting a few PRs, including #6563, #6605, #6606.  It appears that Travis CI (or NVM) no longer classifies NodeJS v8 as LTS, so `lts/carbon` no longer works.  This replaces the string with just the number `8`, as well as adds NodeJS v10 (Dubnium) to Travis.

(Recommending that we look into #5931 sometime soon, since it's been ¾ of a year since NodeJS v8 was dropped from LTS.)