### PR TITLE
Mark <dialog> element as supported in Firefox 80

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -13,17 +13,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "53",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.dialog_element.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "80"
+            },
+            {
+              "version_added": "53",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+            }
+          ],
           "firefox_android": {
             "version_added": "53",
             "flags": [
@@ -125,17 +130,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [
@@ -238,17 +248,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [
@@ -302,17 +317,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [
@@ -366,17 +386,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [
@@ -430,17 +455,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              }
+            ],
             "firefox_android": {
               "version_added": "53",
               "flags": [
@@ -76,17 +81,22 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "80"
+                },
+                {
+                  "version_added": "53",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.dialog_element.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+                }
+              ],
               "firefox_android": {
                 "version_added": "53",
                 "flags": [


### PR DESCRIPTION
This change marks the `dialog` element and the `HTMLDialogElement` interface as supported in Firefox 80+.

Fixes https://github.com/mdn/browser-compat-data/issues/6466