### PR TITLE
Add irrelevant flag data removal data guideline

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -191,4 +191,4 @@ Valid support statements containing flags can be removed from BCD if it is consi
 
 These conditions represent minimum requirements for the removal of valid flag data; other considerations may result in flag data continuing to be relevant, even after the guideline conditions are met.
 
-This guideline was proposed in TODO:
+This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-data/pull/6670).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -2,6 +2,8 @@
 
 This file contains recommendations to help you record data in a consistent and understandable way. It covers the project's preferences for the way features should be represented, rather than hard requirements encoded in the schema definitions or linter logic.
 
+<!-- You can quickly regenerate this TOC by running: npx markdown-toc@1.2.0 --bullets='-' docs/data-guidelines.md -->
+
 - [Data guidelines](#data-guidelines)
   - [Constructors](#constructors)
   - [DOM events (`eventname_event`)](#dom-events-eventname_event)
@@ -12,10 +14,11 @@ This file contains recommendations to help you record data in a consistent and u
   - [Release lines and backported features](#release-lines-and-backported-features)
   - [Safari for iOS versioning](#safari-for-ios-versioning)
   - [Removal of irrelevant features](#removal-of-irrelevant-features)
+  - [Removal of irrelevant flag data](#removal-of-irrelevant-flag-data)
 
 <!-- BEGIN TEMPLATE
 
-## Short title in sentence case
+Short title in sentence case
 
 A description of what to do, preferably in the imperative. If applicable, include an example to illustrate the rule.
 

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -178,3 +178,14 @@ Features can be removed from BCD if it is considered irrelevant. A feature can b
 - a feature is unsupported in all releases in the past five years.
 
 This guideline was proposed in [#6018](https://github.com/mdn/browser-compat-data/pull/6018).
+
+## Removal of irrelevant flag data
+
+Valid support statements containing flags can be removed from BCD if it is considered irrelevant. To be considered irrelevant, the support statement must meet these conditions:
+
+- As of at least two years ago, the browser has supported the feature by default or removed the flagged feature.
+- The removal of the support statement must not create an ambiguous gap or void in the data for that browser (for example, leaving behind only a `"version_added": true` or `null` value).
+
+These conditions represent minimum requirements for the removal of valid flag data; other considerations may result in flag data continuing to be relevant, even after the guideline conditions are met.
+
+This guideline was proposed in TODO:


### PR DESCRIPTION
This PR proposes a limited flag data removal policy, inspired by the [_Removal of irrelevant features_](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features) policy.

The intent here is to allow judicious removals of valid but historic flag data. This should make it easier for contributors to improve data, such as in #6658. Also, please see https://github.com/mdn/browser-compat-data/issues/3318#issuecomment-691034407 for more about the issue of flag data in general.
