### PR TITLE
Add version numbers for Console API

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1381,9 +1381,9 @@
           }
         }
       },
-      "timeStamp": {
+      "timestamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeStamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timestamp",
           "support": {
             "chrome": {
               "version_added": "14"

--- a/api/Console.json
+++ b/api/Console.json
@@ -878,8 +878,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true,
-              "notes": "No information icon"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/Console.json
+++ b/api/Console.json
@@ -114,10 +114,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/clear",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -129,25 +129,28 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "nodejs": {
               "version_added": "8.3.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -162,10 +165,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/count",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -177,25 +180,28 @@
               "version_added": "30"
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "nodejs": {
               "version_added": "8.3.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -210,10 +216,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/countReset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "68"
             },
             "edge": {
               "version_added": "≤79"
@@ -231,19 +237,19 @@
               "version_added": "8.3.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "68"
             }
           },
           "status": {
@@ -258,10 +264,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/debug",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -273,7 +279,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": [
               {
@@ -285,19 +291,22 @@
               }
             ],
             "opera": {
-              "version_added": null
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -423,22 +432,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dirxml",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "nodejs": [
               {
@@ -451,19 +460,22 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -705,13 +717,16 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -754,13 +769,16 @@
               "notes": "Alias for <code>console.group</code>"
             },
             "opera": {
-              "version_added": null
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -802,13 +820,16 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -829,10 +850,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/info",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -851,20 +872,23 @@
               "notes": "Alias for <code>console.log</code>"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": true,
               "notes": "No information icon"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1046,22 +1070,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profile",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "16"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "16"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "nodejs": {
               "version_added": "8.0.0",
@@ -1073,19 +1097,22 @@
               ]
             },
             "opera": {
-              "version_added": null
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "53"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1100,22 +1127,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profileEnd",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "16"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "16"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "nodejs": {
               "version_added": "8.0.0",
@@ -1127,19 +1154,22 @@
               ]
             },
             "opera": {
-              "version_added": null
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1277,13 +1307,16 @@
               "version_added": "0.1.104"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1348,24 +1381,24 @@
           }
         }
       },
-      "timestamp": {
+      "timeStamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timestamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeStamp",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "14"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "39"
             },
             "ie": {
               "version_added": "11"
@@ -1380,19 +1413,22 @@
               ]
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1458,10 +1494,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/warn",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1480,19 +1516,22 @@
               "notes": "Alias for <code>console.error</code>"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Console.json
+++ b/api/Console.json
@@ -239,6 +239,9 @@
             "opera": {
               "version_added": "55"
             },
+            "opera_android": {
+              "version_added": "48"
+            },
             "safari": {
               "version_added": "13"
             },
@@ -878,7 +881,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1521,7 +1524,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds version numbers for various members of the Console API, based upon manual testing (running `'memberName' in console` in various browsers).  Data is as follows:

api.Console.clear - Chrome 25, IE 8, Opera 12, Safari 6.1
api.Console.count - Chrome 1, IE 11, Opera 11, Safari 4
api.Console.countReset - Chrome 68, Opera 55, Safari 13
api.Console.debug - Chrome 1, IE 11, Opera 10, Safari 4
api.Console.dirxml - Chrome 1, Firefox 39, IE 11, Opera 11, Safari 4
api.Console.group - Opera 11
api.Console.groupCollapsed - Opera 11
api.Console.groupEnd - Opera 11
api.Console.info - Chrome 1, Opera 10.5, Safari ≤3
api.Console.profile - Chrome 4 (incorrectly marked 53), Firefox 16, IE 9, Opera 11, Safari 4
api.Console.profileEnd - Chrome 4, Firefox 16, IE 9, Opera 11, Safari 4
api.Console.timeEnd - Opera 11
api.Console.timeStamp - Chrome 14, Firefox 39, Opera Blink, Safari 6
api.Console.warn - Chrome 1, Opera 10.5, Safari ≤3

This also removes a note on `api.Console.info` for Safari that there was "no information icon", which may have been true in older versions but not in the latest Safari.