### PR TITLE
fix(css): unprefix 'line-break' for iOS Safari 11+

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -73,10 +73,15 @@
                 "prefix": "-khtml-"
               }
             ],
-            "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
-            },
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "7.0"


### PR DESCRIPTION
Tested with [BrowserStack](https://www.browserstack.com/) on an iPhone 8 Plus (iOS 11).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
