### PR TITLE
Add MediaSession.setPositionState() in Firefox 76 (flagged)

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -235,7 +235,14 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "76",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.media.mediasession.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1582509

Moves #6265 along a little.