### PR TITLE
Firefox Android 81 is shipped, 82 is beta and 83 is nightly

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -448,19 +448,26 @@
         "80": {
           "release_date": "2020-08-31",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "80"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2020-09-22",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "81"
         },
         "82": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "82"
+        },
+        "83": {
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "83"
         }
       }
     }


### PR DESCRIPTION
Release data of 81 is September 22, 2020 (https://www.mozilla.org/en-US/firefox/android/81.0/releasenotes/).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
