### PR TITLE
@supports selector() not supported Safari 14

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -124,10 +124,12 @@
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "safari": {
-                "version_added": "14"
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
               },
               "safari_ios": {
-                "version_added": "14"
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"


### PR DESCRIPTION
@supports selector() not supported Safari 14

This reverts commit 3028864b453b990826d11858afaf934984304a56.

https://github.com/mdn/browser-compat-data/pull/6591#issuecomment-704336327 indicates that `@supports selector()` isn’t in Safari 14. So we need to revert and then, later, update the Safari version numbers to 14.1 (when 14.1 becomes an allowed version number for Safari in BCD).