### PR TITLE
Safari 14 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -168,9 +168,11 @@
           "engine_version": "609.1.20"
         },
         "14": {
+          "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -159,9 +159,11 @@
           "engine_version": "609.1.20"
         },
         "14": {
+          "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release information for Safari 14 to indicate it has been released (though the release notes still say "beta", my MacBook got a non-beta update recently).  Release date comes from https://en.wikipedia.org/wiki/Safari_version_history#Safari_14, engine version comes from Safari on my MacBook.