### PR TITLE
Remove constructor from CSSTransition

### DIFF
--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -46,65 +46,17 @@
           "deprecated": false
         }
       },
-      "CSSTransition": {
-        "__compat": {
-          "description": "<code>CSSTransition()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": "78"
-            },
-            "chrome_android": {
-              "version_added": "78"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "78"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "transitionProperty": {
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "84"
             },
             "chrome_android": {
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "75"


### PR DESCRIPTION
This PR removes the constructor data for the `CSSTransition` API.  As per the spec (https://drafts.csswg.org/css-transitions-2/#the-CSSTransition-interface), this interface should not have a constructor.  It looks like I had added it in on https://github.com/mdn/browser-compat-data/pull/6372, but I don't know how I determined that Chrome supported the constructor...  (No browser has constructor support.)