### PR TITLE
Drop the "light-level" Media Queries at-rule

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -854,55 +854,6 @@
             }
           }
         },
-        "light-level": {
-          "__compat": {
-            "description": "<code>light-level</code> media feature",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/light-level",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "media_features": {
           "__compat": {
             "description": "Media feature expressions",


### PR DESCRIPTION
This change completely drops the `light-level` Media Queries at-rule from BCD. It was never implemented in any browser engine, and has now been removed from the Media Queries spec:

* https://drafts.csswg.org/mediaqueries-5/#changes-since-2020-07-15
  > Remove the `light-level` media feature as it is redundant with `prefers-contrast` and `prefers-color-scheme`; add examples of how these media features may be automatically inferred by the user agent based on the same factors `light-level` was expected to respond to.
* https://github.com/w3c/csswg-drafts/commit/f5b663c
* https://github.com/w3c/csswg-drafts/issues/5359

I also filed https://github.com/mdn/sprints/issues/3695 to delete the https://developer.mozilla.org/en-US/docs/Web/CSS/@media/light-level MDN article.