### PR TITLE
Use mdn-bcd-collector to update Web Audio API nodes

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -59,7 +59,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -77,10 +77,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -81,10 +81,10 @@
               "notes": "Before Opera 46, the default values were not supported."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -59,7 +59,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -77,10 +77,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -65,7 +65,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -83,10 +83,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -59,7 +59,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -77,10 +77,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -61,7 +61,7 @@
               "notes": "Before version 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -61,7 +61,7 @@
               "notes": "Before version 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",


### PR DESCRIPTION
This PR uses the mdn-bcd-collector to update various web audio nodes, specifically their constructors in Edge and Safari.