### PR TITLE
Add/update Safari data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7681,10 +7681,10 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -5037,11 +5037,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true,
+              "version_added": "6",
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "6",
               "prefix": "webkit"
             },
             "samsunginternet_android": [
@@ -7273,11 +7273,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true,
+              "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
             },
             "samsunginternet_android": {
@@ -7378,11 +7378,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true,
+              "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
             },
             "samsunginternet_android": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -272,10 +272,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -329,10 +329,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -385,10 +385,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -659,10 +659,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -709,10 +709,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -811,10 +811,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -861,10 +861,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -992,28 +992,28 @@
             ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "3"
               },
               {
                 "alternative_name": "charset",
-                "version_added": "9"
+                "version_added": "3"
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": null
+                "version_added": "3"
               }
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "alternative_name": "charset",
-                "version_added": null
+                "version_added": "1"
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": null
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -1083,10 +1083,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -1135,10 +1135,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -1185,10 +1185,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1233,10 +1233,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1281,10 +1281,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1489,10 +1489,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1537,10 +1537,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1585,10 +1585,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1633,10 +1633,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1681,10 +1681,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1836,10 +1836,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1941,10 +1941,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -2038,10 +2040,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2134,10 +2136,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2230,10 +2232,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2751,10 +2753,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2851,10 +2853,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -2901,10 +2903,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2997,10 +2999,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3147,10 +3149,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3195,10 +3197,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3646,10 +3648,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -3696,10 +3698,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4320,10 +4322,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": [
               {
@@ -4546,10 +4548,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -4706,10 +4708,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5035,10 +5037,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true,
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true,
+              "prefix": "webkit"
             },
             "samsunginternet_android": [
               {
@@ -5755,10 +5759,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6003,10 +6007,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -6133,10 +6139,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6181,10 +6187,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6229,10 +6235,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6478,10 +6484,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6526,10 +6532,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -6576,10 +6582,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -6626,10 +6632,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6930,10 +6936,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -6978,10 +6984,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -7026,10 +7032,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -7074,10 +7080,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7122,10 +7128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7267,10 +7273,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkitfullscreenchange"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkitfullscreenchange"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -7370,10 +7378,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkitfullscreenerror"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkitfullscreenerror"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -7424,10 +7434,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7471,10 +7481,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7519,10 +7529,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7567,10 +7577,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7671,14 +7681,10 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -7725,10 +7731,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -7780,10 +7786,12 @@
               "version_removed": "50"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1",
+              "version_removed": "14"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -7928,10 +7936,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -8829,10 +8837,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8891,10 +8899,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8939,10 +8947,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8987,10 +8995,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -9049,10 +9057,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -9152,10 +9160,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -9535,10 +9543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9585,10 +9593,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -9690,10 +9698,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9738,10 +9746,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -9895,10 +9903,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -10089,10 +10097,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -10207,10 +10215,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -10786,10 +10794,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -11031,10 +11039,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -11177,10 +11185,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -11275,10 +11285,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -11325,10 +11335,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -11373,10 +11383,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -11421,10 +11431,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -7579,10 +7579,14 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "7",
+              "partial_implementation": true,
+              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR updates the Safari data for the Document API based upon a combination of manual testing and collector results to achieve more real data for the Document API.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Document