### PR TITLE
Firefox Android supports String.replaceAll since v79

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1822,7 +1822,7 @@
                 "version_added": "77"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
I have manually tested this with the [demo on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll).