### PR TITLE
adding inert support for firefox

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1144,10 +1144,24 @@
               ]
             },
             "firefox": {
-              "version_added": null
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "html5.inert.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "html5.inert.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1164,7 +1164,7 @@
               ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47",
@@ -1187,10 +1187,10 @@
               ]
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
- [ ] Adding support for the HTML `inert` attribute behind a flag in Firefox 81.
- [ ] https://bugzilla.mozilla.org/show_bug.cgi?id=1655722
