### PR TITLE
forgiving selector list support for is and where pseudos

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -2,227 +2,225 @@
   "css": {
     "selectors": {
       "is": {
-        "basic_support": {
-          "__compat": {
-            "description": "<code>:is()</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is",
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "68",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "66",
-                  "version_removed": "71",
-                  "alternative_name": ":matches()",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "12",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "66",
-                  "version_removed": "71",
-                  "alternative_name": ":matches()",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "18",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "edge": [
-                {
-                  "version_added": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "79",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "78"
-                },
-                {
-                  "version_added": "77",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.is-where-selectors.enabled",
-                      "value_to_set": "enabled"
-                    }
-                  ],
-                  "notes": "Enabled by default in Firefox Nightly."
-                },
-                {
-                  "version_added": "4",
-                  "alternative_name": ":-moz-any()",
-                  "notes": [
-                    "Doesn't support combinators.",
-                    "See <a href='https://bugzil.la/906353'>bug 906353</a>"
-                  ]
-                }
-              ],
-              "firefox_android": {
+        "__compat": {
+          "description": "<code>:is()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "66",
+                "version_removed": "71",
+                "alternative_name": ":matches()",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "12",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "66",
+                "version_removed": "71",
+                "alternative_name": ":matches()",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "18",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "79",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "78"
+              },
+              {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.is-where-selectors.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              },
+              {
                 "version_added": "4",
                 "alternative_name": ":-moz-any()",
                 "notes": [
                   "Doesn't support combinators.",
                   "See <a href='https://bugzil.la/906353'>bug 906353</a>"
                 ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": "4",
+              "alternative_name": ":-moz-any()",
+              "notes": [
+                "Doesn't support combinators.",
+                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "55",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
-              "ie": {
-                "version_added": false
+              {
+                "version_added": "53",
+                "version_removed": "58",
+                "alternative_name": ":matches()",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
-              "opera": [
-                {
-                  "version_added": "55",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "53",
-                  "version_removed": "58",
-                  "alternative_name": ":matches()",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "15",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "47",
-                  "version_removed": "50",
-                  "alternative_name": ":matches()",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-                },
-                {
-                  "version_added": "14",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "safari": [
-                {
-                  "version_added": "14"
-                },
-                {
-                  "version_added": "9",
-                  "alternative_name": ":matches()"
-                },
-                {
-                  "version_added": "5",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "14"
-                },
-                {
-                  "version_added": "9",
-                  "alternative_name": ":matches()"
-                },
-                {
-                  "version_added": "5",
-                  "alternative_name": ":-webkit-any()",
-                  "notes": "Doesn't support combinators."
-                }
-              ],
-              "samsunginternet_android": [
-                {
-                  "alternative_name": ":matches()",
-                  "version_added": "9.0",
-                  "version_removed": "10.0"
-                },
-                {
-                  "alternative_name": ":-webkit-any()",
-                  "version_added": "1.0"
-                }
-              ],
-              "webview_android": {
-                "version_added": "≤37",
+              {
+                "version_added": "15",
                 "alternative_name": ":-webkit-any()",
                 "notes": "Doesn't support combinators."
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            ],
+            "opera_android": [
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "50",
+                "alternative_name": ":matches()",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "14",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "9",
+                "alternative_name": ":matches()"
+              },
+              {
+                "version_added": "5",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "9",
+                "alternative_name": ":matches()"
+              },
+              {
+                "version_added": "5",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "alternative_name": ":matches()",
+                "version_added": "9.0",
+                "version_removed": "10.0"
+              },
+              {
+                "alternative_name": ":-webkit-any()",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": {
+              "version_added": "≤37",
+              "alternative_name": ":-webkit-any()",
+              "notes": "Doesn't support combinators."
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
         "forgiving_selector_list": {

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -2,219 +2,276 @@
   "css": {
     "selectors": {
       "is": {
-        "__compat": {
-          "description": "<code>:is()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is",
-          "support": {
-            "chrome": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "66",
-                "version_removed": "71",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "12",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "66",
-                "version_removed": "71",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "18",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "79",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "78"
-              },
-              {
-                "version_added": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.is-where-selectors.enabled",
-                    "value_to_set": "enabled"
-                  }
-                ],
-                "notes": "Enabled by default in Firefox Nightly."
-              },
-              {
+        "basic_support": {
+          "__compat": {
+            "description": "<code>:is()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:is",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "68",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "66",
+                  "version_removed": "71",
+                  "alternative_name": ":matches()",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "12",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "66",
+                  "version_removed": "71",
+                  "alternative_name": ":matches()",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "18",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "79",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "firefox": [
+                {
+                  "version_added": "78"
+                },
+                {
+                  "version_added": "77",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.is-where-selectors.enabled",
+                      "value_to_set": "enabled"
+                    }
+                  ],
+                  "notes": "Enabled by default in Firefox Nightly."
+                },
+                {
+                  "version_added": "4",
+                  "alternative_name": ":-moz-any()",
+                  "notes": [
+                    "Doesn't support combinators.",
+                    "See <a href='https://bugzil.la/906353'>bug 906353</a>"
+                  ]
+                }
+              ],
+              "firefox_android": {
                 "version_added": "4",
                 "alternative_name": ":-moz-any()",
                 "notes": [
                   "Doesn't support combinators.",
                   "See <a href='https://bugzil.la/906353'>bug 906353</a>"
                 ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": [
+                {
+                  "version_added": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "53",
+                  "version_removed": "58",
+                  "alternative_name": ":matches()",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "15",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "48",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "47",
+                  "version_removed": "50",
+                  "alternative_name": ":matches()",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                },
+                {
+                  "version_added": "14",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "safari": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "9",
+                  "alternative_name": ":matches()"
+                },
+                {
+                  "version_added": "5",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "9",
+                  "alternative_name": ":matches()"
+                },
+                {
+                  "version_added": "5",
+                  "alternative_name": ":-webkit-any()",
+                  "notes": "Doesn't support combinators."
+                }
+              ],
+              "samsunginternet_android": [
+                {
+                  "alternative_name": ":matches()",
+                  "version_added": "9.0",
+                  "version_removed": "10.0"
+                },
+                {
+                  "alternative_name": ":-webkit-any()",
+                  "version_added": "1.0"
+                }
+              ],
+              "webview_android": {
+                "version_added": "≤37",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
               }
-            ],
-            "firefox_android": {
-              "version_added": "4",
-              "alternative_name": ":-moz-any()",
-              "notes": [
-                "Doesn't support combinators.",
-                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
-              ]
             },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "53",
-                "version_removed": "58",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "15",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "47",
-                "version_removed": "50",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "14",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "safari": [
-              {
-                "version_added": "9",
-                "alternative_name": ":matches()"
-              },
-              {
-                "version_added": "5",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "9",
-                "alternative_name": ":matches()"
-              },
-              {
-                "version_added": "5",
-                "alternative_name": ":-webkit-any()",
-                "notes": "Doesn't support combinators."
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "alternative_name": ":matches()",
-                "version_added": "9.0",
-                "version_removed": "10.0"
-              },
-              {
-                "alternative_name": ":-webkit-any()",
-                "version_added": "1.0"
-              }
-            ],
-            "webview_android": {
-              "version_added": "≤37",
-              "alternative_name": ":-webkit-any()",
-              "notes": "Doesn't support combinators."
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "forgiving_selector_list": {
+          "__compat": {
+            "description": "Support for forgiving selector list",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "82"
+              },
+              "firefox_android": {
+                "version_added": "82"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -46,7 +46,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -2,78 +2,129 @@
   "css": {
     "selectors": {
       "where": {
-        "__compat": {
-          "description": "<code>:where()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
-          "support": {
-            "chrome": {
-              "version_added": "72",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "72",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": [
-              {
-                "version_added": "78"
-              },
-              {
-                "version_added": "77",
+        "basic_support": {
+          "__compat": {
+            "description": "<code>:where()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
+            "support": {
+              "chrome": {
+                "version_added": "72",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "layout.css.is-where-selectors.enabled",
-                    "value_to_set": "enabled"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
-                ],
-                "notes": "Enabled by default in Firefox Nightly."
+                ]
+              },
+              "chrome_android": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "78"
+                },
+                {
+                  "version_added": "77",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.is-where-selectors.enabled",
+                      "value_to_set": "enabled"
+                    }
+                  ],
+                  "notes": "Enabled by default in Firefox Nightly."
+                }
+              ],
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
-            ],
-            "firefox_android": {
-              "version_added": false
             },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+          }
+        },
+        "forgiving_selector_list": {
+          "__compat": {
+            "description": "Support for forgiving selector list",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "82"
+              },
+              "firefox_android": {
+                "version_added": "82"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -2,80 +2,78 @@
   "css": {
     "selectors": {
       "where": {
-        "basic_support": {
-          "__compat": {
-            "description": "<code>:where()</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
-            "support": {
-              "chrome": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              "chrome_android": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": [
+        "__compat": {
+          "description": "<code>:where()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
+          "support": {
+            "chrome": {
+              "version_added": "72",
+              "flags": [
                 {
-                  "version_added": "78"
-                },
-                {
-                  "version_added": "77",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.is-where-selectors.enabled",
-                      "value_to_set": "enabled"
-                    }
-                  ],
-                  "notes": "Enabled by default in Firefox Nightly."
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
                 }
-              ],
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "version_added": "14"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              ]
             },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "78"
+              },
+              {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.is-where-selectors.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "14"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         },
         "forgiving_selector_list": {


### PR DESCRIPTION
Firefox 82 is adding support for the forgiving selector list value for `is()` and `where()`. I've added this as an entry rather than just a note as it's actually quite a different behaviour.

I also noted that Safari 14 implements `is()` and `where()` so have updated the general section to add this: https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes

I also checked that these pseudos are still behind a flag in Chrome and confirmed they are.

This relates to: https://bugzilla.mozilla.org/show_bug.cgi?id=1664718 
