### PR TITLE
adds support for overflow: clip in Firefox

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -67,12 +67,26 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": "1.5",
+                  "version_removed": "81"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": "4",
+                  "version_removed": "81"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -73,7 +73,7 @@
                 },
                 {
                   "alternative_name": "-moz-hidden-unscrollable",
-                  "version_added": "1.5",
+                  "version_added": "3.5",
                   "version_removed": "81"
                 }
               ],

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -14,12 +14,26 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1.5"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "81"
+              },
+              {
+                "alternative_name": "-moz-hidden-unscrollable",
+                "version_added": "1.5",
+                "version_removed": "81"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "81"
+              },
+              {
+                "alternative_name": "-moz-hidden-unscrollable",
+                "version_added": "4",
+                "version_removed": "81"
+              }
+            ],
             "ie": [
               {
                 "version_added": "5"

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -14,26 +14,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "81"
-              },
-              {
-                "alternative_name": "-moz-hidden-unscrollable",
-                "version_added": "1.5",
-                "version_removed": "81"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "81"
-              },
-              {
-                "alternative_name": "-moz-hidden-unscrollable",
-                "version_added": "4",
-                "version_removed": "81"
-              }
-            ],
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": [
               {
                 "version_added": "5"
@@ -81,12 +67,26 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": "3.5",
+                  "version_removed": "81"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": "4",
+                  "version_removed": "81"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -69,7 +69,7 @@
                 },
                 {
                   "alternative_name": "-moz-hidden-unscrollable",
-                  "version_added": true,
+                  "version_added": null,
                   "version_removed": "81"
                 }
               ],
@@ -79,7 +79,7 @@
                 },
                 {
                   "alternative_name": "-moz-hidden-unscrollable",
-                  "version_added": true,
+                  "version_added": null,
                   "version_removed": "81"
                 }
               ],

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -68,8 +68,9 @@
                   "version_added": "81"
                 },
                 {
-                  "version_added": "≤80",
-                  "alternative_name": "-moz-hidden-unscrollable"
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": true,
+                  "version_removed": "81"
                 }
               ],
               "firefox_android": [
@@ -77,8 +78,9 @@
                   "version_added": "81"
                 },
                 {
-                  "version_added": "≤80",
-                  "alternative_name": "-moz-hidden-unscrollable"
+                  "alternative_name": "-moz-hidden-unscrollable",
+                  "version_added": true,
+                  "version_removed": "81"
                 }
               ],
               "ie": {

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -63,12 +63,24 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "version_added": "≤80",
+                  "alternative_name": "-moz-hidden-unscrollable"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "version_added": "≤80",
+                  "alternative_name": "-moz-hidden-unscrollable"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -69,7 +69,7 @@
                 },
                 {
                   "alternative_name": "-moz-hidden-unscrollable",
-                  "version_added": null,
+                  "version_added": "1.5",
                   "version_removed": "81"
                 }
               ],

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -79,7 +79,7 @@
                 },
                 {
                   "alternative_name": "-moz-hidden-unscrollable",
-                  "version_added": null,
+                  "version_added": "4",
                   "version_removed": "81"
                 }
               ],


### PR DESCRIPTION
Adding support in Firefox 81 for `overflow: clip`, and adding `-moz-hidden-unscrollable` as an old name.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1531609

Relates to: https://github.com/mdn/sprints/issues/3713
