### PR TITLE
Sort out AudioTrack and VideoTrack support in Chromium

### DIFF
--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack",
         "support": {
           "chrome": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -15,7 +15,7 @@
             ]
           },
           "chrome_android": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -64,7 +64,7 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -74,7 +74,7 @@
             ]
           },
           "opera_android": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -93,7 +93,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": false
           }
         },
         "status": {
@@ -107,7 +107,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/enabled",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -117,7 +117,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -166,7 +166,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -176,7 +176,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -195,7 +195,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -210,7 +210,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/id",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -220,7 +220,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -269,7 +269,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -279,7 +279,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -298,7 +298,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -313,7 +313,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/kind",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -323,7 +323,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -372,7 +372,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -382,7 +382,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -401,7 +401,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -416,7 +416,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/label",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -426,7 +426,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -475,7 +475,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -485,7 +485,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -504,7 +504,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -519,7 +519,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/language",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -529,7 +529,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -578,7 +578,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -588,7 +588,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -607,7 +607,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -622,7 +622,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrack/sourceBuffer",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "51",
               "flags": [
                 {
                   "type": "preference",
@@ -632,7 +632,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "51",
               "flags": [
                 {
                   "type": "preference",
@@ -667,7 +667,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "38",
               "flags": [
                 {
                   "type": "preference",
@@ -677,7 +677,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "41",
               "flags": [
                 {
                   "type": "preference",
@@ -696,7 +696,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList",
         "support": {
           "chrome": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -15,7 +15,7 @@
             ]
           },
           "chrome_android": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -64,7 +64,7 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -74,7 +74,7 @@
             ]
           },
           "opera_android": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -93,7 +93,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": false
           }
         },
         "status": {
@@ -108,7 +108,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/addtrack_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -118,7 +118,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -167,7 +167,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -177,7 +177,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -212,7 +212,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/change_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -222,7 +222,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -271,7 +271,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -281,7 +281,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -300,7 +300,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -315,7 +315,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/getTrackById",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -325,7 +325,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -374,7 +374,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -384,7 +384,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -403,7 +403,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -418,7 +418,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/length",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -428,7 +428,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -477,7 +477,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -487,7 +487,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -506,7 +506,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -521,7 +521,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/onaddtrack",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -531,7 +531,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -580,7 +580,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -590,7 +590,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -609,7 +609,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -624,7 +624,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/onchange",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -634,7 +634,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -683,7 +683,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -693,7 +693,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -712,7 +712,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -727,7 +727,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/onremovetrack",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -737,7 +737,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -786,7 +786,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -796,7 +796,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -815,7 +815,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -831,7 +831,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioTrackList/removetrack_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -841,7 +841,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -890,7 +890,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -900,7 +900,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -919,7 +919,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -173,15 +173,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/audioTracks",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "37",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -206,10 +232,24 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "24",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": true
@@ -3638,12 +3678,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/videoTracks",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "37",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+            "chrome_android": {
+              "version_added": "37",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "33",
               "flags": [
@@ -3668,10 +3737,33 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "24",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "24",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -446,14 +446,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/audioTracks",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -465,10 +492,24 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "38",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": "8"
@@ -477,10 +518,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": false
             }
           },
           "status": {
@@ -1321,14 +1362,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/videoTracks",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -1340,10 +1408,24 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "38",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": "8"
@@ -1352,10 +1434,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": false
             }
           },
           "status": {

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack",
         "support": {
           "chrome": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -15,7 +15,7 @@
             ]
           },
           "chrome_android": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -64,7 +64,7 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -74,7 +74,7 @@
             ]
           },
           "opera_android": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -93,7 +93,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": false
           }
         },
         "status": {
@@ -107,7 +107,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/id",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -117,7 +117,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -166,7 +166,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -176,7 +176,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -195,7 +195,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -210,7 +210,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/kind",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -220,7 +220,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -269,7 +269,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -279,7 +279,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -298,7 +298,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -313,7 +313,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/label",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -323,7 +323,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -372,7 +372,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -382,7 +382,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -401,7 +401,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -416,7 +416,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/language",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -426,7 +426,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -475,7 +475,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -485,7 +485,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -504,7 +504,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -519,7 +519,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/selected",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -529,7 +529,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -578,7 +578,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -588,7 +588,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -607,7 +607,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -622,7 +622,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrack/sourceBuffer",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "51",
               "flags": [
                 {
                   "type": "preference",
@@ -632,7 +632,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "51",
               "flags": [
                 {
                   "type": "preference",
@@ -667,7 +667,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "38",
               "flags": [
                 {
                   "type": "preference",
@@ -677,7 +677,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "41",
               "flags": [
                 {
                   "type": "preference",
@@ -696,7 +696,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList",
         "support": {
           "chrome": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -15,7 +15,7 @@
             ]
           },
           "chrome_android": {
-            "version_added": "45",
+            "version_added": "37",
             "flags": [
               {
                 "type": "preference",
@@ -64,7 +64,7 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -74,7 +74,7 @@
             ]
           },
           "opera_android": {
-            "version_added": "32",
+            "version_added": "24",
             "flags": [
               {
                 "type": "preference",
@@ -93,7 +93,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": false
           }
         },
         "status": {
@@ -108,7 +108,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/addtrack_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -118,7 +118,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -167,7 +167,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -177,7 +177,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -212,7 +212,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/change_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -222,7 +222,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -271,7 +271,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -281,7 +281,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -300,7 +300,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -315,7 +315,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/getTrackById",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -325,7 +325,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -374,7 +374,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -384,7 +384,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -403,7 +403,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -418,7 +418,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/length",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -428,7 +428,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -477,7 +477,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -487,7 +487,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -506,7 +506,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -521,7 +521,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/onaddtrack",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -531,7 +531,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -580,7 +580,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -590,7 +590,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -609,7 +609,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -624,7 +624,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/onchange",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -634,7 +634,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -683,7 +683,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -693,7 +693,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -712,7 +712,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -727,7 +727,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/onremovetrack",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -737,7 +737,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -786,7 +786,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -796,7 +796,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -815,7 +815,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -831,7 +831,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/removetrack_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -841,7 +841,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -890,7 +890,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -900,7 +900,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -919,7 +919,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": false
             }
           },
           "status": {
@@ -934,7 +934,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/selectedIndex",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -944,7 +944,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "37",
               "flags": [
                 {
                   "type": "preference",
@@ -993,7 +993,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",
@@ -1003,7 +1003,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "24",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
That was M37 based on the date: https://www.chromium.org/developers/calendar

Note that https://storage.googleapis.com/chromium-find-releases-static/cb9.html#cb9c513a764a62acd2da76e04c3e7ec3ab7e0dfa
claiming this was added in M45 is wrong because this change happened 
before Blink was merged into the Chromium tree.

The AudioVideoTracks has never been enabled by default.

The audioTrack and videoTrack attributes on SourceBuffer were added
later, in April/March 2016, behind the same flag:
https://chromium.googlesource.com/chromium/src/+/1b3dc5a8202a332891b6aed5d4d4521db0b26261
https://chromium.googlesource.com/chromium/src/+/92333c0e5ca6b7768e5bcf6d41ff8fc733ebbfc1

These changes were in M51:
https://storage.googleapis.com/chromium-find-releases-static/1b3.html#1b3dc5a8202a332891b6aed5d4d4521db0b26261
https://storage.googleapis.com/chromium-find-releases-static/923.html#92333c0e5ca6b7768e5bcf6d41ff8fc733ebbfc1

The data was mirrored for Edge and Opera. Samsung Internet and WebView
don't use flags.

Fixes https://github.com/mdn/browser-compat-data/issues/5781.