### PR TITLE
Fix the names of the IE11 fullscreen events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4923,7 +4923,7 @@
             ],
             "ie": {
               "version_added": "11",
-              "alternative_name": "msfullscreenchange"
+              "alternative_name": "MSFullscreenChange"
             },
             "opera": {
               "version_added": "32"
@@ -5136,7 +5136,7 @@
             ],
             "ie": {
               "version_added": "11",
-              "alternative_name": "msfullscreenerror"
+              "alternative_name": "MSFullscreenError"
             },
             "opera": {
               "version_added": "32"


### PR DESCRIPTION
While the event handler attributes are all-lowercase, even event types
are not. Tested with this code:
```html
<!doctype html>
<button>go fullscreen</button>
<pre></pre>
<script>
var button = document.querySelector('button');
button.onclick = function() { document.body.msRequestFullscreen(); }

var pre = document.querySelector("pre");
document.addEventListener("MSFullscreenChange", function (event) {
  pre.textContent = event.type;
});
</script>
```

Using "msfullscreenchange" as the event type doesn't work there.

This reverts part of https://github.com/mdn/browser-compat-data/pull/6511.