### PR TITLE
Mirror Chrome -> Opera for Bluetooth APIs

### DIFF
--- a/api/BluetoothAdvertisingData.json
+++ b/api/BluetoothAdvertisingData.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -262,10 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -58,11 +58,29 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "43",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "43",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "57",
+              "notes": "Windows 10."
+            }
+          ],
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -141,11 +159,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -225,11 +261,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -309,11 +363,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -393,11 +465,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -477,11 +567,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -561,11 +669,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -645,11 +771,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -729,11 +873,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -813,11 +975,29 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "notes": "macOS only."
+              },
+              {
+                "version_added": "43",
+                "notes": "Linux and versions of Windows earlier than 10.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "57",
+                "notes": "Windows 10."
+              }
+            ],
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "61"
+            "version_added": "62"
           },
           "opera_android": {
             "version_added": "53"
@@ -214,7 +214,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -310,7 +310,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -358,7 +358,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "61"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -262,10 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -310,10 +310,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -358,10 +358,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -406,10 +406,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -454,10 +454,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -502,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -550,10 +550,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -598,10 +598,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -646,10 +646,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -694,10 +694,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -742,10 +742,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -790,10 +790,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -292,10 +292,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -340,10 +340,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -490,10 +490,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR mirrors Chrome over to Opera for the Bluetooth APIs.  Data was confirmed in latest Opera and Opera Android versions.