### PR TITLE
mdn-bcd-collector: update data for WebGL EXT_ extensions

### DIFF
--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_blend_minmax",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "38"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "38"
           },
           "edge": {
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "33"
+            "version_added": "47"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "25"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "38"
           }
         },
         "status": {

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -13,10 +13,17 @@
           "edge": {
             "version_added": "17"
           },
-          "firefox": {
-            "version_added": "35",
-            "notes": "Before Firefox 47, this extension was not available on Windows."
-          },
+          "firefox": [
+            {
+              "version_added": "47"
+            },
+            {
+              "version_added": "35",
+              "version_removed": "47",
+              "partial_implementation": true,
+              "notes": "Before Firefox 47, this extension was not available on Windows."
+            }
+          ],
           "firefox_android": {
             "version_added": null
           },

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -21,7 +21,7 @@
               "version_added": "35",
               "version_removed": "47",
               "partial_implementation": true,
-              "notes": "Before Firefox 47, this extension was not available on Windows."
+              "notes": "Not supported on Windows."
             }
           ],
           "firefox_android": {

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -14,10 +14,11 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "47"
+            "version_added": "35",
+            "notes": "Before Firefox 47, this extension was not available on Windows."
           },
           "firefox_android": {
-            "version_added": "47"
+            "version_added": null
           },
           "ie": {
             "version_added": false

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_float",
         "support": {
           "chrome": {
-            "version_added": "63"
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": "63"
+            "version_added": false
           },
           "edge": {
-            "version_added": "79"
+            "version_added": false
           },
           "firefox": {
-            "version_added": "49"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "8.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "63"
+            "version_added": false
           }
         },
         "status": {

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_float",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "63"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "63"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "49"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": null
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": null
           },
           "opera_android": {
-            "version_added": false
+            "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": null
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "63"
           }
         },
         "status": {

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -14,19 +14,19 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "30"
+            "version_added": "47"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "50"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "46"
           },
           "safari": {
             "version_added": "14"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -21,7 +21,7 @@
               "version_added": "36",
               "version_removed": "47",
               "partial_implementation": true,
-              "notes": "Before Firefox 47, this extension was not available on Windows."
+              "notes": "Not supported on Windows."
             }
           ],
           "firefox_android": {

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -13,10 +13,17 @@
           "edge": {
             "version_added": "17"
           },
-          "firefox": {
-            "version_added": "36",
-            "notes": "Before Firefox 47, this extension was not available on Windows."
-          },
+          "firefox": [
+            {
+              "version_added": "47"
+            },
+            {
+              "version_added": "36",
+              "version_removed": "47",
+              "partial_implementation": true,
+              "notes": "Before Firefox 47, this extension was not available on Windows."
+            }
+          ],
           "firefox_android": {
             "version_added": null
           },

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -14,10 +14,11 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "47"
+            "version_added": "36",
+            "notes": "Before Firefox 47, this extension was not available on Windows."
           },
           "firefox_android": {
-            "version_added": "47"
+            "version_added": null
           },
           "ie": {
             "version_added": false

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -15,12 +15,11 @@
             "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "edge": {
-            "version_added": false,
-            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+            "version_added": false
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "63",
+            "version_removed": "59",
             "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "firefox_android": {
@@ -30,16 +29,20 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "34",
+            "version_removed": "52",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "34",
+            "version_removed": "47",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0",
@@ -73,12 +76,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -88,16 +90,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -132,12 +138,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -147,16 +152,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -191,12 +200,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -206,16 +214,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -250,12 +262,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -265,16 +276,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -309,12 +324,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -324,16 +338,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -368,12 +386,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -383,16 +400,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -427,12 +448,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -442,16 +462,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -486,12 +510,11 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false,
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "63",
+              "version_removed": "59",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "firefox_android": {
@@ -501,16 +524,20 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34",
+              "version_removed": "47",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -5,40 +5,41 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_frag_depth",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "38"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "38"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12",
+            "version_removed": "79"
           },
           "firefox": {
-            "version_added": "30"
+            "version_added": "47"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "25"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "38"
           }
         },
         "status": {

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_sRGB",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "40"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "40"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": false
           },
           "firefox": {
-            "version_added": "28"
+            "version_added": "58"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "58"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "27"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "40"
           }
         },
         "status": {

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -21,7 +21,7 @@
               "version_added": "28",
               "version_removed": "58",
               "partial_implementation": true,
-              "notes": "Before Firefox 58, this extension was not available on Windows."
+              "notes": "Not supported on Windows."
             }
           ],
           "firefox_android": {

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -13,10 +13,17 @@
           "edge": {
             "version_added": false
           },
-          "firefox": {
-            "version_added": "28",
-            "notes": "Before Firefox 58, this extension was not available on Windows."
-          },
+          "firefox": [
+            {
+              "version_added": "58"
+            },
+            {
+              "version_added": "28",
+              "version_removed": "58",
+              "partial_implementation": true,
+              "notes": "Before Firefox 58, this extension was not available on Windows."
+            }
+          ],
           "firefox_android": {
             "version_added": null
           },

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -14,10 +14,11 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "58"
+            "version_added": "28",
+            "notes": "Before Firefox 58, this extension was not available on Windows."
           },
           "firefox_android": {
-            "version_added": "58"
+            "version_added": null
           },
           "ie": {
             "version_added": false

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -5,40 +5,41 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_shader_texture_lod",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "38"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "38"
           },
           "edge": {
-            "version_added": "17"
+            "version_added": "17",
+            "version_removed": "79"
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": "47"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "25"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "38"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -14,7 +14,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "65"
+            "version_added": "68"
           },
           "firefox_android": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -14,7 +14,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "65"
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -15,7 +15,8 @@
           },
           "firefox": {
             "version_added": "65",
-            "notes": "Only available on macOS."
+            "partial_implementation": true,
+            "notes": "This extension is currently only available on macOS."
           },
           "firefox_android": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -14,7 +14,8 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": false
