### PR TITLE
Add Safari version for api.Document.URL

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -174,10 +174,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds the Safari version for the `URL` property of the Document API based upon manual testing.