### PR TITLE
Update data for Acceleration/Orientation Sensor APIs

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -5,22 +5,25 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbsoluteOrientationSensor",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
             "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
@@ -28,11 +31,14 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -47,22 +53,25 @@
           "description": "<code>AbsoluteOrientationSensor()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
@@ -70,11 +79,14 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Accelerometer",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -53,13 +53,13 @@
           "description": "<code>Accelerometer()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -101,13 +101,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Accelerometer/x",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -119,7 +119,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
@@ -131,10 +131,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -149,13 +149,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Accelerometer/y",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
@@ -179,10 +179,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -197,13 +197,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Accelerometer/z",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
@@ -227,10 +227,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/Gyroscope.json
+++ b/api/Gyroscope.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gyroscope",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -53,40 +53,40 @@
           "description": "<code>Gyroscope()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -101,40 +101,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gyroscope/x",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -149,40 +149,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gyroscope/y",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -197,40 +197,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gyroscope/z",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -5,34 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/LinearAccelerationSensor",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -47,34 +53,40 @@
           "description": "<code>LinearAccelerationSensor()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -89,40 +101,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LinearAccelerationSensor/x",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -137,40 +149,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LinearAccelerationSensor/y",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -185,40 +197,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LinearAccelerationSensor/z",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/OrientationSensor.json
+++ b/api/OrientationSensor.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OrientationSensor",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -52,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OrientationSensor/populateMatrix",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -100,40 +100,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OrientationSensor/quaternion",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -5,34 +5,34 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RelativeOrientationSensor",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -47,34 +47,34 @@
           "description": "<code>RelativeOrientationSensor()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the version data for the six acceleration/orientation sensor APIs with the help of the mdn-bcd-collector project.  The collector reported that these APIs were introduced in Chrome 67 rather than Chrome 69, and I've confirmed this to be true, so this PR updates the Chromium data accordingly.  It also sets the other browsers that were null to the appropriate values (which was `false` for all of them).

Tests used:
https://mdn-bcd-collector.appspot.com/tests/api/AbsoluteOrientationSensor
https://mdn-bcd-collector.appspot.com/tests/api/Accelerometer
https://mdn-bcd-collector.appspot.com/tests/api/Gyroscope
https://mdn-bcd-collector.appspot.com/tests/api/LinearAccelerationSensor
https://mdn-bcd-collector.appspot.com/tests/api/OrientationSensor
https://mdn-bcd-collector.appspot.com/tests/api/RelativeOrientationSensor