### PR TITLE
MediaSession enabled all builds from FF82

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -29,7 +29,8 @@
             }
           ],
           "firefox_android": {
-            "version_added": null
+            "version_added": "82",
+            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
           },
           "ie": {
             "version_added": false

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -31,7 +31,7 @@
           "firefox_android": {
             "version_added": "82",
             "partial_implementation": true,
-            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+            "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
             "version_added": false

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -30,7 +30,8 @@
           ],
           "firefox_android": {
             "version_added": "82",
-            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+            "partial_implementation": true,
+            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
           },
           "ie": {
             "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -29,7 +29,8 @@
             }
           ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "82",
+            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
           },
           "ie": {
             "version_added": false
@@ -88,7 +89,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": false
@@ -148,7 +150,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": false
@@ -209,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": false
@@ -270,7 +274,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -309,68 +309,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "MediaPositionState": {
-          "__compat": {
-            "description": "Dictionary passed to <code>setPositionState</code> to specify play position within a track (<code>{duration, playbackRate, position}</code>).",
-            "support": {
-              "chrome": {
-                "version_added": "73"
-              },
-              "chrome_android": {
-                "version_added": "57"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": [
-                {
-                  "version_added": "82"
-                },
-                {
-                  "version_added": "71",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.media.mediasession.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": {
-                "version_added": "82",
-                "partial_implementation": true,
-                "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "7.0"
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -30,7 +30,8 @@
           ],
           "firefox_android": {
             "version_added": "82",
-            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+            "partial_implementation": true,
+            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
           },
           "ie": {
             "version_added": false
@@ -90,7 +91,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": false
@@ -151,7 +153,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": false
@@ -213,7 +216,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": false
@@ -275,7 +279,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": false
@@ -335,7 +340,8 @@
               ],
               "firefox_android": {
                 "version_added": "82",
-                "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+                "partial_implementation": true,
+                "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
               },
               "ie": {
                 "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -304,6 +304,67 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "MediaPositionState": {
+          "__compat": {
+            "description": "Dictionary passed to <code>setPositionState</code> to specify play position within a track (<code>{duration, playbackRate, position}</code>).",
+            "support": {
+              "chrome": {
+                "version_added": "73"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": [
+                {
+                  "version_added": "82"
+                },
+                {
+                  "version_added": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.media.mediasession.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "82",
+                "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -31,7 +31,7 @@
           "firefox_android": {
             "version_added": "82",
             "partial_implementation": true,
-            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+            "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
             "version_added": false
@@ -92,7 +92,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": false
@@ -154,7 +154,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": false
@@ -217,7 +217,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": false
@@ -280,7 +280,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": false
@@ -341,7 +341,7 @@
               "firefox_android": {
                 "version_added": "82",
                 "partial_implementation": true,
-                "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+                "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
               },
               "ie": {
                 "version_added": false

--- a/api/MediaSessionAction.json
+++ b/api/MediaSessionAction.json
@@ -30,7 +30,8 @@
             }
           ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "82",
+            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
           },
           "ie": {
             "version_added": null
@@ -89,7 +90,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -149,7 +151,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -209,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -269,7 +273,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -329,7 +334,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -389,7 +395,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -449,7 +456,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -509,7 +517,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -569,7 +578,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null

--- a/api/MediaSessionAction.json
+++ b/api/MediaSessionAction.json
@@ -31,7 +31,8 @@
           ],
           "firefox_android": {
             "version_added": "82",
-            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+            "partial_implementation": true,
+            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
           },
           "ie": {
             "version_added": null
@@ -91,7 +92,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -152,7 +154,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -213,7 +216,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -274,7 +278,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -335,7 +340,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -396,7 +402,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -457,7 +464,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -518,7 +526,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -579,7 +588,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null

--- a/api/MediaSessionAction.json
+++ b/api/MediaSessionAction.json
@@ -32,7 +32,7 @@
           "firefox_android": {
             "version_added": "82",
             "partial_implementation": true,
-            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+            "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
             "version_added": null
@@ -93,7 +93,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -155,7 +155,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -217,7 +217,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -279,7 +279,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -341,7 +341,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -403,7 +403,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -465,7 +465,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -527,7 +527,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -589,7 +589,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null

--- a/api/MediaSessionActionDetails.json
+++ b/api/MediaSessionActionDetails.json
@@ -31,7 +31,7 @@
           "firefox_android": {
             "version_added": "82",
             "partial_implementation": true,
-            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+            "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
             "version_added": null
@@ -92,7 +92,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null
@@ -202,7 +202,7 @@
             "firefox_android": {
               "version_added": "82",
               "partial_implementation": true,
-              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
+              "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
               "version_added": null

--- a/api/MediaSessionActionDetails.json
+++ b/api/MediaSessionActionDetails.json
@@ -29,7 +29,8 @@
             }
           ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "82",
+            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
           },
           "ie": {
             "version_added": null
@@ -88,7 +89,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null
@@ -196,7 +198,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82",
+              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
             },
             "ie": {
               "version_added": null

--- a/api/MediaSessionActionDetails.json
+++ b/api/MediaSessionActionDetails.json
@@ -30,7 +30,8 @@
           ],
           "firefox_android": {
             "version_added": "82",
-            "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+            "partial_implementation": true,
+            "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
           },
           "ie": {
             "version_added": null
@@ -90,7 +91,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null
@@ -199,7 +201,8 @@
             ],
             "firefox_android": {
               "version_added": "82",
-              "notes": "The particular Media Session used for Android media control depends on the user agent. The Android browser implementation does not allow any session to be selected as active."
+              "partial_implementation": true,
+              "notes": "Firefox does not yet integrate this API into Android's media control interfaces. The API is exposed, but the corresponding user-facing behavior is not available."
             },
             "ie": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1477,7 +1477,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "82"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
MediaSession (and friends) are enabled on all builds from FF82 - this adds the version. See bug [Enable MediaSession API](https://bugzilla.mozilla.org/show_bug.cgi?id=1665496)

- The fix enables everything that is conditional on `dom.media.mediasession.enabled` so set covered is everything that was previously tagged with that preference.
- I have not added this for FF Android, as this was feature not previously supported for FF Android even via preference (am querying to make sure this is correct).
- The [spec is still marked as draft](https://w3c.github.io/mediasession/#the-mediasession-interface) so I did not change the experimental flag.

