### PR TITLE
Add/update Firefox data for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1550,7 +1550,7 @@
               "notes": "The preference <code>\"general.oscpu.override\"</code> can be used to set a value to be returned instead of the true CPU description. The preference setting is ignored for calls made by privileged code, which continue to get the actual CPU description."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
               "notes": "The preference <code>\"general.oscpu.override\"</code> can be used to set a value to be returned instead of the true CPU description. The preference setting is ignored for calls made by privileged code, which continue to get the actual CPU description."
             },
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -598,10 +598,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "ie": {
               "version_added": false
@@ -646,10 +646,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1182,10 +1182,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1448,10 +1448,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1546,11 +1546,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "The preference <code>\"general.oscpu.override\"</code> can be used to set a value to be returned instead of the true CPU description. The preference setting is ignored for calls made by privileged code, which continue to get the actual CPU description."
             },
             "firefox_android": {
               "version_added": true
+              "notes": "The preference <code>\"general.oscpu.override\"</code> can be used to set a value to be returned instead of the true CPU description. The preference setting is ignored for calls made by privileged code, which continue to get the actual CPU description."
             },
             "ie": {
               "version_added": false
@@ -1707,10 +1708,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true,
@@ -1917,7 +1918,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "38",
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
                 "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
@@ -1925,7 +1926,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "38",
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
                 "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
@@ -2153,10 +2154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -2201,7 +2202,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": true
@@ -2379,10 +2380,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Firefox data for the Navigator API using the mdn-bcd-collector project, aided with a little manual testing, to achieve more real data for the Navigator API.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator