### PR TITLE
Document Body.p.formData as always rejecting

### DIFF
--- a/api/Body.json
+++ b/api/Body.json
@@ -488,12 +488,12 @@
             "safari": {
               "version_added": "10.1",
               "partial_implementation": true,
-              "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
+              "notes": "From Safari 10.1, the method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
             },
             "safari_ios": {
               "version_added": "10.3",
               "partial_implementation": true,
-              "notes": "See <a href='https://webkit.org/b/212858'>WebKit bug 212858</a>"
+              "notes": "From Safari for iOS 10.3, the method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
Even though it doesn't work at all, it should be partial_implementation 
per https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#non-functional-defined-names-imply-partial_implementation

This is a follow-up to https://github.com/mdn/browser-compat-data/pull/6616.