### PR TITLE
Update audioTracks/videoTracks/textTracks versions for Chrome

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -446,10 +446,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/audioTracks",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "49"
             },
             "edge": {
               "version_added": "12"
@@ -465,10 +465,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "36"
             },
             "safari": {
               "version_added": "8"
@@ -477,10 +477,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "49"
             }
           },
           "status": {
@@ -1321,10 +1321,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/videoTracks",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "49"
             },
             "edge": {
               "version_added": "12"
@@ -1340,10 +1340,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "36"
             },
             "safari": {
               "version_added": "8"
@@ -1352,10 +1352,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
This change corrects the Chrome version data for the `audioTracks`, `videoTracks`, and `textTracks` members of the `SourceBuffer` interface to reflect, per https://chromium.googlesource.com/chromium/src/+/92333c0e5ca6b7768e5bcf6d41ff8fc733ebbfc1, the actual Chrome versions which shipped support for them.

Fixes https://github.com/mdn/browser-compat-data/issues/6102