### PR TITLE
Update when getUserMedia() shipped in Chromium

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -367,11 +367,11 @@
           "support": {
             "chrome": {
               "version_added": "53",
-              "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+              "notes": "If you need this capability before version 53, refer to <code>navigator.webkitGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
             },
             "chrome_android": {
               "version_added": "53",
-              "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+              "notes": "If you need this capability before version 53, refer to <code>navigator.webkitGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
             },
             "edge": {
               "version_added": "12"
@@ -379,7 +379,7 @@
             "firefox": {
               "version_added": "36",
               "notes": [
-                "Older versions of Firefox implement <code>navigator.mozGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API.",
+                "If you need this capability before version 36, refer to <code>navigator.mozGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API.",
                 "Before Firefox 55, <code>getUserMedia()</code> incorrectly returns <code>NotSupportedError</code> when the list of constraints specified is empty, or has all constraints set to <code>false</code>. Starting in Firefox 55, this situation now correctly calls the failure handler with a <code>TypeError</code>.",
                 "When using the Firefox-specific <code>video</code> constraint called <code>mediaSource</code> to request display capture, Firefox 66 and later consider values of <code>screen</code> and <code>window</code> to both cause a list of screens <em>and</em> windows to be shown.",
                 "Starting in Firefox 66, <code>getUserMedia()</code> can no longer be used in sandboxed <code>&lt;iframe&gt;</code>s or <code>data</code> URLs entered in the address bar by the user."
@@ -388,7 +388,7 @@
             "firefox_android": {
               "version_added": "36",
               "notes": [
-                "Older versions of Firefox implement <code>navigator.mozGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API.",
+                "If you need this capability before version 36, refer to <code>navigator.mozGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API.",
                 "Before Firefox 55, <code>getUserMedia()</code> incorrectly returns <code>NotSupportedError</code> when the list of constraints specified is empty, or has all constraints set to <code>false</code>. Starting in Firefox 55, this situation now correctly calls the failure handler with a <code>TypeError</code>.",
                 "When using the Firefox-specific <code>video</code> constraint called <code>mediaSource</code> to request display capture, Firefox 66 and later consider values of <code>screen</code> and <code>window</code> to both cause a list of screens <em>and</em> windows to be shown.",
                 "Starting in Firefox 66, <code>getUserMedia()</code> can no longer be used in sandboxed <code>&lt;iframe&gt;</code>s or <code>data</code> URLs entered in the address bar by the user."
@@ -399,11 +399,11 @@
             },
             "opera": {
               "version_added": "40",
-              "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+              "notes": "If you need this capability before version 40, refer to <code>navigator.webkitGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
             },
             "opera_android": {
               "version_added": "41",
-              "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+              "notes": "If you need this capability before version 41, refer to <code>navigator.webkitGetUserMedia</code>, a prefixed form of the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
             },
             "safari": {
               "version_added": "11"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -367,11 +367,11 @@
           "support": {
             "chrome": [
               {
-                "version_added": "52"
+                "version_added": "53"
               },
               {
                 "version_added": "47",
-                "version_removed": "52",
+                "version_removed": "53",
                 "flags": [
                   {
                     "type": "preference",
@@ -384,11 +384,11 @@
             ],
             "chrome_android": [
               {
-                "version_added": "52"
+                "version_added": "53"
               },
               {
                 "version_added": "47",
-                "version_removed": "52",
+                "version_removed": "53",
                 "flags": [
                   {
                     "type": "preference",
@@ -481,10 +481,10 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "53"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "53"
               },
               "edge": {
                 "version_added": "79"
@@ -499,10 +499,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "40"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "41"
               },
               "safari": {
                 "version_added": null
@@ -511,10 +511,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "53"
               }
             },
             "status": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -365,40 +365,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
-              }
-            ],
+            "chrome": {
+              "version_added": "53",
+              "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+            },
+            "chrome_android": {
+              "version_added": "53",
+              "notes": "Older versions of Chrome implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+            },
             "edge": {
               "version_added": "12"
             },
@@ -423,40 +397,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "40"
-              },
-              {
-                "version_added": "34",
-                "version_removed": "40",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "34",
-                "version_removed": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
-              }
-            ],
+            "opera": {
+              "version_added": "40",
+              "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+            },
+            "opera_android": {
+              "version_added": "41",
+              "notes": "Older versions of Opera implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+            },
             "safari": {
               "version_added": "11"
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -978,8 +978,7 @@
               },
               {
                 "version_added": "21",
-                "prefix": "webkit",
-                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+                "prefix": "webkit"
               }
             ],
             "chrome_android": [
@@ -988,13 +987,18 @@
               },
               {
                 "version_added": "25",
-                "prefix": "webkit",
-                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+                "prefix": "webkit"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "prefix": "webkit"
+              }
+            ],
             "firefox": {
               "version_added": "17",
               "prefix": "moz",
@@ -1010,20 +1014,30 @@
             },
             "opera": [
               {
-                "version_added": "18",
+                "version_added": "40"
+              },
+              {
+                "version_added": "15",
                 "prefix": "webkit"
               },
               {
                 "version_added": "12",
-                "version_removed": "15",
-                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+                "version_removed": "15"
               }
             ],
-            "opera_android": {
-              "version_added": "12",
-              "version_removed": "14",
-              "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
-            },
+            "opera_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": false
             },
@@ -1036,8 +1050,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": "1.5",
-                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1046,8 +1059,7 @@
               },
               {
                 "version_added": "40",
-                "prefix": "webkit",
-                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+                "prefix": "webkit"
               }
             ]
           },


### PR DESCRIPTION
navigator.mediaDevices.getUserMedia() and navigator.getUserMedia() were
enabled together in M53:
https://chromium.googlesource.com/chromium/src/+/d229d009b74255797c16bef6b7e398a165dbeacd

The data for navigator.getUserMedia() was already correct, except for
Opera where it incorrectly appeared to still be prefixed-only.

The change to require a secure context for these APIs was made long
before it was shipped:
https://chromium.googlesource.com/chromium/src/+/dac67a137b9c8d3be8d51bb9fe8ab761d8b054a7

The versions for api.MediaDevices.getUserMedia.secure_context_required
should thus be the same as for the parent feature.