### PR TITLE
CSS ::marker animations and transitions not supported in WebKit

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -144,10 +144,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "11.3"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
WebKit implemented and earlier version of the spec which didn't include animations and transitions.
See https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/style/PropertyCascade.cpp#L73