### PR TITLE
Add/update IE/EdgeHTML data for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -441,7 +441,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -489,7 +489,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true,
@@ -556,7 +556,7 @@
               "notes": "Prior to Firefox 8, <code>navigator.cookieEnabled</code> would report the wrong result if a site exception was in place for the page on which the check was performed. This has been fixed."
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -643,7 +643,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -1179,7 +1179,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -1358,7 +1358,7 @@
               "version_added": "36"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -1640,7 +1640,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -1704,7 +1704,8 @@
               "notes": "Always returns <code>20030107</code>."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Always returns <code>20030107</code>."
             },
             "firefox": {
               "version_added": true
@@ -1713,8 +1714,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true,
-              "notes": "Always returns <code>undefined</code>."
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -1809,7 +1809,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
             },
             "firefox": {
@@ -2159,7 +2159,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -2207,7 +2207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "15"
@@ -2250,7 +2250,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -2385,7 +2385,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "50"


### PR DESCRIPTION
This PR updates the IE and EdgeHTML data for the Navigator API using the mdn-bcd-collector project, aided with a little manual testing, to achieve more real data for the Navigator API.

Notes:
- `productSub` had a note for IE that said it "always returns `undefined`".  Since that's basically the same behavior of an unimplemented feature, it makes no sense to mark it as `true`.
- `productSub` __does__ return the same value in Edge 12 as it does in Chrome/Safari.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator