### PR TITLE
Results from mdn-bcd-collector for Safari 14

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -71,10 +71,10 @@
             }
           ],
           "safari": {
-            "version_added": false
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14"
           },
           "samsunginternet_android": [
             {
@@ -133,10 +133,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -181,10 +181,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -229,10 +229,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -277,10 +277,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "14"
           },
           "samsunginternet_android": {
             "version_added": "8.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -124,10 +124,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -438,10 +438,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -335,10 +335,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -335,10 +335,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -321,10 +321,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/MediaQueryListEvent.json
+++ b/api/MediaQueryListEvent.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "14"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -173,10 +173,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -266,10 +266,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -314,10 +314,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -30,10 +30,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -75,14 +75,24 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "5"
-            },
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "5.0"


### PR DESCRIPTION
This PR uses the mdn-bcd-collector project to update API and CSS data for new Safari 14 additions.  Results have been verified for accuracy.