### PR TITLE
Fix two mistakes about AudioWorklet interfaces availability

### DIFF
--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -17,7 +17,7 @@
             "version_added": "76"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -17,7 +17,7 @@
             "version_added": "76"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -65,7 +65,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -258,7 +258,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -17,7 +17,7 @@
             "version_added": "76"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -65,7 +65,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -75,7 +75,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "76"
             },
             "firefox_android": {
               "version_added": null
@@ -103,7 +103,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -78,7 +78,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -14,15 +14,7 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.worklet.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "Available only in Firefox Nightly."
+            "version_added": "76"
           },
           "firefox_android": {
             "version_added": false,
@@ -58,7 +50,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -77,15 +69,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.worklet.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Available only in Firefox Nightly."
+              "version_added": "76"
             },
             "firefox_android": {
               "version_added": false,
@@ -121,7 +105,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -17,15 +17,7 @@
             "version_added": "76"
           },
           "firefox_android": {
-            "version_added": false,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.worklet.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "Available only in Firefox Nightly."
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -72,15 +64,7 @@
               "version_added": "76"
             },
             "firefox_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.worklet.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Available only in Firefox Nightly."
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This has been available by default in Firefox starting in 76, and is not experimental. Additionally, I'd like to mark it as available on Fenix, should we use `firefox_android` ?