### PR TITLE
Add/update Chromium data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -153,7 +153,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -174,16 +174,16 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -201,7 +201,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -222,16 +222,16 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -246,11 +246,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/alinkColor",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -278,11 +278,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -297,14 +297,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "3",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
@@ -335,14 +335,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": [
                 "Starting in Samsung Internet 9.0, this property is readonly.",
                 "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "≤37",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
@@ -364,7 +364,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -391,10 +391,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -638,7 +638,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -665,10 +665,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -683,11 +683,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/bgColor",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -715,11 +715,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -785,11 +785,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/captureEvents",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -817,11 +817,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -840,7 +840,7 @@
               "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -867,10 +867,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -900,16 +900,16 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "18"
               },
               {
                 "alternative_name": "charset",
-                "version_added": true,
+                "version_added": "18",
                 "notes": "<code>charset</code> alias was made read-only in Chrome 45."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -1018,30 +1018,30 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": "5.0"
+                "version_added": "1.0"
               },
               {
                 "alternative_name": "charset",
-                "version_added": true,
+                "version_added": "1.0",
                 "notes": "<code>charset</code> alias was made read-only in Samsung Internet 5.0."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "1"
               },
               {
                 "alternative_name": "charset",
-                "version_added": true,
+                "version_added": "1",
                 "notes": "<code>charset</code> alias was made read-only in WebView 45."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": true
+                "version_added": "1"
               }
             ]
           },
@@ -1057,11 +1057,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/clear",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -1089,11 +1089,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -1109,11 +1109,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/close",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -1141,11 +1141,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -1161,10 +1161,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/compatMode",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1191,10 +1191,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1209,10 +1209,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/contains",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1239,10 +1239,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1257,10 +1257,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/contentType",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "36"
             },
             "edge": {
               "version_added": "17"
@@ -1274,12 +1274,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "23"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": true
             },
@@ -1287,10 +1299,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "37"
             }
           },
           "status": {
@@ -1454,7 +1466,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1495,10 +1507,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1516,7 +1528,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1543,10 +1555,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1564,7 +1576,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1591,10 +1603,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1612,7 +1624,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1639,10 +1651,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1660,7 +1672,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1687,10 +1699,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1814,7 +1826,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1842,10 +1854,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1917,10 +1929,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEntityReference",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "30"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "30"
             },
             "edge": {
               "version_added": false
@@ -1949,10 +1963,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "2.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "≤37"
             }
           },
           "status": {
@@ -2019,7 +2035,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2046,10 +2062,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2115,7 +2131,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2142,10 +2158,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2163,7 +2179,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2211,7 +2227,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2238,10 +2254,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2732,7 +2748,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2759,10 +2775,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2825,11 +2841,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/dir",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -2859,11 +2875,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -2882,7 +2898,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2909,10 +2925,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2978,7 +2994,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -3005,10 +3021,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3126,7 +3142,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3155,10 +3171,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3622,11 +3638,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/embeds",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -3654,11 +3670,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -4275,7 +4291,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "37"
               },
               {
                 "version_added": "22",
@@ -4284,10 +4300,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "25",
                 "prefix": "webkit"
               }
             ],
@@ -4315,12 +4331,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": true
             },
