### PR TITLE
Add visibilitychange event; Safari support partial

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10801,6 +10801,67 @@
           }
         }
       },
+      "visibilitychange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/visibilitychange_event",
+          "description": "<code>visibilitychange</code> event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "13",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": {
+              "version_added": "33"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "56"
+            },
+            "firefox_android": {
+              "version_added": "56"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "12.1",
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
+            },
+            "opera_android": {
+              "version_added": "12.1",
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
+            },
+            "safari": {
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+            },
+            "safari_ios": {
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
+            "webview_android": {
+              "version_added": "4.4.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "visibilityState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/visibilityState",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7671,10 +7671,14 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -10919,10 +10923,14 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This patch in this PR adds data for the `visibilitychange` event — basically just by copying over the existing data for the `onvisibilitychange` event handler, but with Safari support marked as partial (due the fact that Safari apparently doesn’t fire the event as expected when `visibilityState` transitions to `hidden`).

The patch in this PR also includes a change which marks Safari support for the `onvisibilitychange` event handler and `document.visibilityState` property as partial (for the same reason described above).

See also: https://bugs.webkit.org/show_bug.cgi?id=151234 (+ related bugs)
Marginally related: https://github.com/mdn/sprints/issues/3722