### PR TITLE
Use Node.js ≥10 for CI and drop Travis

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,8 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: hoist to 10.x when we bump the version supported in #5931
-        node-version: [ 8.x ]
+        node-version: [ 10.x, 14.x ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        # TODO: hoist to 10.x when we bump the version supported in #5931
-        node-version: 8.x
+        node-version: 10.x
         registry-url: "https://registry.npmjs.org/"
     - run: npm install
     - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - 8
-  - 'lts/dubnium'
-sudo: false
-notifications:
-  email: false

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ This data can be used in documentation, to build compatibility tables listing
 browser support for APIs. For example:
 [Browser support for WebExtension APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs).
 
-[![npm](https://img.shields.io/npm/v/@mdn/browser-compat-data.svg)](https://www.npmjs.com/package/@mdn/browser-compat-data)
-[![Build Status](https://travis-ci.org/mdn/browser-compat-data.svg?branch=master)](https://travis-ci.org/mdn/browser-compat-data)
-[![Twitter Follow](https://img.shields.io/twitter/follow/mozdevnet.svg?style=social&label=Follow&style=plastic)](https://twitter.com/MozDevNet)
-
 Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
 
 Chat on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org).


### PR DESCRIPTION
This upgrades the GitHub Actions workflows to use Node.js 10 and later (10 for publishing releases, 10 and 14 for tests). It also removes the config for Travis CI.

Note that this PR applies to the `master-scoped-package` branch; it won't affect work on `master` until after we end BCD 1.x-series releases (and consequently merge `master-scoped-branch` into `master`).

This is a step toward #5931, but it doesn't completely resolve it.