### PR TITLE
Samsung Internet 13.0 is released

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -177,7 +177,7 @@
           "engine": "Blink",
           "engine_version": "79"
         },
-        "13": {
+        "13.0": {
           "release_date": "2020-08-28",
           "status": "current",
           "engine": "Blink",

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -167,15 +167,21 @@
         },
         "12.0": {
           "release_date": "2020-06-19",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "12.1": {
           "release_date": "2020-07-07",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
+        },
+        "13": {
+          "release_date": "2020-08-28",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "83"
         }
       }
     }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -179,7 +179,7 @@
         },
         "13": {
           "release_date": "2020-08-28",
-          "status": "retired",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "83"
         }


### PR DESCRIPTION
This PR adds Samsung Internet 13.0 to the release information. Cherry-picked from #6589.