### PR TITLE
Update <iframe sandbox=allow-downloads> for Firefox and Chrome

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -787,6 +787,54 @@
             }
           }
         },
+        "sandbox-allow-downloads": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-downloads\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": {
+                "version_added": "83"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "81"
+              },
+              "firefox_android": {
+                "version_added": "81"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sandbox-allow-modals": {
           "__compat": {
             "description": "<code>sandbox=\"allow-modals\"</code>",


### PR DESCRIPTION
I manually tested in Firefox 82 and Chrome 85, but used the following
references for 81 and 83 respectively.

https://bugzilla.mozilla.org/show_bug.cgi?id=1558394
https://www.chromestatus.com/feature/5706745674465280

Fixes #6667