+            "version_added": "65",
+            "notes": "Only available on macOS."
           },
           "firefox_android": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "65",
             "partial_implementation": true,
-            "notes": "This extension is currently only available on macOS."
+            "notes": "Only supported on macOS."
           },
           "firefox_android": {
             "version_added": false

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -32,7 +32,7 @@
             "version_added": "47"
           },
           "ie": {
-            "version_added": "≤11"
+            "version_added": "11"
           },
           "opera": [
             {

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -6,73 +6,73 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "34"
             },
             {
-              "version_added": true,
+              "version_added": "35",
               "prefix": "WEBKIT_"
             }
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "34"
             },
             {
-              "version_added": true,
+              "version_added": "35",
               "prefix": "WEBKIT_"
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "17"
+            "version_added": "47"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "ie": {
-            "version_added": false
+            "version_added": "≤11"
           },
           "opera": [
             {
-              "version_added": true
+              "version_added": "21"
             },
             {
-              "version_added": true,
+              "version_added": "22",
               "prefix": "WEBKIT_"
             }
           ],
           "opera_android": [
             {
-              "version_added": true
+              "version_added": "21"
             },
             {
-              "version_added": true,
+              "version_added": "22",
               "prefix": "WEBKIT_"
             }
           ],
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "3.0"
             },
             {
-              "version_added": true,
+              "version_added": "4.0",
               "prefix": "WEBKIT_"
             }
           ],
           "webview_android": [
             {
-              "version_added": true
+              "version_added": "37"
             },
             {
-              "version_added": true,
+              "version_added": "37",
               "prefix": "WEBKIT_"
             }
           ]

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -22,9 +22,15 @@
               "prefix": "WEBKIT_"
             }
           ],
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "firefox": {
             "version_added": "47"
           },


### PR DESCRIPTION
This PR uses the mdn-bcd-collector project to update the compatibility data for all of the `EXT_` prefixed WebGL extensions, along with some mirroring and manual testing.  All results were confirmed for accuracy.  (`EXT_color_buffer_float` was omitted due to a slight issue in the collector tests, which will be followed-up later.)

Tests used:
https://mdn-bcd-collector.appspot.com/tests/api/EXT_blend_minmax
https://mdn-bcd-collector.appspot.com/tests/api/EXT_color_buffer_half_float
https://mdn-bcd-collector.appspot.com/tests/api/EXT_disjoint_timer_query
https://mdn-bcd-collector.appspot.com/tests/api/EXT_frag_depth
https://mdn-bcd-collector.appspot.com/tests/api/EXT_sRGB
https://mdn-bcd-collector.appspot.com/tests/api/EXT_shader_texture_lod
https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_compression_bptc
https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_compression_rgtc
https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_filter_anisotropic