### PR TITLE
Mark ondragexit handler and dragexit event as standard_track:false, and deprecated:true

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3414,8 +3414,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1121,8 +1121,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks the `ondragexit` event handler and `dragexit` event as standard_track:false and deprecated:true — because they have now been removed from the HTML spec:

* https://github.com/whatwg/html/commit/40e3868b09f17fc12860596b990bb56bc5cc2a3f
* https://github.com/whatwg/html/issues/2741