### PR TITLE
Add Firefox 80 for Android

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -441,9 +441,16 @@
         "79": {
           "release_date": "2020-07-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/79",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "79"
+        },
+        "80": {
+          "release_date": "2020-08-31",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
+          "status": "current",
+          "engine": "Gecko",
+          "engine_version": "80"
         }
       }
     }


### PR DESCRIPTION
According to https://www.mozilla.org/en-US/firefox/android/80.0/releasenotes/, Firefox 80 for Android is released at August 31, 2020.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
