### PR TITLE
Add real values for Chromium for WebGL2RenderingContext

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -436,10 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bufferSubData",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "58"
             },
             "edge": {
               "version_added": "79"
@@ -454,10 +454,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -466,10 +466,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "58"
             }
           },
           "status": {
@@ -2134,10 +2134,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates the data for two features in WebGL2RenderingContext based upon results from the mdn-bcd-collector (and mirroring).

Tests used:
https://mdn-bcd-collector.appspot.com/tests/api/WebGL2RenderingContext/bufferSubData
https://mdn-bcd-collector.appspot.com/tests/api/WebGL2RenderingContext/getBufferSubData