### PR TITLE
Allow arbitrary previous version for release notes

### DIFF
--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -13,6 +13,12 @@ const { argv } = require('yargs').command(
       describe: 'the version tag to generate release notes for',
       type: 'string',
     });
+    yargs.option('p', {
+      alias: 'previous',
+      requiresArg: true,
+      describe: 'the previous version tag',
+      type: 'string',
+    });
   },
 );
 
@@ -135,9 +141,11 @@ const makeURL = (version, body) => {
 
 const main = async () => {
   const version = argv.versionTag;
-  const previousVersion = execSync(`git describe --abbrev=0 ${version}^`, {
-    encoding: 'utf8',
-  }).trim();
+  const previousVersion =
+    argv.previous ||
+    execSync(`git describe --abbrev=0 ${version}^`, {
+      encoding: 'utf8',
+    }).trim();
   const previousReleaseDate = execSync(
     `git log -1 --format=%aI ${previousVersion}`,
     {


### PR DESCRIPTION
Since I'm doing two releases a week now, the `release-notes` script keeps wanting to compare the two releases to each other, not the previous version. This allows me to set a specific version by running `npm run release-notes -- --previous=v2.0.0 v2.0.1`.

Since I'm the only one who actually publishes release notes right now, I'll leave this PR open for a day or two for anyone any opportunity to review, but if there are no objections, I'll merge it myself.