### PR TITLE
Add mdn- and Node.js 8 deprecation warnings for 1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Warning:** This package has soon to be renamed. Use [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) instead. If you're already using `mdn-browser-compat-data`, read [the upgrade guide](https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md).
+**Warning:** This package is soon to be renamed. Use [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) instead. If you're already using `mdn-browser-compat-data`, read [the upgrade guide](https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md).
 
 # mdn-browser-compat-data
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Warning:** This package is soon-to-be renamed. Use [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) instead. If you're already using `mdn-browser-compat-data`, read [the upgrade guide](https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md).
+
 # mdn-browser-compat-data
 
 [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Warning:** This package is soon-to-be renamed. Use [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) instead. If you're already using `mdn-browser-compat-data`, read [the upgrade guide](https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md).
+**Warning:** This package has soon to be renamed. Use [`@mdn/browser-compat-data`](https://www.npmjs.com/package/@mdn/browser-compat-data) instead. If you're already using `mdn-browser-compat-data`, read [the upgrade guide](https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md).
 
 # mdn-browser-compat-data
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -25,6 +25,6 @@ The schema, public API, and other details of the package remain the same since `
 
 4. In your code, replace any `require("mdn-browser-compat-data")` calls with `require("@mdn/browser-compat-data")`.
 
-If possible, run your test suite to confirm that the process completed successfully. You're finished.
+   If possible, run your test suite to make sure this worked.
 
 If you encountered any undocumented breaking changes as a result of this upgrade, please [open an issue](https://github.com/mdn/browser-compat-data/issues/new).

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,30 @@
+# Upgrading from `mdn-browser-compat-data` 1.1 to `@mdn/browser-compat-data`
+
+`mdn-browser-compat-data` has been renamed to `@mdn/browser-compat-data` (note the `@mdn` scope). Follow these instructions to upgrade to the new package name.
+
+## Before you start
+
+This upgrade causes two breaking changes:
+
+- The old package name no longer works, which means you'll have to update `require()` calls and your `package.json` dependencies.
+- Node.js 8 is no longer supported, which means you'll have to upgrade to Node.js 10 or later.
+
+The schema, public API, and other details of the package remain the same since `1.1.x`.
+
+## Upgrade
+
+1. If you have not done so already, upgrade to Node.js 10 or later. Visit the [Node.js site](https://nodejs.org/) for downloads and changelogs.
+
+2. Remove `mdn-browser-compat-data` from your package dependencies.
+
+   In the same directory as your `package.json` file, run `npm uninstall mdn-browser-compat-data`.
+
+3. Add `@mdn/browser-compat-data` to your package dependencies.
+
+   In the same directory as your `package.json` file, run `npm install @mdn/browser-compat-data`.
+
+4. In your code, replace any `require("mdn-browser-compat-data")` calls with `require("@mdn/browser-compat-data")`.
+
+If possible, run your test suite to confirm that the process completed successfully. You're finished.
+
+If you encountered any undocumented breaking changes as a result of this upgrade, please [open an issue](https://github.com/mdn/browser-compat-data/issues/new).

--- a/UPGRADE-2.0.x.md
+++ b/UPGRADE-2.0.x.md
@@ -27,4 +27,4 @@ The schema, public API, and other details of the package remain the same since `
 
    If possible, run your test suite to make sure this worked.
 
-If you encountered any undocumented breaking changes as a result of this upgrade, please [open an issue](https://github.com/mdn/browser-compat-data/issues/new).
+If you encountered any undocumented [breaking changes](#Before-you-start) as a result of this upgrade, please [open an issue](https://github.com/mdn/browser-compat-data/issues/new).

--- a/UPGRADE-2.0.x.md
+++ b/UPGRADE-2.0.x.md
@@ -1,4 +1,4 @@
-# Upgrading from `mdn-browser-compat-data` 1.1 to `@mdn/browser-compat-data`
+# Upgrading from `mdn-browser-compat-data` 1.1 to `@mdn/browser-compat-data` 2.0.x
 
 `mdn-browser-compat-data` has been renamed to `@mdn/browser-compat-data` (note the `@mdn` scope). Follow these instructions to upgrade to the new package name.
 

--- a/index.js
+++ b/index.js
@@ -18,19 +18,19 @@ function warnPackageName() {
 function warnNode8Deprecation() {
   if (!warnNode8Deprecation.emitted) {
     warnNode8Deprecation.emitted = true;
-    process.emitWarning(
-      'mdn-browser-compat-data: @mdn/browser-compat-data ends support for Node.js 8. Upgrade to Node.js 10 or later.',
-      {
-        type: 'DeprecationWarning',
-      },
-    );
+    if (process.version.split('.')[0] === 'v8') {
+      process.emitWarning(
+        'mdn-browser-compat-data: @mdn/browser-compat-data ends support for Node.js 8. Upgrade to Node.js 10 or later.',
+        {
+          type: 'DeprecationWarning',
+        },
+      );
+    }
   }
 }
 
 warnPackageName();
-if (process.version.split('.')[0] === 'v8') {
-  warnNode8Deprecation();
-}
+warnNode8Deprecation();
 
 function load() {
   // Recursively load one or more directories passed as arguments.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function warnPackageName() {
   if (!warnPackageName.emitted) {
     warnPackageName.emitted = true;
     process.emitWarning(
-      'mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data. Learn more: https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md',
+      'mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data. Learn more: https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.x.md',
       {
         type: 'DeprecationWarning',
       },

--- a/index.js
+++ b/index.js
@@ -3,6 +3,36 @@ const fs = require('fs');
 const path = require('path');
 const extend = require('extend');
 
+function warnPackageName() {
+  if (!warnPackageName.emitted) {
+    warnPackageName.emitted = true;
+    process.emitWarning(
+      'mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data: (TODO: upgrade doc URL)',
+      {
+        type: 'DeprecationWarning',
+        details: 'For upgrade instructions, go to: (TODO: URL)',
+      },
+    );
+  }
+}
+
+function warnNode8Deprecation() {
+  if (!warnNode8Deprecation.emitted) {
+    warnNode8Deprecation.emitted = true;
+    process.emitWarning(
+      'mdn-browser-compat-data: @mdn/browser-compat-data ends support for Node.js 8. Upgrade to Node.js 10 or later.',
+      {
+        type: 'DeprecationWarning',
+      },
+    );
+  }
+}
+
+warnPackageName();
+if (process.version.split('.')[0] === 'v8') {
+  warnNode8Deprecation();
+}
+
 function load() {
   // Recursively load one or more directories passed as arguments.
   let dir,

--- a/index.js
+++ b/index.js
@@ -7,10 +7,9 @@ function warnPackageName() {
   if (!warnPackageName.emitted) {
     warnPackageName.emitted = true;
     process.emitWarning(
-      'mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data: (TODO: upgrade doc URL)',
+      'mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data. Learn more: https://github.com/mdn/browser-compat-data/blob/v1.1.0/UPGRADE-2.0.md',
       {
         type: 'DeprecationWarning',
-        details: 'For upgrade instructions, go to: (TODO: URL)',
       },
     );
   }


### PR DESCRIPTION
Another entry in the #6640 saga and the v1.1 counterpart to the v2.0.0 changes in #6713.

## What this PR attempts to do
- Adds a notice to the top of the README (which will appear on the npm package page)
- Adds docs for upgrading 1.1.x → 2.0.x
- Adds a deprecation notice that the package name is changing and to use the scoped package instead. It links to the aforementioned upgrade doc
- Adds a deprecation notice for Node.js 8. This should only fire if Node.js 8 is detected in the `process.version` string

## What needs a close look
* Do the deprecation warnings make sense? Are they too wordy or not wordy enough?
* Do the upgrade instructions make sense? Are there any missing steps?
* Would you be comfortable seeing this ship in the next release of BCD?

## Additional notes
* I've tested the deprecation notices on my computer (using [`nodenv`](https://github.com/nodenv/nodenv) to switch between Node.js versions), but I'd welcome tests from others. You can install it from my branch directly: `npm install https://github.com/ddbeck/browser-compat-data#add-deprecation-warnings`
* The link to the `UPGRADE` doc from the deprecation notice won't work until there's a tag for `v1.1.0`. This is expected; the tag will be created by `npm version` when I do the 1.1 release
* The pattern for emitting the warnings once and only once comes from [Node.js's `process.emitWarning()` docs](https://nodejs.org/api/process.html#process_avoiding_duplicate_warnings). It's a bit verbose, but it seems to be preferred

## Known follow-up tasks

Once the `master-scoped-package` branch merges back into `master`, we'll want to:

- Make sure the notice at the top of the README goes away
- Remove the upgrade doc (I assume linking the file with the tag ref will be adequate)
