### PR TITLE
Implement 2.0.0 breaking changes

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-[mdn-browser-compat-data](https://github.com/mdn/browser-compat-data) (also often referred to as "BCD") is an open source project that depends on contributions from the community. As long as they abide by the project’s Contribution Guidelines, anyone may contribute to the project at any time by submitting code, participating in discussions, making suggestions, or any other contribution they see fit. This document describes how various types of contributors work within the mdn-browser-compat-data project and how decisions are made.
+[`@mdn/browser-compat-data`](https://github.com/mdn/browser-compat-data) (also often referred to as "BCD") is an open source project that depends on contributions from the community. As long as they abide by the project’s Contribution Guidelines, anyone may contribute to the project at any time by submitting code, participating in discussions, making suggestions, or any other contribution they see fit. This document describes how various types of contributors work within the `@mdn/browser-compat-data` project and how decisions are made.
 
 ## Roles and Responsibilities
 
@@ -66,7 +66,7 @@ A Peer who shows an above-average level of contribution to the project, particul
 
 ### Owners
 
-The mdn-browser-compat-data project is jointly governed by the [Mozilla MDN staff team](https://wiki.mozilla.org/Engagement/MDN_Durable_Team#Team_Members), the [MDN Product Advisory Board Members](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members), and the [Owner group](#list-of-current-owners). They are collectively responsible for high-level guidance of the project.
+The `@mdn/browser-compat-data` project is jointly governed by the [Mozilla MDN staff team](https://wiki.mozilla.org/Engagement/MDN_Durable_Team#Team_Members), the [MDN Product Advisory Board Members](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members), and the [Owner group](#list-of-current-owners). They are collectively responsible for high-level guidance of the project.
 
 The [Owner group](#list-of-current-owners) has final authority over this project including:
 
@@ -108,7 +108,7 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 ## Additional paths to becoming a Peer or Owner
 
-Some Owners or Peers are also [MDN Content Curators](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Documentation_topics_and_curators) and have thus earned the privilege to be a mdn-browser-compat-data Peer, so that their expertise in a given content area (CSS, HTML, etc.) can help improve the compat data for that same content area. Such Peers are marked in the relevant folders using GitHub’s Code Owner mechanism.
+Some Owners or Peers are also [MDN Content Curators](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Documentation_topics_and_curators) and have thus earned the privilege to be a `@mdn/browser-compat-data` Peer, so that their expertise in a given content area (CSS, HTML, etc.) can help improve the compat data for that same content area. Such Peers are marked in the relevant folders using GitHub’s Code Owner mechanism.
 
 Peers might also be representatives of browser vendors and have expertise and/or access to browser-specific information within their company. Their company name is listed in the Peer list.
 
@@ -162,7 +162,7 @@ The moderator is responsible for summarizing the discussion of each agenda item 
 
 ## Peers and owners emeriti
 
-The mdn-browser-compat-data project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
+The `@mdn/browser-compat-data` project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
 
 - Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
 - Jean-Yves Perrier (@teoli2003) (Former project lead, schema design co-author)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mdn-browser-compat-data
+# `@mdn/browser-compat-data`
 
 [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)
 
@@ -10,7 +10,7 @@ This data can be used in documentation, to build compatibility tables listing
 browser support for APIs. For example:
 [Browser support for WebExtension APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs).
 
-[![npm](https://img.shields.io/npm/v/mdn-browser-compat-data.svg)](https://www.npmjs.com/package/mdn-browser-compat-data)
+[![npm](https://img.shields.io/npm/v/@mdn/browser-compat-data.svg)](https://www.npmjs.com/package/@mdn/browser-compat-data)
 [![Build Status](https://travis-ci.org/mdn/browser-compat-data.svg?branch=master)](https://travis-ci.org/mdn/browser-compat-data)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mozdevnet.svg?style=social&label=Follow&style=plastic)](https://twitter.com/MozDevNet)
 
@@ -20,16 +20,16 @@ Chat on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org)
 
 ## Installation
 
-You can install mdn-browser-compat-data as a node package.
+You can install `@mdn/browser-compat-data` as a node package.
 
 ```
-npm install mdn-browser-compat-data
+npm install @mdn/browser-compat-data
 ```
 
 ## Usage
 
 ```js
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 bcd.css.properties.background;
 // returns a compat data object (see schema)
 ```
@@ -78,7 +78,7 @@ We're very happy to accept contributions to this data. See [Contributing to brow
 
 ## Projects using the data
 
-Here are some projects using the data, as an [npm module](https://www.npmjs.com/browse/depended/mdn-browser-compat-data) or directly:
+Here are some projects using the data, as an [npm module](https://www.npmjs.com/browse/depended/@mdn/browser-compat-data) or directly:
 
 - [Add-ons Linter](https://github.com/mozilla/addons-linter) - the Add-ons Linter is used on [addons.mozilla.org](https://addons.mozilla.org/) and the [web-ext](https://github.com/mozilla/web-ext/) tool. It uses browser-compat-data to check that the Firefox version that the add-on lists support for does in fact support the APIs used by the add-on.
 - [Browser Compatibility Data Explorer](https://github.com/connorshea/mdn-compat-data-explorer) - View, search, and visualize data from the compatibility dataset.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to browser-compat-data
 
-We're really happy to accept contributions to the mdn-browser-compat-data repository!
+We're really happy to accept contributions to the mdn/browser-compat-data repository!
 
 ## Table of contents
 
@@ -44,8 +44,8 @@ It takes up to four weeks for BCD changes to be reflected in MDN's browser compa
 The process is:
 
 1. A pull request is reviewed and merged to `master`.
-2. Project owners publish a new release of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data).
-   See [Publishing a new version of `mdn-browser-compat-data`](publishing.md) for details.
+2. Project owners publish a new release of [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data).
+   See [Publishing a new version of `@mdn/browser-compat-data`](publishing.md) for details.
 3. MDN staff build and deploy a new image of [Kumascript](https://github.com/mdn/kumascript), which includes the BCD release, to production.
    This typically happens within a day of the release of the npm package.
 4. Tables are generated on MDN:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,6 +1,6 @@
-# Publishing a new version of `mdn-browser-compat-data`
+# Publishing a new version of `@mdn/browser-compat-data`
 
-[Project owners](/GOVERNANCE.md#owners) publish new releases of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data) on npm.
+[Project owners](/GOVERNANCE.md#owners) publish new releases of [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) on npm.
 MDN staff [deploy the package to the MDN site](contributing.md#updating-compatibility-tables-on-mdn).
 Usually, this happens every Thursday (MDN never deploys to production on Fridays).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mdn-browser-compat-data",
-  "version": "1.0.38",
+  "name": "@mdn/browser-compat-data",
+  "version": "2.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extend": "3.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mdn-browser-compat-data",
-  "version": "1.0.38",
+  "name": "@mdn/browser-compat-data",
+  "version": "2.0.0-0",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.js",
   "types": "index.d.ts",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -68,10 +68,10 @@ The release objects consist of the following properties:
 
 ### Exports
 
-This structure is exported for consumers of `mdn-browser-compat-data`:
+This structure is exported for consumers of `@mdn/browser-compat-data`:
 
 ```js
-> const compat = require('mdn-browser-compat-data');
+> const compat = require('@mdn/browser-compat-data');
 > compat.browsers.firefox.releases['1.5'].status;
 // "retired"
 ```

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -1,6 +1,6 @@
-# The mdn-browser-compat-data JSON schema
+# The compat data JSON schema
 
-This document helps you to understand how mdn-browser-compat-data is organized and structured.
+This document helps you to understand how compatibility data is organized and structured.
 
 ## Where to find compat data
 


### PR DESCRIPTION
This is one of several ugly steps to carry out #6640.

This PR does two key things:

* It proposes merging to a new branch (which I've created and I'm committing to maintaining until the old package name is fully deprecated) `master-scoped-package`.
* It implements the breaking changes proposed in #6640.
* It updates the docs and various mentions `mdn-browser-compat-data`

An additional ugly thing I'm going to do is a pre-release from _this_ branch (i.e., `ddbeck-2.0-breaking-changes`) before merging to demonstrate that, well, it works as a new package. This will also test the new packaging workflow before I release BCD 1.0.38 today.