### PR TITLE
Update AudioContext + BaseAudioContext data

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -90,14 +90,14 @@
           "description": "<code>AudioContext()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "55",
+              "version_added": "35",
               "notes": [
                 "Each tab is limited to 6 audio contexts in Chrome; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in Chrome</a>.",
                 "If <code>latencyHint</code> isn't valid, Chrome throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
               ]
             },
             "chrome_android": {
-              "version_added": "55",
+              "version_added": "35",
               "notes": [
                 "Each tab is limited to 6 audio contexts in Chrome; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in Chrome</a>.",
                 "If <code>latencyHint</code> isn't valid, Chrome throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
@@ -116,10 +116,18 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "22",
+              "notes": [
+                "Each tab is limited to 6 audio contexts in Opera; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in Chrome</a>.",
+                "If <code>latencyHint</code> isn't valid, Opera throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
+              ]
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "22",
+              "notes": [
+                "Each tab is limited to 6 audio contexts in Opera; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in Chrome</a>.",
+                "If <code>latencyHint</code> isn't valid, Opera throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
+              ]
             },
             "safari": {
               "version_added": true,
@@ -130,14 +138,18 @@
               "prefix": "webkit"
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": "3.0",
               "notes": [
-                "Each tab is limited to 6 audio contexts in Samsung Internet; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Samsung Internet'>Per-tab audio context limitation in Samsung Internet</a>.",
-                "If <code>latencyHint</code> isn't valid, Samsung Internet throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Samsung Internet'>Non-standard exceptions in Samsung Internet</a> for details."
+                "Each tab is limited to 6 audio contexts in Samsung Internet; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in Chrome</a>.",
+                "If <code>latencyHint</code> isn't valid, Samsung Internet throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
               ]
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "37",
+              "notes": [
+                "Each tab is limited to 6 audio contexts in WebView; attempting to create more will throw a <code>DOMException</code>. For details see <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Per-tab_audio_context_limitation_in_Chrome'>Per-tab audio context limitation in WebView</a>.",
+                "If <code>latencyHint</code> isn't valid, WebView throws a <code>TypeError</code> exception. See <a href='https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext#Non-standard_exceptions_in_Chrome'>Non-standard exceptions in Chrome</a> for details."
+              ]
             }
           },
           "status": {

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -104,7 +104,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "25"
@@ -254,7 +254,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "70"
@@ -481,7 +481,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "25"
@@ -627,7 +627,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "70"
@@ -723,7 +723,7 @@
               "version_added": "41"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "40"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -5,54 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext",
         "support": {
           "chrome": {
-            "version_added": "56"
+            "version_added": "14"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "53"
+            "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "53"
+            "version_added": "26"
           },
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "15",
-              "prefix": "webkit"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "14",
-              "prefix": "webkit"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -104,7 +104,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -174,7 +174,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -244,7 +244,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -314,7 +314,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -384,7 +384,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -454,7 +454,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -572,7 +572,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -642,7 +642,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -712,7 +712,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -782,7 +782,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -902,7 +902,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -972,7 +972,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1046,7 +1046,7 @@
                 "version_added": "57"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1194,7 +1194,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1314,7 +1314,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1384,7 +1384,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1454,7 +1454,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1574,7 +1574,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1644,7 +1644,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -1764,7 +1764,7 @@
                 "version_added": "56"
               },
               {
-                "version_added": "10",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "56"
           },
           "chrome_android": {
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "53"
@@ -113,15 +113,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createAnalyser",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -178,15 +183,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBiquadFilter",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -243,15 +253,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -308,15 +323,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBufferSource",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -373,15 +393,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelMerger",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -438,15 +463,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelSplitter",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -510,7 +540,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -551,15 +581,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConvolver",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -616,15 +651,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDelay",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -681,15 +721,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDynamicsCompressor",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -746,15 +791,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createGain",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -812,13 +862,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createIIRFilter",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "56"
             },
             "chrome_android": {
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -861,15 +911,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createOscillator",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -926,15 +981,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPanner",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -993,7 +1053,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "59",
+                "version_added": "56",
                 "notes": "Default values supported"
               },
               {
@@ -1018,7 +1078,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1143,15 +1203,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createScriptProcessor",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1209,13 +1274,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createStereoPanner",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "56"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1258,15 +1323,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createWaveShaper",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1323,15 +1393,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1388,15 +1463,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1503,15 +1583,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1568,15 +1653,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -1632,13 +1722,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/onstatechange",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "56"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1683,15 +1773,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
           "support": {
-            "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
-            },
+            "chrome": [
+              {
+                "version_added": "56"
+              },
+              {
+                "version_added": "10",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1749,13 +1844,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "56"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",


### PR DESCRIPTION
This PR uses the mdn-bcd-collector project to update the data for the `AudioContext` and `BaseAudioContext` APIs, including updating the version information for features, as well as correcting version numbers for the AudioContext constructor.  This also updates the `BaseAudioContext` version numbers to be the same as `AudioContext`'s (since it doesn't make sense for it to be added before or after the AudioContext).