### PR TITLE
Update data for DOMError API

### DIFF
--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -5,27 +5,42 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
+          },
+          "chrome_android": {
+            "version_added": true
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
             "version_added": "12",
-            "version_removed": "58"
+            "version_removed": "69"
           },
           "firefox_android": {
-            "version_added": true,
-            "version_removed": "58"
+            "version_added": "12",
+            "version_removed": "69"
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
-            "version_added": null
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
           }
         },
         "status": {
@@ -39,27 +54,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError/message",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
             },
             "edge": {
               "version_added": "≤18"
             },
             "firefox": {
               "version_added": "12",
-              "version_removed": "58"
+              "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": true,
-              "version_removed": "58"
+              "version_added": "12",
+              "version_removed": "69"
             },
             "ie": {
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {
@@ -74,27 +104,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError/name",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "12",
-              "version_removed": "58"
+              "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": true,
-              "version_removed": "58"
+              "version_added": "12",
+              "version_removed": "69"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
             }
           },
           "status": {

--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -18,8 +18,8 @@
             "version_removed": "69"
           },
           "firefox_android": {
-            "version_added": "12",
-            "version_removed": "69"
+            "version_added": "14",
+            "version_removed": "79"
           },
           "ie": {
             "version_added": "10"
@@ -35,7 +35,7 @@
           ],
           "opera_android": [
             {
-              "version_added": "23"
+              "version_added": "24"
             },
             {
               "version_added": "≤12.1",
@@ -79,8 +79,8 @@
               "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": "12",
-              "version_removed": "69"
+              "version_added": "14",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": null
@@ -129,8 +129,8 @@
               "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": "12",
-              "version_removed": "69"
+              "version_added": "14",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": "10"

--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMError",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "36"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "36"
           },
           "edge": {
             "version_added": "12"
@@ -22,14 +22,26 @@
             "version_removed": "69"
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "23"
+            },
+            {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "23"
+            },
+            {
+              "version_added": "≤12.1",
+              "version_removed": "14"
+            }
+          ],
           "safari": {
             "version_added": false
           },
@@ -37,10 +49,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -121,7 +133,7 @@
               "version_removed": "69"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates the data for the DOMError API in three ways:

1) Adds the additional browsers such as Opera Android, Safari iOS, etc.
2) Adds version numbers based upon manual testing (https://mdn-bcd-collector.appspot.com/tests/api/DOMError)
3) Updates the version when the API was removed from Firefox from mdn-bcd-collector results