### PR TITLE
Add/update Chromium data for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1560,10 +1560,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/crypto",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "12"
@@ -1579,10 +1579,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "24"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "safari": {
               "version_added": "6.1"
@@ -1591,10 +1591,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "37"
             }
           },
           "status": {
@@ -2180,10 +2180,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2205,10 +2205,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -901,7 +901,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -972,10 +972,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -1023,10 +1023,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1560,10 +1560,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/crypto",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1579,10 +1579,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": "24"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "24"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6.1"
@@ -1591,10 +1591,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2019,10 +2019,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/document",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2049,10 +2049,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2180,10 +2180,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/external",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2205,10 +2205,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2256,7 +2256,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2305,7 +2305,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2376,10 +2376,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/frameElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2406,10 +2406,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2424,10 +2424,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/frames",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2454,10 +2454,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3305,10 +3305,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/isSecureContext",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "15"
@@ -3323,10 +3323,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": true
@@ -3335,10 +3335,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "47"
             }
           },
           "status": {
@@ -3499,10 +3499,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3529,10 +3529,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3742,10 +3742,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/locationbar",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3772,10 +3772,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3886,10 +3886,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/menubar",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3916,10 +3916,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4080,10 +4080,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/moveBy",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4110,10 +4110,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4128,10 +4128,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/moveTo",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4158,10 +4158,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4369,10 +4369,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4399,10 +4399,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4675,10 +4675,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondevicemotion",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -4693,10 +4693,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": null
@@ -4705,10 +4705,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -4723,10 +4723,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ondeviceorientation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4753,10 +4753,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4777,7 +4777,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -4789,10 +4789,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "safari": {
               "version_added": null
@@ -6225,10 +6225,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pageXOffset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6255,10 +6255,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6513,10 +6513,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/personalbar",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6543,10 +6543,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6974,10 +6974,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/releaseEvents",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7004,10 +7004,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7363,10 +7363,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resizeBy",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7394,10 +7394,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7412,10 +7412,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resizeTo",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7443,10 +7443,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7658,10 +7658,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/screen",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7688,10 +7688,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7706,10 +7706,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/screenLeft",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7736,10 +7736,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7754,10 +7754,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/screenTop",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7784,10 +7784,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7802,10 +7802,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/screenX",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7834,10 +7834,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7852,10 +7852,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/screenY",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -7884,10 +7884,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7998,10 +7998,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollbars",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8028,10 +8028,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8441,19 +8441,19 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageXOffset"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "alternative_name": "pageXOffset"
               }
             ],
@@ -8531,19 +8531,19 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "alternative_name": "pageXOffset"
               }
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageXOffset"
               }
             ]
@@ -8771,10 +8771,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/self",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8801,10 +8801,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9220,10 +9220,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/status",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9250,10 +9250,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9268,10 +9268,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/statusbar",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9298,10 +9298,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9316,10 +9316,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/stop",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "14"
@@ -9346,10 +9346,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9413,10 +9413,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/toolbar",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9443,10 +9443,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9461,10 +9461,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/top",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -9492,10 +9492,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -9961,13 +9961,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/visualViewport",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63",
@@ -9993,10 +9993,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "13"
@@ -10008,7 +10008,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "61"
             }
           },
           "status": {
@@ -10540,10 +10540,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/window",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -10570,10 +10570,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the Chromium data for the Window API based upon a combination of manual testing and collector results to achieve more real data for the Window API. (Note: most Opera updates have been deferred to #6837.)

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/Window