### PR TITLE
Remove the Gamepad() constructor subfeature

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -95,68 +95,6 @@
           "deprecated": false
         }
       },
-      "Gamepad": {
-        "__compat": {
-          "description": "<code>Gamepad()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/Gamepad",
-          "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": {
-              "version_added": "32"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "axes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/axes",


### PR DESCRIPTION
This was added in https://github.com/mdn/browser-compat-data/pull/1760.

However, there's no constructor in https://w3c.github.io/gamepad/#gamepad-interface
and it appears there never was from the spec repo's history. One gets
Gamepad objects from `navigator.getGamepads()` and can't create them.

That browsers also don't support the constructor was verified by their
absense in source code:
 - Chromium: https://chromium.googlesource.com/chromium/src/+/9b50996d6e44f8b5140c33758be20d5a687a8eae/third_party/blink/renderer/modules/gamepad/gamepad.idl
 - Gecko: https://hg.mozilla.org/mozilla-central/file/f22c20641704d783097b1b128d826c8460de7354/dom/webidl/Gamepad.webidl
 - WebKit: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Modules/gamepad/Gamepad.idl?rev=266799

Additionally, `new Gamepad()` was tested in Chrome 85, Edge 18, Firefox
80 and Safari 13.1, and found to throw the same error as for another
non-constructor, `new MediaError()`:
https://software.hixie.ch/utilities/js/live-dom-viewer/saved/8445