### PR TITLE
Fix Safari version for api.CanvasPattern.setTransform

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -76,7 +76,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": "11"


### PR DESCRIPTION
This PR fixes the Safari version for `CanvasPattern.setTransform()` based upon results from the mdn-bcd-collector project.  Based upon the existing Chrome and Safari iOS versions, it doesn't make sense it was added in Safari 3.1.

Test used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasPattern/setTransform