### PR TITLE
Add/update IE/EdgeHTML data for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -886,7 +886,7 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": true
             },
             "opera_android": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -883,10 +883,10 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
               "version_added": true
@@ -1129,7 +1129,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": "0.9.1",
@@ -2034,7 +2034,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -2196,7 +2196,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -2287,7 +2287,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -2391,7 +2391,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true
@@ -2439,7 +2439,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -3514,7 +3514,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4095,7 +4095,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4143,7 +4143,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4384,7 +4384,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -4690,7 +4690,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -4738,7 +4738,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -5901,7 +5901,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "3"
@@ -6989,7 +6989,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -7379,7 +7379,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7428,7 +7428,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7625,7 +7625,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -7673,7 +7673,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -7721,7 +7721,7 @@
               "version_added": "64"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -7769,7 +7769,7 @@
               "version_added": "64"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -7819,7 +7819,7 @@
               "notes": "Before Firefox 28, Gecko was using device pixels instead of CSS pixels; in other words, it was assuming a value of <code>screenPixelsPerCSSPixel</code> of 1 for any device."
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -7869,7 +7869,7 @@
               "notes": "Before Firefox 28, Gecko was using device pixels instead of CSS pixels; in other words, it was assuming a value of <code>screenPixelsPerCSSPixel</code> of 1 for any device."
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -8459,7 +8459,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -8484,15 +8484,10 @@
                 "alternative_name": "pageXOffset"
               }
             ],
-            "ie": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "9",
-                "alternative_name": "pageXOffset"
-              }
-            ],
+            "ie": {
+              "version_added": "9",
+              "alternative_name": "pageXOffset"
+            },
             "opera": [
               {
                 "version_added": true
@@ -8627,7 +8622,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -8786,7 +8781,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -9235,7 +9230,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -9477,7 +9472,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -10555,7 +10550,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates the Internet Explorer and pre-Blink Edge data for the Window API based upon manual testing to achieve more real data for the Window API.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Window