### PR TITLE
CSS ::marker shipping in Chromium 86

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -6,33 +6,48 @@
           "description": "<code>::marker</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::marker",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
-            },
-            "edge": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "68"
             },
@@ -58,7 +73,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "86"
             }
           },
           "status": {
@@ -71,33 +86,48 @@
           "__compat": {
             "description": "Animation and transition support",
             "support": {
-              "chrome": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              },
-              "chrome_android": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              },
-              "edge": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "86"
+                },
+                {
+                  "version_added": "83",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "86"
+                },
+                {
+                  "version_added": "83",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "86"
+                },
+                {
+                  "version_added": "83",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "firefox": {
                 "version_added": "80"
               },
@@ -123,7 +153,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "86"
               }
             },
             "status": {


### PR DESCRIPTION
CSS ::marker shipping in Chromium 86:
https://www.chromestatus.com/feature/6710566854852608

Also, animation and transition support only started working (behind flag) in 83:
https://storage.googleapis.com/chromium-find-releases-static/a46.html#a46d064de471a4f4705cbbffc65d69bac2a44736

I know the data because I implemented ::marker in Chromium.