### PR TITLE
Safari 13.1/Safari iOS/iPadOS 13.4 is retired

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -163,7 +163,7 @@
         "13.1": {
           "release_date": "2020-03-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -154,7 +154,7 @@
         "13.4": {
           "release_date": "2020-03-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },


### PR DESCRIPTION
This PR fixes up the Safari data to mark 13.1/13.4 as `retired`.