### PR TITLE
Add Firefox for Android 81

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -451,6 +451,11 @@
           "status": "current",
           "engine": "Gecko",
           "engine_version": "80"
+        },
+        "81": {
+          "status": "beta",
+          "engine": "Gecko",
+          "engine_version": "81"
         }
       }
     }


### PR DESCRIPTION
It's [in progress](https://github.com/mozilla-mobile/fenix/releases/tag/v81.1.1-beta.5), but it's not obvious to when the Android releases drop.

This is primarily to unblock #6668.