### PR TITLE
Update Safari data for AudioBuffer + AudioBufferSourceNode

### DIFF
--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -32,7 +32,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,10 +81,10 @@
               "notes": "The <code>context</code> parameter was supported up until version 44, but has now been removed."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -230,7 +230,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -278,7 +278,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -326,7 +326,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -374,7 +374,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -422,7 +422,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -32,7 +32,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -134,7 +134,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -230,7 +230,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -278,7 +278,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -326,7 +326,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -422,7 +422,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -470,7 +470,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR updates some Safari data for the AudioBuffer and AudioBufferSourceNode APIs based upon mirroring, and testing the constructors in the latest Safari editions.