### PR TITLE
Add Chrome versions for console substitution strings

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -354,7 +354,10 @@
                 "version_added": "8.10.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null
@@ -572,7 +575,10 @@
                 "version_added": "0.1.100"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null
@@ -933,7 +939,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null
@@ -1042,7 +1051,10 @@
                 "version_added": "0.1.100"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null
@@ -1578,7 +1590,10 @@
                 "version_added": "0.1.100"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null

--- a/api/Console.json
+++ b/api/Console.json
@@ -323,11 +323,11 @@
             "description": "Substitution strings",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "edge": {
@@ -363,11 +363,11 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true,
+                "version_added": "1.0",
                 "notes": "In Samsung Internet 1.5, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               }
             },
@@ -543,10 +543,10 @@
             "description": "Substitution strings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12",
@@ -581,10 +581,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -904,10 +904,10 @@
             "description": "Substitution strings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12",
@@ -942,10 +942,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1011,11 +1011,11 @@
             "description": "Substitution strings",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "edge": {
@@ -1051,11 +1051,11 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true,
+                "version_added": "1.0",
                 "notes": "In Samsung Internet 1.5, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               }
             },
@@ -1549,10 +1549,10 @@
             "description": "Substitution strings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12",
@@ -1587,10 +1587,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets the Chromium versions (as well as Opera) for substitution strings in the console API, based upon manual testing.

Test used:
```js
console.debug("%s: Hello, %s. You've called me %d times.", "debug", "Bob", 2);
console.error("%s: Hello, %s. You've called me %d times.", "error", "Bob", 2);
console.info("%s: Hello, %s. You've called me %d times.", "info", "Bob", 2);
console.log("%s: Hello, %s. You've called me %d times.", "log", "Bob", 2);
console.warn("%s: Hello, %s. You've called me %d times.", "warn", "Bob", 2);
``