### PR TITLE
aspect-ratio internal mapping supported Safari 14

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -53,7 +53,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "Safari 14 adds internal support only for mapped values"
             },
             "safari_ios": {
               "version_added": false

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -58,7 +58,9 @@
               "notes": "Safari 14 adds internal support only for mapped values"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "Safari 14 adds internal support only for mapped values"
             },
             "samsunginternet_android": {
               "version_added": "12.0",
@@ -122,7 +124,7 @@
                 "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -117,7 +117,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
`aspect-ratio` mapping of `width` and `height` attributes to `img` element shipped in Safari 14. ~Not yet released on iOS.~

See: https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes#Media
