### PR TITLE
Add/update WebKit + Blink data for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2245,11 +2245,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vibrate",
           "support": {
             "chrome": {
-              "version_added": "32",
-              "notes": [
-                "Beginning in Chrome 55, this is not supported in cross-origin iframes.",
-                "Beginning in Chrome 60, this method requires a user gesture. Otherwise it returns <code>false</code>."
-              ]
+              "version_added": "32"
             },
             "chrome_android": {
               "version_added": "32",
@@ -2292,18 +2288,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "19",
-              "notes": [
-                "Beginning in Opera 42, this is not supported in cross-origin iframes.",
-                "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
-              ]
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "19",
-              "notes": [
-                "Beginning in Opera for Android 42, this is not supported in cross-origin iframes.",
-                "Beginning in Opera for Android 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
-              ]
+              "version_added": true,
+              "notes": "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
             },
             "safari": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -453,10 +453,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"
@@ -559,10 +559,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -571,7 +571,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -607,16 +607,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -661,10 +661,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -837,10 +837,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getBattery",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
@@ -871,10 +871,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "38"
             }
           },
           "status": {
@@ -937,10 +937,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": [
               {
@@ -1025,10 +1025,12 @@
               "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "safari": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "samsunginternet_android": [
               {
@@ -1197,10 +1199,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -1319,10 +1321,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -1343,10 +1345,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/mediaDevices",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -1361,10 +1363,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": false
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -1376,7 +1378,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "47"
             }
           },
           "status": {
@@ -1439,13 +1441,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/mediaSession",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "73"
             },
             "chrome_android": {
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"
@@ -1463,10 +1465,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -1634,10 +1636,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/presentation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "≤79"
@@ -1666,19 +1668,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -1696,11 +1698,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/productSub",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Always returns <code>20030107</code>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Always returns <code>20030107</code>."
             },
             "edge": {
@@ -1717,25 +1719,28 @@
               "notes": "Always returns <code>undefined</code>."
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "notes": "Always returns <code>20030107</code>."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14",
+              "notes": "Always returns <code>20030107</code>."
             },
             "safari": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Always returns <code>20030107</code>."
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Always returns <code>20030107</code>."
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Always returns <code>20030107</code>."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Always returns <code>20030107</code>."
             }
           },
           "status": {
@@ -1825,10 +1830,10 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -1869,13 +1874,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "67"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false
@@ -1950,10 +1955,10 @@
               ]
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -2102,7 +2107,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": false
+              "version_added": "81"
             },
             "firefox": {
               "version_added": false
@@ -2147,55 +2152,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "vendorSub": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vendorSub",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2216,16 +2173,64 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vendorSub": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vendorSub",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
               "version_added": true
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {
@@ -2240,7 +2245,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vibrate",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "32",
+              "notes": [
+                "Beginning in Chrome 55, this is not supported in cross-origin iframes.",
+                "Beginning in Chrome 60, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "chrome_android": {
               "version_added": "32",
@@ -2283,11 +2292,18 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "19",
+              "notes": [
+                "Beginning in Opera 42, this is not supported in cross-origin iframes.",
+                "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              "version_added": "19",
+              "notes": [
+                "Beginning in Opera for Android 42, this is not supported in cross-origin iframes.",
+                "Beginning in Opera for Android 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "safari": {
               "version_added": false
@@ -2394,10 +2410,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR updates the Chromium, Safari, and Opera data for the Navigator API using the mdn-bcd-collector project, aided with a little manual testing, to achieve more real data for the Navigator API.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator