### PR TITLE
text-combine-upright note

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -33,6 +33,10 @@
             },
             "firefox": [
               {
+                "version_added": "81",
+                "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
+              },
+              {
                 "version_added": "48",
                 "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
               },
@@ -71,6 +75,10 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "81",
+                "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
+              },
               {
                 "version_added": "48",
                 "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."


### PR DESCRIPTION
Added a note to the `text-combine-upright` property as it was made non-animatable in Firefox 81: https://bugzilla.mozilla.org/show_bug.cgi?id=1654195