### PR TITLE
Update data for Payment APIs

### DIFF
--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -4,62 +4,77 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent",
         "support": {
-          "chrome": {
-            "version_added": "61",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "61",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "edge": {
-            "version_added": "≤79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "edge": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {
@@ -74,61 +89,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent/AbortPaymentEvent",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -143,61 +137,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent/respondWith",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -34,21 +34,9 @@
               ]
             }
           ],
-          "edge": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": false
           },

--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "57"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "49"
           },
           "safari": {
             "version_added": false
@@ -64,7 +64,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "70"
           }
         },
         "status": {
@@ -97,10 +97,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {

--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -6,10 +6,11 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "61",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",
@@ -21,10 +22,11 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "61",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",

--- a/api/AbortPaymentEvent.json
+++ b/api/AbortPaymentEvent.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent",
         "support": {
-          "chrome": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "70"
+          },
+          "chrome_android": {
+            "version_added": "70"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -79,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent/AbortPaymentEvent",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -127,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortPaymentEvent/respondWith",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -6,10 +6,11 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "60"
             },
             {
-              "version_added": "61",
+              "version_added": "58",
+              "version_removed": "60",
               "flags": [
                 {
                   "type": "preference",
@@ -21,10 +22,11 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "56"
             },
             {
               "version_added": "53",
+              "version_removed": "56",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -37,7 +37,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "56",
@@ -75,16 +75,16 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "44"
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -104,7 +104,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/addressLine",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -113,7 +113,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -122,16 +122,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -152,7 +152,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/city",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -161,7 +161,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -170,16 +170,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -200,7 +200,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/country",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -209,7 +209,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -218,16 +218,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -248,7 +248,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/dependentLocality",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -257,7 +257,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -266,16 +266,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -296,7 +296,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/languageCode",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -316,10 +316,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": null
@@ -346,7 +346,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/organization",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -355,7 +355,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -364,16 +364,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -394,7 +394,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/phone",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -403,7 +403,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -412,16 +412,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -442,7 +442,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/postalCode",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -451,7 +451,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -460,16 +460,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -490,7 +490,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/recipient",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -499,7 +499,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -508,16 +508,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -538,7 +538,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/region",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -547,7 +547,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -556,16 +556,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -610,10 +610,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -634,7 +634,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/sortingCode",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
               "version_added": "53"
@@ -643,7 +643,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "56"
@@ -652,16 +652,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -683,16 +683,16 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "58"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "62"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "62"
@@ -701,16 +701,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -14,36 +14,12 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": "56",
-            "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "firefox_android": {
-            "version_added": "56",
-            "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "ie": {
             "version_added": false
@@ -87,10 +63,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -135,10 +113,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -183,10 +163,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -231,10 +213,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -329,10 +313,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -377,10 +363,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -425,10 +413,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -473,10 +463,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -521,10 +513,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -569,10 +563,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "64"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -617,10 +613,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -666,10 +664,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -4,26 +4,36 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress",
         "support": {
-          "chrome": {
-            "version_added": "61",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#web-payments",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "53",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#web-payments",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "53",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-payments",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "edge": {
             "version_added": "≤18"
           },
@@ -63,10 +73,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -75,7 +85,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -92,58 +102,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/addressLine",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -152,7 +132,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -170,58 +150,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/city",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -230,7 +180,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -248,58 +198,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/country",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -308,7 +228,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -326,58 +246,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/dependentLocality",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -386,7 +276,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -404,60 +294,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/languageCode",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
               "version_added": "56",
-              "version_removed": "63",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "63"
             },
             "firefox_android": {
               "version_added": "56",
-              "version_removed": "63",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "63"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -466,7 +326,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -484,58 +344,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/organization",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -544,7 +374,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -562,58 +392,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/phone",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -622,7 +422,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -640,58 +440,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/postalCode",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -700,7 +470,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -718,58 +488,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/recipient",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -778,7 +518,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -796,58 +536,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/region",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -856,7 +566,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -883,26 +593,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "64"
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "64"
             },
             "ie": {
               "version_added": false
@@ -938,58 +632,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/sortingCode",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -998,7 +662,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1017,58 +681,28 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "62",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": "62",
-              "notes": "Available only in nightly builds. Requires the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -1077,7 +711,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress",
         "support": {
-          "chrome": [
-            {
-              "version_added": "60"
-            },
-            {
-              "version_added": "58",
-              "version_removed": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "60"
+          },
+          "chrome_android": {
+            "version_added": "56"
+          },
           "edge": {
             "version_added": "15"
           },
@@ -104,10 +78,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/addressLine",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -152,10 +126,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/city",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -200,10 +174,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/country",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -248,10 +222,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/dependentLocality",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -296,10 +270,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/languageCode",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -346,10 +320,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/organization",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -394,10 +368,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/phone",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -442,10 +416,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/postalCode",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -490,10 +464,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/recipient",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -538,10 +512,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/region",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -634,10 +608,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/sortingCode",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -683,10 +657,10 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -6,10 +6,11 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "59",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",
@@ -21,10 +22,11 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "59",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -34,21 +34,9 @@
               ]
             }
           ],
-          "edge": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": false
           },

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -4,36 +4,51 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentInstruments",
         "support": {
-          "chrome": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "edge": {
-            "version_added": "≤79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "edge": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -41,25 +56,25 @@
             "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {
@@ -74,34 +89,13 @@
           "description": "<code>clear()</code>",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -110,25 +104,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -144,34 +138,13 @@
           "description": "<code>delete()</code>",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -180,25 +153,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -214,34 +187,13 @@
           "description": "<code>get()</code>",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -250,25 +202,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -284,34 +236,13 @@
           "description": "<code>has()</code>",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -320,25 +251,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -354,34 +285,13 @@
           "description": "<code>keys()</code>",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -390,25 +300,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -424,34 +334,13 @@
           "description": "<code>set()</code>",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -460,25 +349,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -184,7 +184,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -233,7 +233,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -282,7 +282,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -331,7 +331,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "57"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "49"
           },
           "safari": {
             "version_added": false
@@ -64,7 +64,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "70"
           }
         },
         "status": {
@@ -97,10 +97,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -146,10 +146,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -195,10 +195,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -210,7 +210,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -244,10 +244,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -293,10 +293,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -308,7 +308,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -342,10 +342,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -357,7 +357,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentInstruments",
         "support": {
-          "chrome": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "59",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "59",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "70"
+          },
+          "chrome_android": {
+            "version_added": "70"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -79,10 +53,10 @@
           "description": "<code>clear()</code>",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -128,10 +102,10 @@
           "description": "<code>delete()</code>",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -177,10 +151,10 @@
           "description": "<code>get()</code>",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -226,10 +200,10 @@
           "description": "<code>has()</code>",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -275,10 +249,10 @@
           "description": "<code>keys()</code>",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -324,10 +298,10 @@
           "description": "<code>set()</code>",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -182,7 +182,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "57"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "49"
           },
           "safari": {
             "version_added": false
@@ -64,7 +64,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "70"
           }
         },
         "status": {
@@ -96,10 +96,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -111,7 +111,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -193,10 +193,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -208,7 +208,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -6,10 +6,11 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "59",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",
@@ -21,10 +22,11 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "59",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -4,36 +4,51 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager",
         "support": {
-          "chrome": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "edge": {
-            "version_added": "≤79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "59",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "edge": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -41,25 +56,25 @@
             "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {
@@ -73,34 +88,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/instruments",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -109,25 +103,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -143,34 +137,13 @@
           "description": "<code>requestPermission()</code>",
           "support": {
             "chrome": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -179,25 +152,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -212,34 +185,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/userHint",
           "support": {
             "chrome": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "63"
             },
             "chrome_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "63"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -248,25 +200,25 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -34,21 +34,9 @@
               ]
             }
           ],
-          "edge": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": false
           },

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager",
         "support": {
-          "chrome": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "59",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "59",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "70"
+          },
+          "chrome_android": {
+            "version_added": "70"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -78,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/instruments",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -127,10 +101,10 @@
           "description": "<code>requestPermission()</code>",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -175,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/userHint",
           "support": {
             "chrome": {
-              "version_added": "63"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "63"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -14,36 +14,12 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "63",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "firefox_android": {
-            "version_added": "63",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "ie": {
             "version_added": false
@@ -90,7 +66,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -138,7 +114,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": true
           },
           "edge": {
-            "version_added": false
+            "version_added": true
           },
           "firefox": {
             "version_added": "63",
@@ -49,19 +49,19 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -78,53 +78,37 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/methodDetails",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "85"
             },
             "firefox": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -142,53 +126,37 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/methodName",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "85"
             },
             "firefox": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "76"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "76"
           },
           "edge": {
-            "version_added": true
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "63",
@@ -49,16 +49,16 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "63"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "54"
           },
           "safari": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -78,16 +78,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/methodDetails",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "76"
             },
             "edge": {
-              "version_added": "85"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "63"
@@ -96,16 +96,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -126,16 +126,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/methodName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "76"
             },
             "edge": {
-              "version_added": "85"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "63"
@@ -144,16 +144,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
             "version_added": "11.1"
@@ -113,10 +113,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -243,10 +243,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -307,10 +307,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -372,10 +372,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null
@@ -402,13 +402,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onmerchantvalidation",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "64",
@@ -442,13 +442,13 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -466,13 +466,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onpaymentmethodchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "firefox": {
               "version_added": "63",
@@ -500,19 +500,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -564,10 +564,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -628,10 +628,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -694,10 +694,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -889,10 +889,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -953,10 +953,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -1018,10 +1018,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -1082,10 +1082,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"
@@ -1146,10 +1146,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": "11.1"

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "44"
           },
           "safari": {
             "version_added": "11.1"
@@ -113,10 +113,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -209,7 +209,7 @@
           "description": "<code>canMakePayment()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -243,10 +243,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -307,10 +307,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -442,7 +442,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": true
@@ -466,13 +466,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onpaymentmethodchange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "76"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63",
@@ -500,13 +500,13 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": true
@@ -564,10 +564,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -628,10 +628,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -694,10 +694,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": null
@@ -889,10 +889,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -953,10 +953,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -1018,10 +1018,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -1082,10 +1082,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"
@@ -1146,10 +1146,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -14,36 +14,12 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": "55",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "firefox_android": {
-            "version_added": "55",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "ie": {
             "version_added": false
@@ -88,26 +64,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -153,26 +115,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -218,26 +166,12 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -282,26 +216,12 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -347,26 +267,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -411,26 +317,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -475,26 +367,12 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -539,26 +417,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -603,26 +467,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -667,28 +517,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "alternative_name": "shippingAddress",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "alternative_name": "shippingAddress",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
             },
             "ie": {
               "version_added": false
@@ -734,26 +568,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "63",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -799,26 +619,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -864,26 +670,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -928,26 +720,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -993,26 +771,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -1057,26 +821,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -1121,26 +871,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest",
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "60"
           },
           "chrome_android": {
             "version_added": "53"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "55",
@@ -79,13 +79,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/PaymentRequest",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "55",
@@ -144,7 +144,7 @@
           "description": "<code>abort()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -273,7 +273,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/id",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "60"
@@ -530,7 +530,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onshippingaddresschange",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -594,7 +594,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/onshippingoptionchange",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -919,7 +919,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingOption",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -1048,7 +1048,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingType",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "55"
@@ -1112,7 +1112,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/show",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -34,21 +34,9 @@
               ]
             }
           ],
-          "edge": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": false
           },

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "57"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "49"
           },
           "safari": {
             "version_added": false
@@ -64,7 +64,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "70"
           }
         },
         "status": {
@@ -79,7 +79,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/PaymentRequestEvent",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "57"
@@ -97,10 +97,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -127,7 +127,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/instrumentKey",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -175,7 +175,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/methodData",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -193,10 +193,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -208,7 +208,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -223,7 +223,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/modifiers",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -241,10 +241,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -256,7 +256,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -272,7 +272,7 @@
           "description": "<code>openWindow()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "61"
@@ -290,10 +290,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -305,7 +305,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -320,7 +320,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/paymentRequestId",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -338,10 +338,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -353,7 +353,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -368,7 +368,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/paymentRequestOrigin",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -386,10 +386,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -401,7 +401,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -417,7 +417,7 @@
           "description": "<code>respondWith()</code",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "59"
@@ -435,10 +435,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -450,7 +450,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -466,7 +466,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "68"
+                "version_added": "70"
               },
               {
                 "version_added": "61",
@@ -497,10 +497,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -512,7 +512,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {
@@ -527,7 +527,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/total",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": {
               "version_added": "60"
@@ -545,10 +545,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -560,7 +560,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "70"
             }
           },
           "status": {

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -4,36 +4,51 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent",
         "support": {
-          "chrome": {
-            "version_added": "57",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "57",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "edge": {
-            "version_added": "≤79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "57",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "edge": [
+            {
+              "version_added": true
+            },
+            {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -44,22 +59,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {
@@ -74,34 +89,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/PaymentRequestEvent",
           "support": {
             "chrome": {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -113,22 +107,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -143,34 +137,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/instrumentKey",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -182,22 +155,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -212,34 +185,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/methodData",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -251,22 +203,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -281,34 +233,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/modifiers",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -320,22 +251,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -351,34 +282,13 @@
           "description": "<code>openWindow()</code>",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -390,22 +300,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -420,34 +330,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/paymentRequestId",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -459,22 +348,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -489,34 +378,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/paymentRequestOrigin",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -528,22 +396,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -559,34 +427,13 @@
           "description": "<code>respondWith()</code",
           "support": {
             "chrome": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -598,22 +445,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -629,14 +476,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "68"
               },
               {
                 "version_added": "61",
@@ -646,14 +486,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "68"
               },
               {
                 "version_added": "61",
@@ -662,14 +495,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -681,22 +507,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -711,34 +537,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/total",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -750,22 +555,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -182,7 +182,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -327,7 +327,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -375,7 +375,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -424,7 +424,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -472,7 +472,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -520,7 +520,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -6,10 +6,11 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "57",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",
@@ -21,10 +22,11 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "70"
             },
             {
               "version_added": "57",
+              "version_removed": "74",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent",
         "support": {
-          "chrome": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "57",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "70"
-            },
-            {
-              "version_added": "57",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "70"
+          },
+          "chrome_android": {
+            "version_added": "70"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -82,7 +56,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -130,7 +104,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -178,7 +152,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -226,7 +200,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -275,7 +249,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -323,7 +297,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -371,7 +345,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -420,7 +394,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -464,26 +438,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/topOrigin",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "67",
-                "alternative_name": "topLevelOrigin"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "67",
-                "alternative_name": "topLevelOrigin"
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -530,7 +490,7 @@
               "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -24,7 +24,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "56",
@@ -62,16 +62,16 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -98,7 +98,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "56",
@@ -126,16 +126,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -191,16 +191,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -14,36 +14,12 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": "56",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "firefox_android": {
-            "version_added": "56",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "ie": {
             "version_added": false
@@ -88,26 +64,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -153,26 +115,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -62,10 +62,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -94,22 +94,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "≤79"
             },
@@ -139,16 +126,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -172,22 +159,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -217,10 +191,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": "60"
           },
-          "chrome_android": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome_android": {
+            "version_added": "56"
+          },
           "edge": {
             "version_added": "15"
           },
@@ -95,7 +82,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -160,7 +147,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestUpdateEvent",
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": "60"
           },
           "chrome_android": [
             {
@@ -92,7 +92,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestUpdateEvent/PaymentRequestUpdateEvent",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -157,7 +157,7 @@
           "description": "<code>updateWith()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -34,7 +34,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -14,36 +14,12 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": "55",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "firefox_android": {
-            "version_added": "55",
-            "notes": "Available only in nightly builds.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false,
+            "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
           },
           "ie": {
             "version_added": false
@@ -88,26 +64,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -152,26 +114,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -216,26 +164,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -284,7 +218,7 @@
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "ie": {
@@ -331,11 +265,11 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "ie": {
@@ -381,26 +315,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -445,26 +365,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -509,26 +415,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -573,26 +465,12 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -641,7 +519,7 @@
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "ie": {
@@ -687,26 +565,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -751,26 +615,12 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "56",
-              "notes": "Available only in nightly builds.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false,
+              "notes": "Available only in nightly builds."
             },
             "ie": {
               "version_added": false
@@ -820,7 +670,7 @@
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
-              "version_added": "62",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "ie": {

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": "60"
           },
-          "chrome_android": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "51",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome_android": {
+            "version_added": "56"
+          },
           "edge": {
             "version_added": "15"
           },
@@ -95,7 +82,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -159,7 +146,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -223,7 +210,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -388,7 +375,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -516,7 +503,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -694,7 +681,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -758,7 +745,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -823,7 +810,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse",
         "support": {
           "chrome": {
-            "version_added": "56"
+            "version_added": "60"
           },
           "chrome_android": [
             {
@@ -92,7 +92,7 @@
           "description": "<code>complete()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -156,7 +156,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/details",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -220,7 +220,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/methodName",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -385,7 +385,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerEmail",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -449,7 +449,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerName",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "58"
@@ -513,7 +513,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerPhone",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -577,7 +577,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/requestId",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "60"
@@ -691,7 +691,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingAddress",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -755,7 +755,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/shippingOption",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -820,7 +820,7 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "55"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -24,7 +24,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "55",
@@ -62,13 +62,13 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
             "version_added": true
@@ -126,16 +126,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -190,16 +190,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -254,16 +254,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -284,13 +284,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/onpayerdetailchange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "78"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -304,16 +304,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -419,16 +419,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -483,16 +483,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -547,16 +547,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -611,16 +611,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -647,7 +647,7 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "85"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -661,16 +661,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -725,16 +725,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -789,16 +789,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -840,16 +840,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -62,10 +62,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -94,22 +94,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -139,10 +126,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -171,22 +158,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -216,10 +190,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -248,22 +222,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -293,10 +254,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -323,16 +284,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/onpayerdetailchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
@@ -343,19 +304,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -426,22 +387,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -471,10 +419,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -535,10 +483,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -567,22 +515,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -612,10 +547,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -676,10 +611,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -712,10 +647,10 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "85"
             },
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
@@ -726,16 +661,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -758,22 +693,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -803,10 +725,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -835,22 +757,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -880,10 +789,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -913,27 +822,14 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "55",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome_android": {
+              "version_added": "55"
+            },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "62",
+              "version_added": false,
               "notes": "Available only in nightly builds."
             },
             "firefox_android": {
@@ -944,10 +840,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
When pulling data from the `mdn-bcd-collector` project I've been working on, I noticed a few odd discrepancies with data reported by the collector and BCD's data.  It turns out that support for the Payment APIs is in more browsers than we initially thought.  This PR does the following to fix these discrepancies, plus adjust our data in a desirable way:

1) Updates the data to reflect what was found based upon testing with the collector and manual testing (Opera, Opera Android, and Samsung Internet all support the APIs, apparently -- WebView has partial API support, though this is probably not intentional)
2) Removes repeated flag information for the API's subfeatures (we don't need to mention the flag for PaymentResponse.complete, for example, when PaymentResponse already has it)

The data for these interfaces was, to put it simply, quite the mess.  This PR hopefully resolves the mess.