### PR TITLE
Add/update Firefox data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11259,11 +11259,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": true
+              "version_removed": "10"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": true
+              "version_removed": "10"
             },
             "ie": {
               "version_added": null
@@ -11309,11 +11309,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": true
+              "version_removed": "10"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": true
+              "version_removed": "10"
             },
             "ie": {
               "version_added": null
@@ -11359,11 +11359,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": true
+              "version_removed": "10"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": true
+              "version_removed": "10"
             },
             "ie": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -5933,11 +5933,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": true
+              "version_removed": "6"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": true
+              "version_removed": "6"
             },
             "ie": {
               "version_added": false
@@ -11109,11 +11109,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": true
+              "version_removed": "6"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": true
+              "version_removed": "6"
             },
             "ie": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -8711,7 +8711,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false,
+              "version_added": true,
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>."
             },
             "firefox_android": {
@@ -10186,7 +10186,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false,
+              "version_added": true,
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>."
             },
             "firefox_android": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -159,10 +159,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -207,10 +207,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -257,10 +257,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -314,10 +314,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "ie": {
               "version_added": null
@@ -370,10 +370,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -644,10 +644,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -694,10 +694,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -796,10 +796,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -927,7 +927,7 @@
             ],
             "firefox": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "alternative_name": "charset",
@@ -935,12 +935,12 @@
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "firefox_android": [
               {
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "alternative_name": "charset",
@@ -948,7 +948,7 @@
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "ie": [
@@ -1068,10 +1068,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -1120,10 +1120,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -1170,10 +1170,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -1218,10 +1218,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -1266,10 +1266,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -1522,10 +1522,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -1570,10 +1570,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -1618,10 +1618,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1666,10 +1666,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -1820,11 +1820,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Doesn't conform to the DOM spec for XUL and XHTML documents: <code>localName</code> and <code>namespaceURI</code> are not set to null on the created element."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1926,10 +1926,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "6"
             },
             "ie": {
               "version_added": false
@@ -2023,10 +2025,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -2119,10 +2121,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -2167,10 +2169,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -2215,10 +2217,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2736,10 +2738,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2834,11 +2836,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Incorrect behavior before Firefox 23."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Incorrect behavior before Firefox 23."
             },
             "ie": {
@@ -2886,10 +2888,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -2982,10 +2984,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -3130,11 +3132,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "From Firefox 62, if the domain cannot be identified, <code>domain</code> returns an empty string instead of <code>null</code>. See <a href='https://bugzil.la/819475'>bug 819475</a>."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "From Firefox 62, if the domain cannot be identified, <code>domain</code> returns an empty string instead of <code>null</code>. See <a href='https://bugzil.la/819475'>bug 819475</a>."
             },
             "ie": {
@@ -3631,10 +3633,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -3681,10 +3683,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -4068,13 +4070,13 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "14",
               "partial_implementation": true,
               "notes": "This method never did anything and always threw an exception."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "14",
               "partial_implementation": true,
               "notes": "This method never did anything and always threw an exception."
@@ -4531,10 +4533,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -4645,9 +4647,22 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "41"
+              },
+              {
+                "version_added": "35",
+                "version_removed": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-loading-api.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -4691,10 +4706,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -5320,6 +5335,9 @@
             ],
             "firefox_android": [
               {
+                "version_added": "79"
+              },
+              {
                 "version_added": "63",
                 "partial_implementation": true,
                 "notes": "Not supported on <code>ShadowRoot</code>.",
@@ -5740,10 +5758,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -5988,10 +6006,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": true
             },
             "ie": {
               "version_added": false
@@ -6118,10 +6138,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -6166,10 +6186,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -6463,10 +6483,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -6511,10 +6531,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -6561,10 +6581,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -6611,10 +6631,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -6819,10 +6839,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -6963,10 +6983,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "10"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "10"
             },
             "ie": {
               "version_added": false
@@ -7011,10 +7031,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "10"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "10"
             },
             "ie": {
               "version_added": false
@@ -7059,10 +7079,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -7107,10 +7127,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -7409,10 +7429,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -7456,10 +7476,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -7504,10 +7524,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -7552,10 +7572,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -7710,10 +7730,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -7913,10 +7933,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -8765,7 +8785,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": false,
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>."
             },
             "firefox_android": {
@@ -8814,10 +8834,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -8924,10 +8944,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -8972,10 +8992,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -9083,13 +9103,13 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "14",
               "partial_implementation": true,
               "notes": "This method never did anything and always threw an exception."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "14",
               "partial_implementation": true,
               "notes": "This method never did anything and always threw an exception."
@@ -9137,10 +9157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -9520,10 +9540,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -9570,10 +9590,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -9880,10 +9900,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -10074,10 +10094,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -10192,10 +10212,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -10240,7 +10260,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": false,
               "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>."
             },
             "firefox_android": {
@@ -11016,10 +11036,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -11162,10 +11182,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": true
             },
             "ie": {
               "version_added": false
@@ -11260,10 +11282,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -11310,10 +11332,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": true
             },
             "ie": {
               "version_added": null
@@ -11358,10 +11382,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": true
             },
             "ie": {
               "version_added": null
@@ -11406,10 +11432,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": true
             },
             "ie": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -4631,38 +4631,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-loading-api.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-loading-api.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },
@@ -5307,30 +5281,6 @@
                     "name": "dom.animations-api.getAnimations.enabled"
                   }
                 ]
-              },
-              {
-                "version_added": "47",
-                "version_removed": "63",
-                "partial_implementation": true,
-                "notes": "Not supported on <code>ShadowRoot</code>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "46",
-                "version_removed": "47",
-                "partial_implementation": true,
-                "notes": "Does not return any animations on pseudo-elements and is not supported on <code>ShadowRoot</code>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -5345,30 +5295,6 @@
                   {
                     "type": "preference",
                     "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "47",
-                "version_removed": "63",
-                "partial_implementation": true,
-                "notes": "Not supported on <code>ShadowRoot</code>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "46",
-                "version_removed": "47",
-                "partial_implementation": true,
-                "notes": "Does not return any animations on pseudo-elements and is not supported on <code>ShadowRoot</code>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
                   }
                 ]
               }


### PR DESCRIPTION
This PR updates the Firefox data for the Document API based upon manual testing to achieve more real data for the Document API.  This also includes a little bit of irrelevant flag removal to simplify the data.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Document