### PR TITLE
fix(css): unprefix content size values for Safari and Opera

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -104,6 +104,9 @@
               },
               "safari": [
                 {
+                  "version_added": "11"
+                },
+                {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 },
@@ -113,6 +116,9 @@
                 }
               ],
               "safari_ios": [
+                {
+                  "version_added": "11"
+                },
                 {
                   "prefix": "-webkit-",
                   "version_added": "7"

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -99,6 +99,9 @@
               },
               "safari": [
                 {
+                  "version_added": "11"
+                },
+                {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 },
@@ -108,6 +111,9 @@
                 }
               ],
               "safari_ios": [
+                {
+                  "version_added": "11"
+                },
                 {
                   "prefix": "-webkit-",
                   "version_added": "7"
@@ -191,6 +197,9 @@
               },
               "safari": [
                 {
+                  "version_added": "11"
+                },
+                {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 },
@@ -200,6 +209,9 @@
                 }
               ],
               "safari_ios": [
+                {
+                  "version_added": "11"
+                },
                 {
                   "prefix": "-webkit-",
                   "version_added": "7"
@@ -283,6 +295,9 @@
               },
               "safari": [
                 {
+                  "version_added": "11"
+                },
+                {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 },
@@ -292,6 +307,9 @@
                 }
               ],
               "safari_ios": [
+                {
+                  "version_added": "11"
+                },
                 {
                   "prefix": "-webkit-",
                   "version_added": "7"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -150,6 +150,9 @@
               },
               "safari": [
                 {
+                  "version_added": "11"
+                },
+                {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 },
@@ -159,6 +162,9 @@
                 }
               ],
               "safari_ios": [
+                {
+                  "version_added": "11"
+                },
                 {
                   "prefix": "-webkit-",
                   "version_added": "6.1"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -158,10 +158,15 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "opera": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                }
+              ],
               "opera_android": {
                 "version_added": "33"
               },
@@ -250,10 +255,15 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "opera": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                }
+              ],
               "opera_android": {
                 "version_added": "33"
               },


### PR DESCRIPTION
Tested with [BrowserStack](https://www.browserstack.com/) on an iPhone 8 Plus (iOS 11) and macOS High Sierra.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
