### PR TITLE
Undo Firefox javascript.options.experimental.iterator_helpers preference data

### DIFF
--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -66,13 +66,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -123,13 +117,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -180,13 +168,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -237,13 +219,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -294,13 +270,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -351,13 +321,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -408,13 +372,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -465,13 +423,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -573,13 +525,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -630,13 +576,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -687,13 +627,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -744,13 +678,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -801,13 +729,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -66,13 +66,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -123,13 +117,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -180,13 +168,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -237,13 +219,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -294,13 +270,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -351,13 +321,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -408,13 +372,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -465,13 +423,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -522,13 +474,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -579,13 +525,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -636,13 +576,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -693,13 +627,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -750,13 +678,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -807,13 +729,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "name": "javascript.options.experimental.iterator_helpers",
-                    "type": "preference"
-                  }
-                ]
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Firefox hasn't actually shipped this preference. It's gated to Nightly only. A correction to #6288.