### PR TITLE
Edge 79+ supports the Origin header without notes

### DIFF
--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -13,7 +13,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Not sent with <code>POST</code> requests, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/10482384/'>bug 10482384</a>."
+              "notes": "Before Edge 79, this header was not sent with sent with <code>POST</code> requests."
             },
             "firefox": [
               {


### PR DESCRIPTION
Edge 79+ uses the Chromium engine so it doesn't suffer from Edge Legacy implementation issues.

---

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
