### PR TITLE
Mark the <rb> element with partial_implementation for Chrome and Safari

### DIFF
--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -11,7 +11,7 @@
               "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "partial_implementation": true,
               "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
@@ -55,7 +55,7 @@
               "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "37",
               "partial_implementation": true,
               "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             }

--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -6,13 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/rb",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "firefox": {
               "version_added": "38"
@@ -24,22 +30,34 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "15",
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Safari has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Safari has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             }
           },
           "status": {


### PR DESCRIPTION
This change marks the `rb` element with `partial_implementation` for Safari and Chrome and all Blink/Chrome-based browsers. It also adds a note explaining what’s partially implemented and what’s not.

Fixes https://github.com/mdn/browser-compat-data/issues/6475