### PR TITLE
Samsung Internet 13.0 is actually in beta

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -173,13 +173,12 @@
         },
         "12.1": {
           "release_date": "2020-07-07",
-          "status": "retired",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "79"
         },
         "13.0": {
-          "release_date": "2020-08-28",
-          "status": "current",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "83"
         }


### PR DESCRIPTION
It looks like Samsung Internet 13.0 is actually in beta at the moment, and not an official release.  Source: https://medium.com/samsung-internet-dev/samsung-internet-13-0-beta-692d2673d9fe