### PR TITLE
Element.setPointerCapture throws NotFoundError

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8138,7 +8138,8 @@
             ],
             "firefox_android": [
               {
-                "version_added": false
+                "version_added": true,
+                "notes": "Before Firefox 82, <code>setPointerCapture()</code> throws <code>InvalidPointerId</code> for an invalid <code>pointerId</code> argument. From Firefox 82, it throws <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>the specified</a> <code>NotFoundError</code> exception. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
               },
               {
                 "version_added": "41",
@@ -8148,8 +8149,7 @@
                     "name": "dom.w3c_pointer_events.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "From Firefox 82 throws <code>NotFoundError</code> exception if pointer id is invalid (as per <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>WC3 PointerEvents specification</a>). Earlier Firefox versions throw <code>InvalidPointerId</code>. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
+                ]
               }
             ],
             "ie": [

--- a/api/Element.json
+++ b/api/Element.json
@@ -8138,7 +8138,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": true,
+                "version_added": "79",
                 "notes": "Before Firefox 82, <code>setPointerCapture()</code> throws <code>InvalidPointerId</code> for an invalid <code>pointerId</code> argument. From Firefox 82, it throws <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>the specified</a> <code>NotFoundError</code> exception. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
               },
               {

--- a/api/Element.json
+++ b/api/Element.json
@@ -8122,7 +8122,8 @@
             },
             "firefox": [
               {
-                "version_added": "59"
+                "version_added": "59",
+                "notes": "From Firefox 82 throws <code>NotFoundError</code> exception if pointer id is invalid (as per <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>WC3 PointerEvents specification</a>). Earlier Firefox versions throw <code>InvalidPointerId</code>. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
               },
               {
                 "version_added": "41",
@@ -8147,7 +8148,8 @@
                     "name": "dom.w3c_pointer_events.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "From Firefox 82 throws <code>NotFoundError</code> exception if pointer id is invalid (as per <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>WC3 PointerEvents specification</a>). Earlier Firefox versions throw <code>InvalidPointerId</code>. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
               }
             ],
             "ie": [

--- a/api/Element.json
+++ b/api/Element.json
@@ -8123,7 +8123,7 @@
             "firefox": [
               {
                 "version_added": "59",
-                "notes": "From Firefox 82 throws <code>NotFoundError</code> exception if pointer id is invalid (as per <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>WC3 PointerEvents specification</a>). Earlier Firefox versions throw <code>InvalidPointerId</code>. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
+                "notes": "Before Firefox 82, <code>setPointerCapture()</code> throws <code>InvalidPointerId</code> for an invalid <code>pointerId</code> argument. From Firefox 82, it throws <a href='https://w3c.github.io/pointerevents/#setting-pointer-capture'>the specified</a> <code>NotFoundError</code> exception. See <a href='https://bugzil.la/1662124'>bug 1662124</a>."
               },
               {
                 "version_added": "41",


### PR DESCRIPTION
This adds a note to `Element.setPointerCapture()` that it throws `NotFoundError` instead of `InvalidPointerId` from FF82 (to both android and desktop versions). This originates from defect fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1662124

I wasn't 100% sure of right place to put this information - see notes inline.


