### PR TITLE
Opera Android 60 supports String.replaceAll

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1834,7 +1834,7 @@
                 "version_added": "71"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "13.1"


### PR DESCRIPTION
This is in accordance with the addition in Chromium 85.

I have manually tested and verified support with the example on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll), the same way i did in  #6676
