### PR TITLE
Update versions ANGLE_instanced_arrays

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -32,7 +32,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": "2.0"
@@ -79,7 +79,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -127,7 +127,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -175,7 +175,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays",
         "support": {
           "chrome": {
-            "version_added": "30"
+            "version_added": "32"
           },
           "chrome_android": {
-            "version_added": "30"
+            "version_added": "32"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": "17"
+            "version_added": "19"
           },
           "opera_android": {
-            "version_added": "18"
+            "version_added": "19"
           },
           "safari": {
             "version_added": "7"
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "17"
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": "19"
             },
             "safari": {
               "version_added": "7"
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawElementsInstancedANGLE",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "17"
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": "19"
             },
             "safari": {
               "version_added": "7"
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/vertexAttribDivisorANGLE",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -166,10 +166,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "17"
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": "19"
             },
             "safari": {
               "version_added": "7"

--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "33"
+            "version_added": "47"
           },
           "firefox_android": {
             "version_added": true
@@ -61,7 +61,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "33"
+              "version_added": "47"
             },
             "firefox_android": {
               "version_added": true
@@ -109,7 +109,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "33"
+              "version_added": "47"
             },
             "firefox_android": {
               "version_added": true
@@ -157,7 +157,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "33"
+              "version_added": "47"
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates the versions for the ANGLE_instanced_arrays based upon mdn-bcd-collector results and manual testing.  The Chrome version was initially estimated based upon the commit date, but it was proven that it was implemented a few versions later.  Additionally, the Firefox data was incorrect as determined by the collector.