### PR TITLE
Update Document() data with mdn-bcd-collector data

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -59,13 +59,13 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR updates the Document constructor data with a combination of mdn-bcd-collector data (Edge), as well as manual testing (Firefox, Safari).

Test: https://mdn-bcd-collector.appspot.com/tests/api/Document/Document