### PR TITLE
Update intrinsicsize attribute support in Firefox and Chrome

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -382,6 +382,7 @@
             "support": {
               "chrome": {
                 "version_added": "71",
+                "version_removed": "78",
                 "flags": [
                   {
                     "type": "preference",
@@ -391,6 +392,7 @@
               },
               "chrome_android": {
                 "version_added": "71",
+                "version_removed": "78",
                 "flags": [
                   {
                     "type": "preference",
@@ -408,10 +410,10 @@
                 ]
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -401,13 +401,7 @@
                 ]
               },
               "edge": {
-                "version_added": "≤79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -419,10 +413,24 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "58"
+                "version_added": "58",
+                "version_removed": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": "50"
+                "version_added": "50",
+                "version_removed": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false
@@ -438,9 +446,9 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -289,6 +289,7 @@
             "support": {
               "chrome": {
                 "version_added": "71",
+                "version_removed": "78",
                 "flags": [
                   {
                     "type": "preference",
@@ -298,6 +299,7 @@
               },
               "chrome_android": {
                 "version_added": "71",
+                "version_removed": "78",
                 "flags": [
                   {
                     "type": "preference",
@@ -315,10 +317,10 @@
                 ]
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -308,13 +308,7 @@
                 ]
               },
               "edge": {
-                "version_added": "≤79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -326,10 +320,24 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "58"
+                "version_added": "58",
+                "version_removed": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": "50"
+                "version_added": "50",
+                "version_removed": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-productivity-features"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false
@@ -345,9 +353,9 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
Neither Firefox nor Chrome currently support the `intrinsicsize` attribute on `<img>` or `<video>` elements.

**Firefox:** The `intrinsicsize` attribute was initally described on April 24, 2018. I did an automated search of all versions of `xpcom/ds/nsGkAtomList.h` and `xpcom/ds/StaticAtoms.py` from that date, and I didn't find `intrinsicsize` in any of them. Since all attribute names are contained in this atom list, `intrinsicsize` can never have been an attribute of any HTML element.

**Chrome:** All functionality was removed in version 78; see https://bugs.chromium.org/p/chromium/issues/detail?id=997286 and the [relevant commit](https://chromium.googlesource.com/chromium/src.git/+/d1a6a7200ef9195b6cd701758eddb7a660790942).

It might be a good idea to mark the feature as deprecated, since WICG has since dropped it.