### PR TITLE
Update start/stop for Audio[Buffer/Scheduled]SourceNode + OscillatorNode

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -205,10 +205,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/start",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -235,7 +235,7 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -253,10 +253,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/stop",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -283,7 +283,7 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -297,10 +297,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/start",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -329,7 +329,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -347,10 +347,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/stop",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -379,7 +379,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR is a cherry-pick from https://github.com/mdn/browser-compat-data/pull/6642#discussion_r485059170.  It was found that the `start` and `stop` methods were implemented in Chrome 24, not Chrome 14.  This PR updates the data accordingly.

Furthermore, AudioBufferSourceNode had data for `start` but not `stop`.  Since it inherits from AudioScheduledSourceNode, this PR removes AudioBufferSourceNode.start to de-dupe data.  (Due to the removal, it would need a release note.)