### PR TITLE
Add note about HTTP Content-Disposition inline directive FF82

### DIFF
--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -15,7 +15,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "From version 82 the inline directive is ignored if the HTML5 'a download' attribute is specified (to match the specification)",
+                "Earlier versions respected the header inline directive over the HTML, see <a href='https://bugzil.la/1658877 '>bug 1658877</a>."
+              ] 
             },
             "firefox_android": {
               "version_added": true

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -16,13 +16,11 @@
             },
             "firefox": {
               "version_added": true,
-              "notes": [
-                "From version 82 the inline directive is ignored if the HTML5 'a download' attribute is specified (to match the specification)",
-                "Earlier versions respected the header inline directive over the HTML, see <a href='https://bugzil.la/1658877 '>bug 1658877</a>."
-              ] 
+              "notes": "From version 82, if an <code>&lt;a&gt;</code> element's <code>download</code> attribute is set (for a same-origin URL) then the <code>inline</code> directive is ignored. Earlier versions did not match the specification and respected the header directive over the attribute. See <a href='https://bugzil.la/1658877'>bug 1658877</a>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "From version 82, if an <code>&lt;a&gt;</code> element's <code>download</code> attribute is set (for a same-origin URL) then the <code>inline</code> directive is ignored. Earlier versions did not match the specification and respected the header directive over the attribute. See <a href='https://bugzil.la/1658877'>bug 1658877</a>."
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
This adds a note about a change in behaviour for FF82 in the From FF82 the download directive for an anchor is respected rather than the HTTP Content-Disposition header, inline directive. 
- The defect fix is https://bugzilla.mozilla.org/show_bug.cgi?id=1658877
- Related documentation updates are here: https://github.com/mdn/sprints/issues/3733

Behaviour was verified by the engineer in the bug report.