### PR TITLE
Update Edge browser data.

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -84,19 +84,26 @@
         "84": {
           "release_date": "2020-07-16",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-84052240-july-16",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "84"
         },
         "85": {
-          "status": "beta",
+          "release_date": "2020-08-27",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-85056441-august-27",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "85"
         },
         "86": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "86"
+        },
+        "87": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "87"
         }
       }
     }


### PR DESCRIPTION
Edge 85 was promoted to the stable channel in August:
https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-85056441-august-27

Version 86 is in the [beta channel](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-beta-channel#version-86062211-september-9) and the canary channel has Edge 87.
