### PR TITLE
Update audioTracks/videoTracks/textTracks versions for Safari

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -252,10 +252,10 @@
               ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3614,7 +3614,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": "8"
             }
           },
           "status": {
@@ -3757,7 +3760,10 @@
               ]
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -75,7 +75,9 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13",
+            "partial_implementation": true,
+            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
           },
           "samsunginternet_android": [
             {
@@ -515,7 +517,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1179,7 +1183,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1431,7 +1437,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This change corrects the Safari version data for the `audioTracks`, `videoTracks`, and `textTracks` members of the `SourceBuffer` interface to reflect, per https://trac.webkit.org/changeset/178172/webkit, the actual version of Safari which first shipped support for them.

Relates to https://github.com/mdn/browser-compat-data/issues/6102