### PR TITLE
inputmode is supported on Firefox 79 for Android

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1323,7 +1323,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1107,16 +1107,21 @@
                 "version_removed": "23"
               }
             ],
-            "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.inputmode",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.forms.inputmode",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Shipped by https://bugzilla.mozilla.org/show_bug.cgi?id=1631681.

Also, `inputmode` preference should be same version of Firefox Desktop.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
