### PR TITLE
CSS Update easing-function jump keyword

### DIFF
--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -167,16 +167,16 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "64"
                 },
                 "opera_android": {
                   "version_added": "55"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
Safari 14.0 supports it. In Safari TP, it is included in 106:
https://webkit.org/blog/10580/release-notes-for-safari-technology-preview-106/
https://trac.webkit.org/changeset/261046/webkit/

Ref: #6461 