### PR TITLE
Fix AmbientLightSensor+Magnetometer API data

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -160,7 +160,7 @@
               "notes": "In Opera 66, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
             "opera_android": {
-              "version_added": "48",
+              "version_added": "43",
               "notes": "In Opera for Android 57, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
             "safari": {

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -6,24 +6,74 @@
         "support": {
           "chrome": [
             {
-              "version_added": "54"
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             {
-              "version_added": "69",
-              "notes": "Based on Generic Sensor API."
+              "version_added": "56",
+              "version_removed": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
             }
           ],
           "chrome_android": [
             {
-              "version_added": "54"
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             {
-              "version_added": "69",
-              "notes": "Based on Generic Sensor API."
+              "version_added": "56",
+              "version_removed": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
             }
           ],
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-generic-sensor",
+                "value_to_set": "Enabled"
+              },
+              {
+                "type": "preference",
+                "name": "#enable-generic-sensor-extra-classes",
+                "value_to_set": "Enabled"
+              }
+            ]
           },
           "firefox": {
             "version_added": false
@@ -34,36 +84,74 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "56"
-          },
-          "opera_android": {
-            "version_added": "48"
-          },
+          "opera": [
+            {
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "43",
+              "version_removed": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "46",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "43",
+              "version_removed": "46",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": false
           },
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "6.0"
-            },
-            {
-              "version_added": "10.0",
-              "notes": "Based on Generic Sensor API."
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "54"
-            },
-            {
-              "version_added": "69",
-              "notes": "Based on Generic Sensor API."
-            }
-          ]
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -76,26 +164,14 @@
           "description": "<code>AmbientLightSensor()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AmbientLightSensor/AmbientLightSensor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,10 +183,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -118,24 +194,12 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "version_added": "10.0",
-                "notes": "Based on Generic Sensor API."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -148,34 +212,16 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AmbientLightSensor/illuminance",
           "support": {
-            "chrome": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              },
-              {
-                "version_added": "79",
-                "notes": "Stopped returning floats and returned integers avoid fingerprinting."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              },
-              {
-                "version_added": "79",
-                "notes": "Stopped returning floats and returned integers avoid fingerprinting."
-              }
-            ],
+            "chrome": {
+              "version_added": "56",
+              "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+            },
+            "chrome_android": {
+              "version_added": "56",
+              "notes": "In Chrome for Android 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+            },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -187,10 +233,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43",
+              "notes": "In Opera 66, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "In Opera for Android 57, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
             "safari": {
               "version_added": false
@@ -198,28 +246,12 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "version_added": "10.0",
-                "notes": "Based on Generic Sensor API."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "69",
-                "notes": "Based on Generic Sensor API."
-              },
-              {
-                "version_added": "79",
-                "notes": "Stopped returning floats and returned integers avoid fingerprinting."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -4,73 +4,32 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AmbientLightSensor",
         "support": {
-          "chrome": [
-            {
-              "version_added": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "56",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": "56",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "edge": {
             "version_added": "79",
             "flags": [
               {
                 "type": "preference",
-                "name": "#enable-generic-sensor",
-                "value_to_set": "Enabled"
-              },
-              {
-                "type": "preference",
-                "name": "#enable-generic-sensor-extra-classes",
+                "name": "#enable-experimental-web-platform-features",
                 "value_to_set": "Enabled"
               }
             ]
@@ -84,62 +43,26 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "43",
-              "version_removed": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "46",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "43",
-              "version_removed": "46",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "43",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "opera_android": {
+            "version_added": "43",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "safari": {
             "version_added": false
           },

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -4,41 +4,153 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Magnetometer",
         "support": {
-          "chrome": {
-            "version_added": "69"
-          },
-          "chrome_android": {
-            "version_added": "69"
-          },
+          "chrome": [
+            {
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "56",
+              "version_removed": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "56",
+              "version_removed": "62",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-generic-sensor",
+                "value_to_set": "Enabled"
+              },
+              {
+                "type": "preference",
+                "name": "#enable-generic-sensor-extra-classes",
+                "value_to_set": "Enabled"
+              }
+            ]
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "56"
-          },
-          "opera_android": {
-            "version_added": "48"
-          },
+          "opera": [
+            {
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "43",
+              "version_removed": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "46",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor-extra-classes",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "43",
+              "version_removed": "46",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-generic-sensor",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": false
           }
         },
         "status": {
@@ -53,40 +165,40 @@
           "description": "<code>Magnetometer()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {
@@ -101,40 +213,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Magnetometer/x",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {
@@ -149,40 +261,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Magnetometer/y",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {
@@ -197,40 +309,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Magnetometer/z",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -4,73 +4,32 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Magnetometer",
         "support": {
-          "chrome": [
-            {
-              "version_added": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "56",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": "56",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "edge": {
             "version_added": "79",
             "flags": [
               {
                 "type": "preference",
-                "name": "#enable-generic-sensor",
-                "value_to_set": "Enabled"
-              },
-              {
-                "type": "preference",
-                "name": "#enable-generic-sensor-extra-classes",
+                "name": "#enable-experimental-web-platform-features",
                 "value_to_set": "Enabled"
               }
             ]
@@ -84,62 +43,26 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "43",
-              "version_removed": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "46",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "43",
-              "version_removed": "46",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "43",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "opera_android": {
+            "version_added": "43",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "safari": {
             "version_added": false
           },


### PR DESCRIPTION
This PR updates all of the data for the `AmbientLightSensor` API.  When running results from the mdn-bcd-collector project, I noticed that it was reporting that the API was not supported in Chrome.  Doing some digging around, it looks like the data was added very, _very_ incorrectly.

First off, the `AmbientLightSensor` API had always been based upon the Generic Sensor API since it was first implemented.  Second, neither API was exposed by default -- the #enable-generic-sensor flag needed to be enabled (and then later, the #enable-generic-sensor-extra-classes as well).

This data was determined by testing for `'AmbientLightSensor' in self;` and `'Magnetometer' in self;` in BrowserStack in various Chrome versions with different flags.