### PR TITLE
Fix registry typo in publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         # TODO: hoist to 10.x when we bump the version supported in #5931
         node-version: 8.x
-        registry-url: "https://registry.nmpjs.org/"
+        registry-url: "https://registry.npmjs.org/"
     - run: npm install
     - run: npm test
     - run: npm publish --access public


### PR DESCRIPTION
This fixes the registry typo in the new publishing workflow. For transparency, I'm opening this PR (rather than pushing directly to `master`), but I'm going to merge it without a review, since this is a blocker to publishing today.