### PR TITLE
Add Firefox version for api.Console.exception.substitution_strings

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -659,10 +659,10 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "28"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "28"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds the Firefox version for the substitution strings feature of `console.exception` based upon manual testing.

Test code:
```js
console.exception("%s: Hello, %s. You've called me %d times.", "exception", "Bob", 2);
```