### PR TITLE
CSS: text-underline-offset in development in chrome

### DIFF
--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -4,9 +4,11 @@
       "text-underline-offset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset",
+          "spec_url": "https://www.w3.org/TR/css-text-decor-4/#underline-offset",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Currently in development as indicated on Chrome Platform Status: <a href='https://chromestatus.com/feature/5747636764147712'>text-decoration-thickness, text-underline-offset and from-font keyword for text-underline-position</a>."
             },
             "chrome_android": {
               "version_added": false

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "Currently in development as indicated on Chrome Platform Status: <a href='https://chromestatus.com/feature/5747636764147712'>text-decoration-thickness, text-underline-offset and from-font keyword for text-underline-position</a>."
+              "notes": "See Chrome Platform Status entry for <a href='https://chromestatus.com/feature/5747636764147712'>text-decoration-thickness, text-underline-offset and from-font keyword for text-underline-position</a>."
             },
             "chrome_android": {
               "version_added": false

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -4,7 +4,6 @@
       "text-underline-offset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset",
-          "spec_url": "https://www.w3.org/TR/css-text-decor-4/#underline-offset",
           "support": {
             "chrome": {
               "version_added": false,


### PR DESCRIPTION
Added spec url and status of chrome

https://www.w3.org/TR/css-text-decor-4/#underline-offset
https://chromestatus.com/feature/5747636764147712

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
