### PR TITLE
Fix Console API version for Firefox

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "2"
+            "version_added": "4"
           },
           "firefox_android": {
             "version_added": "4"


### PR DESCRIPTION
This PR fixes the Firefox version for the Console API.  It was incorrectly marked as "2", however based upon manual testing, the `console` variable was undefined until Firefox 4.