### PR TITLE
datalist doesn't work starting Firefox for Android v67

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -19,7 +19,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "The dropdown menu containing available options does not appear in Firefox for Android starting version 67 - see <a href='https://bugzil.la/1535985'>bug 1535985</a>."
+              "notes": "Since Firefox for Android 79, the dropdown menu containing available options does not appear. See <a href='https://bugzil.la/1535985'>bug 1535985</a>."
             },
             "ie": {
               "version_added": "10"

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -19,7 +19,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "The dropdown menu containing available options does not appear in Firefox for Android starting version 67 - see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1535985'>bug 1535985</a>."
+              "notes": "The dropdown menu containing available options does not appear in Firefox for Android starting version 67 - see <a href='https://bugzil.la/1535985'>bug 1535985</a>."
             },
             "ie": {
               "version_added": "10"

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,7 +18,8 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "The dropdown menu containing available options does not appear in Firefox for Android starting version 67 - see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1535985'>bug 1535985</a>."
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
* up to v80 stable as of this proposal
* also affects v81 beta (but left out of proposal as we should track only stable releases)
* bug is being tracked here - https://bugzilla.mozilla.org/show_bug.cgi?id=1535985

I have personally tested this on Firefox for Android v80 Stable and Firefox for Android v81 Beta.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
