### PR TITLE
Update compat data for insertAdjacent* methods

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4789,10 +4789,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -4789,10 +4789,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -4848,7 +4848,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "4"
@@ -4904,10 +4904,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Hello,

I've updated the Safari compatibility data for the Element.insertAdjacent* methods.

The existing data says that these methods were added in Safari 10 and iOS Safari 10, which were both released in September 2016. This disagreed with the caniuse data, so I did a little research.

- the existing data was committed in PR #3141
- https://caniuse.com/?search=insertadjacent says:
  - insertAdjacentElement and insertAdjacentText are present in Safari 3.1 (Mar 2008) and iOS Safari 3.2 (Apr 2010)
  - insertAdjacentHTML are present in Safari 4 (Jun 2009) and iOS Safari 4 (Sep 2010)
- https://bugs.webkit.org/show_bug.cgi?id=6520 says insertAdjacentElement was committed to WebKit in March 2006
- https://bugs.webkit.org/show_bug.cgi?id=17622 says insertAdjacentHTML and insertAdjacentText were committed in June 2008

The caniuse data seems more in line with the webkit bug tracker dates, with the exception of insertAdjacentText, which it says is present in a March 2008 version of Safari, even though the commit didn't land until June 2008. I attribute this to the fact that caniuse groups insertAdjacentElement and insertAdjacentText into [one entry](https://github.com/Fyrd/caniuse/blob/master/features-json/insert-adjacent.json). In this case, I used the same compat data as [insertAdjacentHTML](https://github.com/Fyrd/caniuse/blob/master/features-json/insertadjacenthtml.json), whose dates make more sense.

I don't have a way to test these old versions, so these changes are based entirely on what I've presented above.

Thanks for your time.