### PR TITLE
Safari: Change some ServiceWorkerRegistration properties and NavigationPreloadManager to not supported

### DIFF
--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -31,7 +31,7 @@
             "version_added": "46"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": null

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -34,7 +34,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "8.0"

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -80,10 +80,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -130,10 +130,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -180,10 +180,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -230,10 +230,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -211,7 +211,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -331,7 +331,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -460,7 +460,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -568,7 +568,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -208,7 +208,7 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "11.3"
@@ -328,7 +328,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "11.3"
@@ -457,7 +457,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -565,7 +565,7 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "11.3"


### PR DESCRIPTION
Fixes #6557. 

With Safari on macOS, I verified that the following is not supported (properties are missing from console.log output and can't be accessed) and changed the support from `"11.1"` to `false`:
 * `ServiceWorkerRegistration.getNotifications`
 * `ServiceWorkerRegistration.navigationPreload`
 * `ServiceWorkerRegistration.paymentManager`
 * `ServiceWorkerRegistration.pushManager`
 * `NavigationPreloadManager`

For Safari on iOS, I can only rely on the data at [web-confluence.appspot.com](https://web-confluence.appspot.com/#!/catalog?releases=%5B%22Safari_11.0_iPhone_11.4.1%22,%22Safari_13.0.2_OSX_10.15%22%5D&q=%22ServiceWorkerRegistration%7Cnavigationpreloadmanager%22). 
I changed the support for Safari on iOS to `false` as well. 