### PR TITLE
Mark WindowOrWorkerGlobalScope.p.origin as supported in Safari 11+

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1108,10 +1108,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This change marks `WindowOrWorkerGlobalScope.prototype.origin` as supported in Safari 11 — per https://bugs.webkit.org/show_bug.cgi?id=168023, which per https://trac.webkit.org/browser/webkit/tags/Safari-604.2.4/Source/WebCore/page/WindowOrWorkerGlobalScope.idl#L31 was first added in Safari 11, because per https://trac.webkit.org/browser/webkit/tags/Safari-603.2.1/Source/WebCore/page/WindowOrWorkerGlobalScope.idl it was not in the tag for Safari 10.1

Fixes https://github.com/mdn/browser-compat-data/issues/6344