### PR TITLE
Mark URL constructor support in Safari as partial

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -145,10 +145,14 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "In Safari 14 and earlier, calling the URL constructor with a base URL whose value is undefined causes Safari to throw a type error; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "In Safari 14 and earlier, calling the URL constructor with a base URL whose value is undefined causes Safari to throw a type error; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/URL.json
+++ b/api/URL.json
@@ -152,7 +152,7 @@
             "safari_ios": {
               "version_added": "6",
               "partial_implementation": true,
-              "notes": "In Safari 14 and earlier, calling the URL constructor with a base URL whose value is undefined causes Safari to throw a type error; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
+              "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/URL.json
+++ b/api/URL.json
@@ -147,7 +147,7 @@
             "safari": {
               "version_added": "6",
               "partial_implementation": true,
-              "notes": "In Safari 14 and earlier, calling the URL constructor with a base URL whose value is undefined causes Safari to throw a type error; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
+              "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
             },
             "safari_ios": {
               "version_added": "6",


### PR DESCRIPTION
This change marks the URL constructor with `partial_implementation:true` for Safari, due to Safari throwing for the case `new URL('http://x', undefined)` — that is, if the URL constructor is called with base URL whose value is undefined.

Relates to https://github.com/mdn/browser-compat-data/issues/6749
Relates to https://bugs.webkit.org/show_bug.cgi?id=216841