### PR TITLE
Document.execCommand - note that calls cannot be nested

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3779,10 +3779,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Nested calls are not supported from Firefox 82 (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Nested calls are not supported from Firefox 82 (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
             },
             "ie": {
               "version_added": "4"

--- a/api/Document.json
+++ b/api/Document.json
@@ -3784,7 +3784,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Nested calls are not supported from Firefox 82 (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
+              "notes": "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
             },
             "ie": {
               "version_added": "4"

--- a/api/Document.json
+++ b/api/Document.json
@@ -3780,7 +3780,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Nested calls are not supported from Firefox 82 (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
+              "notes": "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
             },
             "firefox_android": {
               "version_added": "4",


### PR DESCRIPTION
This adds a note that nested `Document.execCommand` calls are not supported in FF82 and later to both FireFox and FF Android. The information originates from https://bugzilla.mozilla.org/show_bug.cgi?id=1634262

Passes linter locally. 