### PR TITLE
Complete nodejs data for RegExp

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -24,6 +24,13 @@
           "engine": "V8",
           "engine_version": "2.2"
         },
+        "0.8.0": {
+          "release_date": "2012-06-25",
+          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.8.0/ChangeLog",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "3.11"
+        },
         "0.9.1": {
           "release_date": "2012-08-28",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.9.1/ChangeLog",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "6"
@@ -243,7 +243,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -347,7 +347,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -397,7 +397,7 @@
                   "version_added": "5.5"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "35"
@@ -450,7 +450,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -500,7 +500,7 @@
                   "version_added": "5.5"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "35"
@@ -553,7 +553,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "15"
@@ -605,7 +605,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -657,7 +657,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -709,7 +709,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -761,7 +761,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "8"
@@ -865,7 +865,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -915,7 +915,7 @@
                   "version_added": "5.5"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "35"
@@ -968,7 +968,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -1145,7 +1145,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "8"
@@ -1197,7 +1197,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -1247,7 +1247,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.8.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -1298,7 +1298,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -1349,7 +1349,7 @@
                   "version_added": "4"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "35"
@@ -1402,7 +1402,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -1452,7 +1452,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "36"
@@ -1503,7 +1503,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "6.0.0"
                 },
                 "opera": {
                   "version_added": "36"
@@ -1556,7 +1556,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -1661,7 +1661,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -1711,7 +1711,7 @@
                   "version_added": "9"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"
@@ -1765,7 +1765,8 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0",
+                "notes": "Case folding is implemented in version 8.6.0"
               },
               "opera": {
                 "version_added": "37"


### PR DESCRIPTION
Part of #6249. This fills in all the `true` and `null` values for Node in `RegExp`.

Most of the entries were supported in the first version of Node, because they were also in Chrome v1. For the ones that remained I checked the data against Chrome/V8 releases and https://node.green, as well as some manual testing.

There was one oddity I noticed in the browser data though, for `javascript.builtins.RegExp.source.empty_regex_string`. This was only added to V8 in version 3.10.6 ([release notes](https://chromium.googlesource.com/v8/v8/+/refs/tags/3.10.6/ChangeLog)), which means Node 0.8.0 (backed up by manual testing). This equates to Chrome 20 ([according to Wikipedia, anyway](https://en.wikipedia.org/wiki/Google_Chrome_version_history)), but the data currently lists Chrome 6 for that entry. I've left the Chrome entry alone here, but it might be worth a separate PR.