### PR TITLE
Remove irrelevant bugfix note on FF WebSocket

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -15,8 +15,7 @@
           },
           "firefox": [
             {
-              "version_added": "11",
-              "notes": "See <a href='https://bugzil.la/695635'>bug 695635</a>."
+              "version_added": "11"
             },
             {
               "version_added": "7",


### PR DESCRIPTION
### Summary
The [bugfix in the note](https://bugzilla.mozilla.org/show_bug.cgi?id=695635) tracked unprefixed WebSocket usage, and was closed in FF 11. Maintaining a link to it on the most recent version implies the bugfix page is still relevant for readers, which is untrue.

Even if devs were targeting those older FF versions, the bugfix page didn't contain anything they'd need to be aware of.

### Test
This was tested with `npm test`; all tests passed.


##### Checklist
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
