### PR TITLE
Update Body mixin support data for Safari

### DIFF
--- a/api/Body.json
+++ b/api/Body.json
@@ -70,10 +70,10 @@
             }
           ],
           "safari": {
-            "version_added": "10"
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -161,10 +161,10 @@
               }
             ],
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -253,10 +253,10 @@
               }
             ],
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -335,10 +335,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -427,10 +427,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -486,12 +486,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "10",
+              "version_added": "10.1",
               "partial_implementation": true,
               "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "10.3",
               "partial_implementation": true,
               "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
             },
@@ -582,10 +582,10 @@
               }
             ],
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -674,10 +674,10 @@
               }
             ],
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
The initial implementation was in WebKit 602.1.19:
https://trac.webkit.org/changeset/195954/webkit

However, it was all [Conditional=FETCH_API] and didn't ship until Safari
10.1 / iOS 10.3 together with the rest of fetch().

The body attribute was added in WebKit 605.1.4:
https://trac.webkit.org/changeset/221329/webkit

Note that the commit message talks about Request, not Response.