### PR TITLE
fix(css): support 'flex-basis: auto' in Safaris

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -189,14 +189,24 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "1.5"
               },


### PR DESCRIPTION
Tested with [BrowserStack](https://www.browserstack.com/) on Safari 9.1 and iOS Safari 9 (iPhone 6S).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
