### PR TITLE
Updates to allow-downloads

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -798,13 +798,13 @@
                 "version_added": "83"
               },
               "edge": {
-                "version_added": null
+                "version_added": "83"
               },
               "firefox": {
-                "version_added": "81"
+                "version_added": "82"
               },
               "firefox_android": {
-                "version_added": "81"
+                "version_added": "82"
               },
               "ie": {
                 "version_added": false
@@ -816,16 +816,16 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "83"
               }
             },
             "status": {


### PR DESCRIPTION
The `sandbox="allow-downloads"` seems to be shipping in 82 not 81. https://bugzilla.mozilla.org/show_bug.cgi?id=1656212 so I have updated that while working on https://github.com/mdn/sprints/issues/3727 
