### PR TITLE
Add/update IE/EdgeHTML data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -165,7 +165,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -263,7 +263,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -320,7 +320,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -650,7 +650,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -700,7 +700,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -802,7 +802,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -914,15 +914,15 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               {
                 "alternative_name": "charset",
-                "version_added": "≤79"
+                "version_added": "12"
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": "≤79"
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -953,15 +953,15 @@
             ],
             "ie": [
               {
-                "version_added": null
+                "version_added": "9"
               },
               {
                 "alternative_name": "charset",
-                "version_added": null
+                "version_added": "4"
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": null
+                "version_added": "9"
               }
             ],
             "opera": [
@@ -1074,7 +1074,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -1126,7 +1126,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -1176,7 +1176,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -1215,7 +1215,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1480,7 +1480,7 @@
               }
             ],
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -1528,7 +1528,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1576,7 +1576,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1624,7 +1624,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -1672,7 +1672,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -2173,7 +2173,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -2842,7 +2842,7 @@
               "notes": "Incorrect behavior before Firefox 23."
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -2892,7 +2892,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -2988,7 +2988,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -3138,7 +3138,7 @@
               "notes": "From Firefox 62, if the domain cannot be identified, <code>domain</code> returns an empty string instead of <code>null</code>. See <a href='https://bugzil.la/819475'>bug 819475</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -3637,7 +3637,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4080,7 +4080,7 @@
               "notes": "This method never did anything and always threw an exception."
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
               "version_added": false
@@ -4537,7 +4537,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4697,7 +4697,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -5746,7 +5746,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -6124,7 +6124,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -6172,7 +6172,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -6469,7 +6469,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -6567,7 +6567,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -6617,7 +6617,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7558,7 +7558,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7660,7 +7660,7 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "12.1",
@@ -7716,7 +7716,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7769,7 +7769,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "28",
@@ -7919,7 +7919,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -8930,7 +8930,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -8978,7 +8978,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -9095,7 +9095,7 @@
               "notes": "This method never did anything and always threw an exception."
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
               "version_added": false
@@ -9143,7 +9143,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -9526,7 +9526,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5"
             },
             "opera": {
               "version_added": null
@@ -9576,7 +9576,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -10150,7 +10150,7 @@
               }
             ],
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -10198,7 +10198,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -11022,7 +11022,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -11266,7 +11266,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -11316,7 +11316,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -11364,7 +11364,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -11412,7 +11412,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -7660,7 +7660,7 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1",


### PR DESCRIPTION
This PR updates the Internet Explorer and pre-Blink Edge data for the Document API based upon manual testing to achieve more real data for the Document API.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Document