### PR TITLE
Update Safari onvisibilitychange support

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10788,13 +10788,11 @@
             },
             "safari": {
               "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "notes": "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "safari_ios": {
               "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "notes": "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -7618,11 +7618,11 @@
             },
             "safari": {
               "version_added": "10.1",
-              "notes": "Before Safari 10.1, this event handler attribute was not supported, however the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "safari_ios": {
               "version_added": "10.3",
-              "notes": "Before Safari iOS 10.3, this event handler attribute was not supported, however the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": "Before Safari iOS 10.3, this event handler attribute was not supported; however, the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -7618,11 +7618,17 @@
             },
             "safari": {
               "version_added": "10.1",
-              "notes": "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": [
+                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              ]
             },
             "safari_ios": {
               "version_added": "10.3",
-              "notes": "Before Safari iOS 10.3, this event handler attribute was not supported; however, the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": [
+                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                "Before Safari iOS 10.3, this event handler attribute was not supported; however, the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+              ]
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -10788,11 +10794,17 @@
             },
             "safari": {
               "version_added": "7",
-              "notes": "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": [
+                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              ]
             },
             "safari_ios": {
               "version_added": "7",
-              "notes": "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              "notes": [
+                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+              ]
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -7617,14 +7617,12 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "10.1",
+              "notes": "Before Safari 10.1, this event handler attribute was not supported, however the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "safari_ios": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "10.3",
+              "notes": "Before Safari iOS 10.3, this event handler attribute was not supported, however the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR fixes data for the `visibilitychange` event and handler for Safari (similar to #6833 for IE/Edge).  As determined by manual testing (after reviewing results from the mdn-bcd-collector), Safari had no support for `onvisibilitychange` until Safari 10.1.  However, it supported the event since Safari 7, through `addEventListener`.  Furthermore, the notes that were there are not accurate -- the event fired when transitioning to `hidden` no problem.

Test code used:
```js
document.addEventListener("visibilitychange", function() {
  if (document.visibilityState === 'visible') {
    console.log('addEventListener: visible');
  } else {
    console.log('addEventListener: hidden');
  }
});

document.onvisibilitychange = function() {
  if (document.visibilityState === 'visible') {
    console.log('onvisibilitychange: visible');
  } else {
    console.log('onvisibilitychange: hidden');
  }
};
```