### PR TITLE
Move api.Console.timestamp -> api.Console.timeStamp

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1348,9 +1348,9 @@
           }
         }
       },
-      "timestamp": {
+      "timeStamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timestamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeStamp",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
This PR renames the `timestamp` subfeature with the proper capitalization, `timeStamp`.  There is no `timestamp` (no caps) in the Console API, and the linked documentation talks about `timeStamp` (with caps).