### PR TITLE
Fix docs labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,7 @@ dependencies :chains::
   - "package-lock.json"
   - "package.json"
 docs :writing_hand::
-  - "*.md"
+  - "**.md"
 infra :building_construction::
   - ".editorconfig"
   - ".git*"


### PR DESCRIPTION
The labeler missed a file in `docs` on #6671. This should fix it.