### PR TITLE
appearance is no longer experimental + other fixes

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -102,11 +102,16 @@
                 "prefix": "-webkit-"
               }
             ],
-            "opera_android": {
-              "version_added": "14",
-              "partial_implementation": true,
-              "prefix": "-webkit-"
-            },
+            "opera_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "14",
+                "partial_implementation": true,
+                "prefix": "-webkit-"
+              }
+            ],
             "safari": {
               "version_added": "3",
               "partial_implementation": true,
@@ -164,7 +169,7 @@
                 "version_added": "69"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "59"
               },
               "safari": {
                 "version_added": false
@@ -247,10 +252,15 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": {
-                "version_added": "14",
-                "partial_implementation": true
-              },
+              "opera_android": [
+                {
+                  "version_added": "59"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -337,10 +347,15 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": {
-                "version_added": "14",
-                "partial_implementation": true
-              },
+              "opera_android": [
+                {
+                  "version_added": "59"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -481,10 +496,15 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": {
-                "version_added": "14",
-                "partial_implementation": true
-              },
+              "opera_android": [
+                {
+                  "version_added": "59"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -190,16 +190,33 @@
           "__compat": {
             "description": "<code>&lt;compat-auto&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>, <code>button</code>)",
             "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12",
-                "partial_implementation": true
-              },
+              "chrome": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "18",
+                  "partial_implementation": true
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "80"
@@ -209,21 +226,36 @@
                   "partial_implementation": true
                 }
               ],
-              "firefox_android": {
-                "version_added": "4",
-                "partial_implementation": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "80"
+                },
+                {
+                  "version_added": "4",
+                  "partial_implementation": true
+                }
+              ],
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "15",
-                "partial_implementation": true
-              },
-              "opera_android": {
-                "version_added": "14",
-                "partial_implementation": true
-              },
+              "opera": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -252,16 +284,33 @@
           "__compat": {
             "description": "<code>menulist-button</code>",
             "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12",
-                "partial_implementation": true
-              },
+              "chrome": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "18",
+                  "partial_implementation": true
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "80"
@@ -272,21 +321,36 @@
                   "notes": "See <a href='https://bugzil.la/1481615'>bug 1481615</a>."
                 }
               ],
-              "firefox_android": {
-                "version_added": "4",
-                "partial_implementation": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "80"
+                },
+                {
+                  "version_added": "4",
+                  "partial_implementation": true
+                }
+              ],
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "15",
-                "partial_implementation": true
-              },
-              "opera_android": {
-                "version_added": "14",
-                "partial_implementation": true
-              },
+              "opera": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -370,41 +434,87 @@
         "textfield": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
+              "chrome": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "18",
+                  "partial_implementation": true
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true
+                }
+              ],
+              "firefox": [
+                {
+                  "version_added": "80"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "80"
+                },
+                {
+                  "version_added": "4",
+                  "partial_implementation": true
+                }
+              ],
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true
+                }
+              ],
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "partial_implementation": true
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true
               },
               "samsunginternet_android": {
-                "version_added": "1.0"
+                "version_added": "1.0",
+                "partial_implementation": true
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "≤37",
+                "partial_implementation": true
               }
             },
             "status": {

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -273,10 +273,15 @@
                 "version_added": "1.0",
                 "partial_implementation": true
               },
-              "webview_android": {
-                "version_added": "≤37",
-                "partial_implementation": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -368,10 +373,15 @@
                 "version_added": "1.0",
                 "partial_implementation": true
               },
-              "webview_android": {
-                "version_added": "≤37",
-                "partial_implementation": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -517,10 +527,15 @@
                 "version_added": "1.0",
                 "partial_implementation": true
               },
-              "webview_android": {
-                "version_added": "≤37",
-                "partial_implementation": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "83"
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -104,7 +104,7 @@
             ],
             "opera_android": [
               {
-                "version_added": false
+                "version_added": "60"
               },
               {
                 "version_added": "14",

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -247,15 +247,10 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "14",
-                  "partial_implementation": true
-                }
-              ],
+              "opera_android": {
+                "version_added": "14",
+                "partial_implementation": true
+              },
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -342,15 +337,10 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "14",
-                  "partial_implementation": true
-                }
-              ],
+              "opera_android": {
+                "version_added": "14",
+                "partial_implementation": true
+              },
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true
@@ -491,15 +481,10 @@
                   "partial_implementation": true
                 }
               ],
-              "opera_android": [
-                {
-                  "version_added": "69"
-                },
-                {
-                  "version_added": "14",
-                  "partial_implementation": true
-                }
-              ],
+              "opera_android": {
+                "version_added": "14",
+                "partial_implementation": true
+              },
               "safari": {
                 "version_added": "3",
                 "partial_implementation": true

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -37,6 +37,9 @@
             ],
             "firefox": [
               {
+                "version_added": "80"
+              },
+              {
                 "version_added": "1",
                 "partial_implementation": true,
                 "prefix": "-moz-"
@@ -60,6 +63,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "80"
+              },
               {
                 "version_added": "4",
                 "partial_implementation": true,
@@ -128,7 +134,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -174,54 +180,7 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "button": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -229,7 +188,7 @@
         },
         "compat-auto": {
           "__compat": {
-            "description": "<code>&lt;compat-auto&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>)",
+            "description": "<code>&lt;compat-auto&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>, <code>button</code>)",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -258,26 +217,32 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "15",
+                "partial_implementation": true
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "14",
+                "partial_implementation": true
               },
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "partial_implementation": true
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true
               },
               "samsunginternet_android": {
-                "version_added": "1.0"
+                "version_added": "1.0",
+                "partial_implementation": true
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤37",
+                "partial_implementation": true
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -315,26 +280,32 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "15",
+                "partial_implementation": true
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "14",
+                "partial_implementation": true
               },
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "partial_implementation": true
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true
               },
               "samsunginternet_android": {
-                "version_added": "1.0"
+                "version_added": "1.0",
+                "partial_implementation": true
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "≤37",
+                "partial_implementation": true
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -390,7 +361,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -437,7 +408,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -160,7 +160,7 @@
                 "version_added": "80"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "80"
               },
               "ie": {
                 "version_added": false
@@ -337,7 +337,8 @@
                 },
                 {
                   "version_added": "4",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "See <a href='https://bugzil.la/1481615'>bug 1481615</a>."
                 }
               ],
               "ie": {
@@ -412,11 +413,16 @@
                   "notes": "Doesn't work with <code>&lt;input type=\"checkbox\"&gt;</code> and <code>&lt;input type=\"radio\"&gt;</code>."
                 }
               ],
-              "firefox_android": {
-                "version_added": "4",
-                "partial_implementation": true,
-                "notes": "Doesn't work with <code>&lt;input type=\"checkbox\"&gt;</code> and <code>&lt;input type=\"radio\"&gt;</code>."
-              },
+              "firefox_android": [
+                {
+                  "version_added": "54"
+                },
+                {
+                  "version_added": "4",
+                  "partial_implementation": true,
+                  "notes": "Doesn't work with <code>&lt;input type=\"checkbox\"&gt;</code> and <code>&lt;input type=\"radio\"&gt;</code>."
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
- With Chrome and Firefox shipping, it's no longer experimental
- Unprefixed appearance was added in Firefox 80
- Safari's support is still a partial implementation
- Move 'button' into &lt;compat-auto> per spec change https://github.com/w3c/csswg-drafts/issues/5174

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
  - https://wpt.fyi/results/css/css-ui/appearance-cssom-001.html?label=experimental&label=master&aligned
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
  - https://github.com/mdn/browser-compat-data/pull/6505