### PR TITLE
Drop parens() from cancelValuesAndHoldAtTime() alternative_name

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -106,7 +106,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime()"
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ],
             "chrome_android": [
@@ -116,7 +116,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime()"
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ],
             "edge": {
@@ -138,7 +138,7 @@
               {
                 "version_added": true,
                 "version_removed": "43",
-                "alternative_name": "cancelValuesAndHoldAtTime()"
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ],
             "opera_android": [
@@ -148,7 +148,7 @@
               {
                 "version_added": true,
                 "version_removed": "43",
-                "alternative_name": "cancelValuesAndHoldAtTime()"
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ],
             "safari": {
@@ -162,9 +162,9 @@
                 "version_added": "7.0"
               },
               {
-                "alternative_name": "cancelValuesAndHoldAtTime()",
                 "version_added": true,
-                "version_removed": "6.0"
+                "version_removed": "6.0",
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ],
             "webview_android": [
@@ -174,7 +174,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime()"
+                "alternative_name": "cancelValuesAndHoldAtTime"
               }
             ]
           },


### PR DESCRIPTION
This is the only method where the alternative_name has parens.