### PR TITLE
Mark Request.p.formData partial in Safari

### DIFF
--- a/api/Body.json
+++ b/api/Body.json
@@ -486,10 +486,14 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
Per https://webkit.org/b/212858, `Request.prototype.formData` isn’t fully supported in Safari. So this change marks it with `"partial_implementation": true` and adds a note with a link to the relevant WebKit bug.

Fixes https://github.com/mdn/browser-compat-data/issues/6520