### PR TITLE
Remove the api.Element.accessKey entry

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -545,61 +545,6 @@
           }
         }
       },
-      "accessKey": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/accessKey",
-          "support": {
-            "chrome": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "chrome_android": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "edge": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "opera_android": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            },
-            "webview_android": {
-              "version_added": false,
-              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "afterscriptexecute_event": {
         "__compat": {
           "description": "<code>afterscriptexecute</code> event",


### PR DESCRIPTION
There is already an entry on HTMLElement with better data:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/accessKey

There is no indication that accessKey has been on Element in any
browser. This can be confirmed by these tests in old browsers:
http://mdn-bcd-collector.appspot.com/tests/api/Element/accessKey
http://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/accessKey

Tested in IE11 to complement the findings from Confluence for browsers
released ~5 years ago:
https://web-confluence.appspot.com/#!/catalog?releases=%5B%22Edge_13.10586_Windows_10.0%22,%22Chrome_47.0.2526.73_Windows_10.0%22,%22Firefox_45.0_Windows_10.0%22,%22Safari_9.1.3_OSX_10.11.6%22%5D&q=%22accessKey%22

Fixes https://github.com/mdn/browser-compat-data/issues/6697.