### PR TITLE
Mark CSS place-self supported in Safari 11+

### DIFF
--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -32,10 +32,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This change marks the CSS `place-self` property as supported in Safari 11, per https://developer.apple.com/safari/technology-preview/release-notes/#r31 (TP 31) and https://trac.webkit.org/changeset/216829/webkit (2017-05-13).

Fixes https://github.com/mdn/browser-compat-data/issues/6846