### PR TITLE
Firefox Android 60 is not ESR

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -378,7 +378,7 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
-          "status": "esr",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "60"
         },


### PR DESCRIPTION
This PR removes the "esr" label on Firefox Android 60, since it not only is retired, but also uncertain how ESR releases would work without a separate, dedicated app.