### PR TITLE
Mark navigator.canShare() experimental and nonstandard

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -424,8 +424,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This change marks the `navigator.canShare()` method as `experimental:true` and `standard_track:false,` per https://github.com/w3c/web-share/pull/134 and https://github.com/w3c/web-share/pull/134#issuecomment-703653048 in particular. https://github.com/w3c/web-share/commit/2bbde9c dropped it as a specified feature (along with the entire Web Share Level 2 spec.)