### PR TITLE
Update data for Sensor and SensorErrorEvent APIs

### DIFF
--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -52,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/activated",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -100,40 +100,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/hasReading",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -148,40 +148,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/onactivate",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -196,40 +196,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/onerror",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -244,40 +244,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/onreading",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -292,40 +292,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/start",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -340,40 +340,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/stop",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -388,40 +388,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sensor/timestamp",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SensorErrorEvent",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "67"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "56"
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "67"
           }
         },
         "status": {
@@ -53,40 +53,40 @@
           "description": "<code>SensorErrorEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {
@@ -101,40 +101,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SensorErrorEvent/error",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "67"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the version data for the Sensor and SensorErrorEvent APIs with the help of the mdn-bcd-collector project.  The collector reported that these APIs were introduced in Chrome 67 rather than Chrome 69, and I've confirmed this to be true, so this PR updates the Chromium data accordingly.  It also sets the other browsers that were null to the appropriate values (which was `false` for all of them).

Tests used:
https://mdn-bcd-collector.appspot.com/tests/api/Sensor
https://mdn-bcd-collector.appspot.com/tests/api/SensorErrorEvent