### PR TITLE
Update Edge versions for AudioContext using mdn-bcd-collector

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -104,7 +104,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "25"
@@ -254,7 +254,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "70"
@@ -481,7 +481,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "25"
@@ -627,7 +627,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "70"
@@ -723,7 +723,7 @@
               "version_added": "41"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "40"


### PR DESCRIPTION
This PR uses the mdn-bcd-collector to update Edge version data for features within AudioContext.