### PR TITLE
Mark NavigatorID members standard; most deprecated

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1572,7 +1572,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -1736,8 +1736,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },
@@ -2226,8 +2226,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },

--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -91,7 +91,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -139,7 +139,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -187,7 +187,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -239,7 +239,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -287,7 +287,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change consistently marks all members of `NavigatorID` as standard — because they are all in fact defined in the HTML spec. And it marks almost all as deprecated — because almost all of them are required to return either a constant (and so, useless) value, or else are defined to *optionally* return a constant value, but are strongly encouraged by the spec to do return a constant value.

The only exceptions are:

* `navigator.userAgent`, defined to return a non-constant value

* `navigator.vendor`, defined to return a value depending on which engine the browser is running; either `Google Inc.`, `Apple Computer, Inc.`, or the empty string (for Gecko)
  https://html.spec.whatwg.org/multipage/#dom-navigator-useragent

Fixes https://github.com/mdn/browser-compat-data/issues/6567