@@ -4329,7 +4357,7 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "5.0"
+                "version_added": "3.0"
               },
               {
                 "prefix": "webkit",
@@ -4338,10 +4366,10 @@
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -4522,11 +4550,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fgColor",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -4554,11 +4582,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -4623,10 +4651,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fonts",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
@@ -4641,10 +4669,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -4653,10 +4681,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4674,7 +4702,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4701,10 +4729,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4738,7 +4766,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               {
                 "version_added": "≤79",
@@ -5165,6 +5193,9 @@
           "support": {
             "chrome": [
               {
+                "version_added": "84"
+              },
+              {
                 "version_added": "83",
                 "flags": [
                   {
@@ -5200,6 +5231,9 @@
             ],
             "chrome_android": [
               {
+                "version_added": "84"
+              },
+              {
                 "version_added": "83",
                 "flags": [
                   {
@@ -5234,6 +5268,9 @@
               }
             ],
             "edge": [
+              {
+                "version_added": "84"
+              },
               {
                 "version_added": "83",
                 "flags": [
@@ -5304,6 +5341,9 @@
             },
             "opera": [
               {
+                "version_added": "70"
+              },
+              {
                 "version_added": "69",
                 "flags": [
                   {
@@ -5338,6 +5378,9 @@
               }
             ],
             "opera_android": [
+              {
+                "version_added": "60"
+              },
               {
                 "version_added": "48",
                 "partial_implementation": true,
@@ -5416,8 +5459,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only"
+              "version_added": "84"
             }
           },
           "status": {
@@ -5678,7 +5720,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -5705,10 +5747,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5820,13 +5862,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "85"
             },
             "edge": {
-              "version_added": false
+              "version_added": "85"
             },
             "firefox": {
               "version_added": "65"
@@ -5845,10 +5887,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "11.1"
@@ -5860,7 +5902,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "85"
             }
           },
           "status": {
@@ -5923,10 +5965,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/height",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": true
             },
             "edge": {
               "version_added": false
@@ -5955,10 +5999,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             }
           },
           "status": {
@@ -6058,7 +6104,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6085,10 +6131,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6106,7 +6152,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6133,10 +6179,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6154,7 +6200,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6181,10 +6227,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6403,7 +6449,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6430,10 +6476,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6496,11 +6542,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/linkColor",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -6528,11 +6574,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -6551,7 +6597,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6578,10 +6624,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6996,10 +7042,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/oncopy",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -7026,10 +7072,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7044,10 +7090,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/oncut",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -7074,10 +7120,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7206,21 +7252,39 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenchange"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "32",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "32",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "safari": {
               "version_added": null
             },
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "5.0",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
@@ -7309,21 +7373,39 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenerror"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "32",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "32",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "safari": {
               "version_added": null
             },
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "5.0",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
@@ -7346,10 +7428,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onpaste",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -7376,10 +7458,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7393,10 +7475,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "edge": {
               "version_added": "13"
@@ -7411,10 +7493,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
               "version_added": true
@@ -7423,10 +7505,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -7441,10 +7523,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onpointerlockerror",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "edge": {
               "version_added": "13"
@@ -7459,10 +7541,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
               "version_added": true
@@ -7471,10 +7553,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -7489,10 +7571,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onreadystatechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7519,10 +7601,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -7584,17 +7666,11 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onvisibilitychange",
           "support": {
-            "chrome": [
-              {
-                "version_added": "33"
-              },
-              {
-                "version_added": "13",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "62"
+            },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "62"
             },
             "edge": {
               "version_added": "18"
@@ -7627,10 +7703,10 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "62"
             }
           },
           "status": {
@@ -7645,11 +7721,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/open",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -7677,11 +7753,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -7848,11 +7924,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/plugins",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -7880,11 +7956,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -8751,13 +8827,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/preferredStyleSheetSet",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "3"
@@ -8781,10 +8857,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -8802,7 +8878,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8843,10 +8919,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8864,7 +8940,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8882,7 +8958,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -8891,10 +8967,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8912,7 +8988,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8939,10 +9015,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8960,7 +9036,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9001,10 +9077,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9077,7 +9153,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9104,10 +9180,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9378,11 +9454,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/registerElement",
           "support": {
             "chrome": {
-              "version_added": "35",
+              "version_added": "33",
               "version_removed": "80"
             },
             "chrome_android": {
-              "version_added": "35",
+              "version_added": "33",
               "version_removed": "80"
             },
             "edge": {
@@ -9425,11 +9501,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "25",
+              "version_added": "23",
               "version_removed": "67"
             },
             "opera_android": {
-              "version_added": "25"
+              "version_added": "24",
+              "version_removed": "57"
             },
             "safari": {
               "version_added": false
@@ -9438,10 +9515,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "version_removed": "13.0"
             },
             "webview_android": {
-              "version_added": "37",
+              "version_added": "4.4.3",
               "version_removed": "80"
             }
           },
@@ -9478,7 +9556,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -9505,11 +9583,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/releaseEvents",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -9537,11 +9615,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -9557,13 +9635,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "85"
             },
             "edge": {
-              "version_added": false
+              "version_added": "85"
             },
             "firefox": {
               "version_added": "65"
@@ -9582,10 +9660,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "11.1"
@@ -9597,7 +9675,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "85"
             }
           },
           "status": {
@@ -9660,10 +9738,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/scripts",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9690,10 +9768,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9817,13 +9895,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/selectedStyleSheetSet",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "3"
@@ -9847,10 +9925,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -10059,15 +10137,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/timeline",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only"
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only"
+              "version_added": "84"
             },
             "edge": {
-              "version_added": false
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "75"
@@ -10099,10 +10175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "13.1"
@@ -10114,7 +10190,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -10132,7 +10208,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -10159,10 +10235,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -10951,11 +11027,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/vlinkColor",
           "support": {
             "chrome": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "64",
+              "version_added": "18",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -10983,11 +11059,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "9.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "64",
+              "version_added": "1",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -11099,10 +11175,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/width",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": true
             },
             "edge": {
               "version_added": false
@@ -11131,10 +11209,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": true
             }
           },
           "status": {
@@ -11197,11 +11277,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -11229,11 +11309,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -11252,7 +11332,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -11281,10 +11361,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -11302,7 +11382,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -11331,10 +11411,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -11352,7 +11432,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -11381,10 +11461,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -153,7 +153,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -180,10 +180,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -201,7 +201,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -228,10 +228,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -364,7 +364,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -391,10 +391,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -638,7 +638,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -665,10 +665,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -840,7 +840,7 @@
               "version_added": "8"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -867,10 +867,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": true
             }
           },
           "status": {
@@ -1418,7 +1418,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1459,10 +1459,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1480,7 +1480,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1507,10 +1507,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1528,7 +1528,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1555,10 +1555,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1576,7 +1576,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1603,10 +1603,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1624,7 +1624,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1651,10 +1651,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1778,7 +1778,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1806,10 +1806,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -1989,7 +1989,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2016,10 +2016,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -2085,7 +2085,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2112,10 +2112,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -2133,7 +2133,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2181,7 +2181,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2208,10 +2208,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -2702,7 +2702,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2729,10 +2729,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -2852,7 +2852,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2879,10 +2879,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -2948,7 +2948,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -2975,10 +2975,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -3096,7 +3096,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3125,10 +3125,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -4656,7 +4656,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -4683,10 +4683,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -5676,7 +5676,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6062,7 +6062,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6089,10 +6089,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -6110,7 +6110,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6137,10 +6137,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -6158,7 +6158,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6185,10 +6185,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -6407,7 +6407,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6434,10 +6434,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -6555,7 +6555,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -6582,10 +6582,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -8842,7 +8842,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -8883,10 +8883,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -8904,7 +8904,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -8931,10 +8931,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -8952,7 +8952,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -8979,10 +8979,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -9000,7 +9000,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -9041,10 +9041,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -9117,7 +9117,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -9144,10 +9144,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -10172,7 +10172,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -10199,10 +10199,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -11298,7 +11298,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -11327,10 +11327,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -11348,7 +11348,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -11377,10 +11377,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {
@@ -11398,7 +11398,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -11427,10 +11427,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -174,10 +174,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -222,10 +222,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -5921,12 +5921,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/height",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "18",
-              "version_removed": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -5957,12 +5955,10 @@
               "version_removed": "10"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "1",
-              "version_removed": true
+              "version_added": false
             }
           },
           "status": {
@@ -7210,24 +7206,12 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenchange"
             },
-            "opera": [
-              {
-                "version_added": "58"
-              },
-              {
-                "version_added": "32",
-                "alternative_name": "onwebkitfullscreenchange"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "32",
-                "alternative_name": "onwebkitfullscreenchange"
-              }
-            ],
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": {
               "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
@@ -7236,15 +7220,9 @@
               "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "10.0"
-              },
-              {
-                "version_added": "5.0",
-                "alternative_name": "onwebkitfullscreenchange"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": [
               {
                 "version_added": "71"
@@ -7333,24 +7311,12 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenerror"
             },
-            "opera": [
-              {
-                "version_added": "58"
-              },
-              {
-                "version_added": "32",
-                "alternative_name": "onwebkitfullscreenerror"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "32",
-                "alternative_name": "onwebkitfullscreenerror"
-              }
-            ],
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": {
               "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
@@ -7359,15 +7325,9 @@
               "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "10.0"
-              },
-              {
-                "version_added": "5.0",
-                "alternative_name": "onwebkitfullscreenerror"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": [
               {
                 "version_added": "71"
@@ -7628,11 +7588,17 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onvisibilitychange",
           "support": {
-            "chrome": {
-              "version_added": "62"
-            },
+            "chrome": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "13",
+                "prefix": "webkit"
+              }
+            ],
             "chrome_android": {
-              "version_added": "62"
+              "version_added": "33"
             },
             "edge": {
               "version_added": "18"
@@ -7665,10 +7631,10 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "62"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8922,7 +8888,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": true
             },
             "safari": {
               "version_added": "2"
@@ -11139,12 +11105,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/width",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "18",
-              "version_removed": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -11175,12 +11139,10 @@
               "version_removed": "10"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "1",
-              "version_removed": true
+              "version_added": false
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -246,11 +246,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/alinkColor",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -278,11 +278,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -297,14 +297,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "3",
+              "version_added": "64",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
@@ -335,14 +335,14 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": [
                 "Starting in Samsung Internet 9.0, this property is readonly.",
                 "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
               ]
             },
             "webview_android": {
-              "version_added": "≤37",
+              "version_added": "64",
               "notes": [
                 "Starting in Chrome 65, this property is readonly.",
                 "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
@@ -683,11 +683,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/bgColor",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -715,11 +715,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -785,11 +785,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/captureEvents",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -817,11 +817,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -1057,11 +1057,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/clear",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -1089,11 +1089,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -1109,11 +1109,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/close",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -1141,11 +1141,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -2795,11 +2795,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/dir",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -2829,11 +2829,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -3592,11 +3592,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/embeds",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -3624,11 +3624,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -4504,11 +4504,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fgColor",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -4536,11 +4536,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -6500,11 +6500,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/linkColor",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -6532,11 +6532,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -7683,11 +7683,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/open",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -7715,11 +7715,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -7888,11 +7888,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/plugins",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -7920,11 +7920,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -9547,11 +9547,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/releaseEvents",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -9579,11 +9579,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -10991,11 +10991,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/vlinkColor",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -11023,11 +11023,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "9.0",
               "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "64",
               "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
@@ -11243,11 +11243,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/writeln",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
@@ -11275,11 +11275,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "5.0",
               "notes": "Before Samsung Internet 9.0, this method was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "45",
               "notes": "Before Chrome 64, this method was accessed through the <code>HTMLDocument</code> alias."
             }
           },


### PR DESCRIPTION
This PR updates the Chromium data for the Document API based upon a combination of manual testing and collector results to achieve more real data for the Document API.  (Note: most Opera updates have been deferred to #6835.)

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Document