### PR TITLE
Add release information for WakeLockSentinel.released

### DIFF
--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -143,6 +143,54 @@
           }
         }
       },
+      "released": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/released",
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "87"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/type",


### PR DESCRIPTION
This was added to the spec in [1], and to Blink in [2], which is present
since Chromium 87.

[1] https://github.com/w3c/screen-wake-lock/pull/279
[2] https://chromium-review.googlesource.com/c/chromium/src/+/2379740

(The MDN page depends on mdn/sprints#3691)
