### PR TITLE
Remove AudioParam.cancelValuesAndHoldAtTime which never shipped

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -99,26 +99,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioParam/cancelAndHoldAtTime",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "≤79"
             },
@@ -131,52 +117,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": true,
-                "version_removed": "43",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true,
-                "version_removed": "43",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "7.0"
-              },
-              {
-                "version_added": true,
-                "version_removed": "6.0",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "56",
-                "alternative_name": "cancelValuesAndHoldAtTime"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
The name was changed to cancelAndHoldAtTime and backported to the M57
branch, so that cancelValuesAndHoldAtTime was never shipped:
https://bugs.chromium.org/p/chromium/issues/detail?id=686242#c3

Confirmed by testing http://mdn-bcd-collector.appspot.com/api/AudioParam/
in Chrome 56 and 57.

The source of this data is https://github.com/mdn/browser-compat-data/pull/450.