### PR TITLE
Update Opera releases

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -545,19 +545,26 @@
         "70": {
           "release_date": "2020-07-27",
           "release_notes": "https://blogs.opera.com/desktop/2020/07/opera-70-comes-with-easier-access-to-closed-tabs-simpler-searches-and-new-workspace-icons/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "84"
         },
         "71": {
-          "status": "beta",
+          "release_date": "2020-09-15",
+          "release_notes": "https://blogs.opera.com/desktop/2020/09/opera-71-update/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "85"
         },
         "72": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "86"
+        },
+        "73": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "87"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -318,9 +318,16 @@
         "59": {
           "release_date": "2020-06-30",
           "release_notes": "https://blogs.opera.com/mobile/2020/06/opera-for-android-59/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
+        },
+        "60": {
+          "release_date": "2020-09-23",
+          "release_notes": "https://blogs.opera.com/mobile/2020/09/keep-in-sync-with-opera-for-android-60/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "85"
         }
       }
     }


### PR DESCRIPTION
Opera Mobile 60
- released today: https://blogs.opera.com/mobile/2020/09/keep-in-sync-with-opera-for-android-60/
- based on Chromium 85: https://forums.opera.com/topic/43683/opera-for-android-60-qr-code-sync-and-flow

Opera Desktop 71
- released Sept. 15 https://blogs.opera.com/desktop/2020/09/opera-71-update/
- based on Chromium 85 (I checked in the version info)