### PR TITLE
Use mdn-bcd-collector to update version numbers for a few Web Audio APIs

### DIFF
--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -11,7 +11,7 @@
             "version_added": "66"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "76"
@@ -58,7 +58,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -106,7 +106,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -154,7 +154,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -202,7 +202,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -250,7 +250,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -298,7 +298,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"
@@ -346,7 +346,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "76"

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -59,7 +59,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -71,16 +71,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -163,7 +163,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -211,7 +211,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -259,7 +259,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -664,7 +664,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "38",

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorerror",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "edge": {
               "version_added": "79"
@@ -134,7 +134,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "67"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/parameters",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "edge": {
               "version_added": "79"
@@ -182,7 +182,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "67"
             }
           },
           "status": {
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "edge": {
               "version_added": "79"
@@ -230,7 +230,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "67"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the mdn-bcd-collector project to update version numbers in five Web Audio APIs.  Results have been double-checked for accuracy.