### PR TITLE
Update BlobBuilder (removed everywhere)

### DIFF
--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": {
             "version_added": "18",
-            "version_removed": "24",
+            "version_removed": "25",
             "prefix": "WebKit"
           },
           "edge": {

--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -6,27 +6,19 @@
         "support": {
           "chrome": {
             "version_added": "8",
-            "prefix": "Webkit"
+            "version_removed": "24",
+            "prefix": "WebKit"
           },
           "chrome_android": {
             "version_added": "18",
-            "prefix": "Webkit"
+            "version_removed": "24",
+            "prefix": "WebKit"
           },
-          "edge": [
-            {
-              "version_added": "79",
-              "prefix": "Webkit"
-            },
-            {
-              "version_added": "≤18",
-              "version_removed": "79"
-            },
-            {
-              "version_added": "12",
-              "version_removed": "79",
-              "prefix": "MS"
-            }
-          ],
+          "edge": {
+            "version_added": "12",
+            "version_removed": "79",
+            "prefix": "MS"
+          },
           "firefox": {
             "version_added": "6",
             "version_removed": "18",
@@ -57,11 +49,13 @@
           },
           "samsunginternet_android": {
             "version_added": "1.0",
-            "prefix": "Webkit"
+            "version_removed": "1.5",
+            "prefix": "WebKit"
           },
           "webview_android": {
             "version_added": "3",
-            "prefix": "Webkit"
+            "version_removed": "≤37",
+            "prefix": "WebKit"
           }
         },
         "status": {


### PR DESCRIPTION
Updated primarily because of the incorrect prefix. It was
"WebKitBlobBuilder" from its introduction until its removal:
https://trac.webkit.org/changeset/83884/webkit
https://trac.webkit.org/changeset/130343/webkit

Chrome's `version_removed` was determined using this test:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8531

The `version_added` was not verified, and the removal version was
mirrored for *_android.

Edge 15 and 18 were tested to confirm that there was only
"MSBlobBuilder".
