### PR TITLE
Fix Firefox data for MediaMetadata API

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": null
           },
           "safari_ios": {
             "version_added": null
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
@@ -180,7 +180,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
@@ -228,7 +228,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null
@@ -276,7 +276,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -14,7 +14,14 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "71"
+            "version_added": "71",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.media.mediasession.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": null
@@ -29,7 +36,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": null
@@ -77,7 +84,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -125,7 +132,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -173,7 +180,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -221,7 +228,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -269,7 +276,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
This PR fixes the Firefox data for the MediaMetadata API.  In #5135, support data was added for the interface.  However, from manual testing, I found that it was actually supported behind the `dom.media.mediasession.enabled` flag.  This PR corrects that.