### PR TITLE
Fix visibilitychange event data for IE/Edge

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7651,7 +7651,8 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "18",
+              "notes": "Before Edge 18, this event handler was not supported, however the event itself was supported since Edge 12. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "firefox": {
               "version_added": "56"
@@ -7660,7 +7661,8 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": false
+              "version_added": false,
+              "notes": "This event handler is not supported, however the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "opera": {
               "version_added": "12.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -10825,7 +10825,8 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "The <code>onvisibilitychange</code> property was not supported until Edge 18. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "firefox": {
               "version_added": "56"
@@ -10834,7 +10835,8 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "The <code>onvisibilitychange</code> property is not supported in IE. To listen to this event, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "opera": {
               "version_added": "12.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7652,7 +7652,7 @@
             },
             "edge": {
               "version_added": "18",
-              "notes": "Before Edge 18, this event handler was not supported, however the event itself was supported since Edge 12. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "Before Edge 18, this event handler attribute was not supported, however the event itself was supported since Edge 12. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "firefox": {
               "version_added": "56"
@@ -7662,7 +7662,7 @@
             },
             "ie": {
               "version_added": false,
-              "notes": "This event handler is not supported, however the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "This event handler attribute is not supported, however the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "opera": {
               "version_added": "12.1",
@@ -10826,7 +10826,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "The <code>onvisibilitychange</code> property was not supported until Edge 18. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "The <code>onvisibilitychange</code> attribute was not supported until Edge 18. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "firefox": {
               "version_added": "56"
@@ -10836,7 +10836,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "The <code>onvisibilitychange</code> property is not supported in IE. To listen to this event, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "The <code>onvisibilitychange</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "opera": {
               "version_added": "12.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7660,7 +7660,7 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "12.1",
@@ -10823,7 +10823,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "56"

--- a/api/Document.json
+++ b/api/Document.json
@@ -7662,7 +7662,7 @@
             },
             "ie": {
               "version_added": false,
-              "notes": "This event handler attribute is not supported, however the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "This event handler attribute is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "opera": {
               "version_added": "12.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7652,7 +7652,7 @@
             },
             "edge": {
               "version_added": "18",
-              "notes": "Before Edge 18, this event handler attribute was not supported, however the event itself was supported since Edge 12. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "Before Edge 18, this event handler attribute was not supported; however, the event itself was supported since Edge 12. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "firefox": {
               "version_added": "56"


### PR DESCRIPTION
This PR fixes data for the `visibilitychange` event and handler for IE and Edge.  As determined by manual testing (after reviewing results from the mdn-bcd-collector), Internet Explorer and Edge had no support for `onvisibilitychange` until Edge 18.  However, it supported the event since IE 10, through `addEventListener`.

Test code used:
```js
document.addEventListener("visibilitychange", function() {
  if (document.visibilityState === 'visible') {
    console.log('addEventListener: visible');
  } else {
    console.log('addEventListener: hidden');
  }
});

document.onvisibilitychange = function() {
  if (document.visibilityState === 'visible') {
    console.log('onvisibilitychange: visible');
  } else {
    console.log('onvisibilitychange: hidden');
  }
};
```