### PR TITLE
Update CanvasGradient API

### DIFF
--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasGradient",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "6"
           },
           "chrome_android": {
             "version_added": "18"
@@ -30,16 +30,16 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "3.2"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasGradient/addColorStop",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -68,25 +68,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the data for the CanvasGradient API, fixing inaccuracies in the Chrome and Safari data, as well as setting real versions for `addColorStop`.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasGradient