### PR TITLE
window.name is reset on cross domain load - FF82

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4396,11 +4396,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "From Firefox 82, if a new page from another domain is loaded into a tab, then <code>window.name</code> is set to the empty string. This change prevents some cross-site attacks. See <a href='https://bugzil.la/444222'>bug 444222</a>."
+              "notes": "From Firefox 82, if a new page from another domain is loaded into a tab, then <code>window.name</code> is set to the empty string (the original string is restored if the tab reverts back to the original page). This change prevents some cross-site attacks. See <a href='https://bugzil.la/444222'>bug 444222</a>."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From Firefox 82, <code>window.name</code> is reset if a new page from another domain is loaded into a tab. See <a href='https://bugzil.la/444222'>bug 444222</a>."
+              "notes": "From Firefox 82, if a new page from another domain is loaded into a tab, then <code>window.name</code> is set to the empty string (the original string is restored if the tab reverts back to the original page). This change prevents some cross-site attacks. See <a href='https://bugzil.la/444222'>bug 444222</a>."
             },
             "ie": {
               "version_added": "4"

--- a/api/Window.json
+++ b/api/Window.json
@@ -4395,10 +4395,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From Firefox 82, <code>window.name</code> is reset if a new page from another domain is loaded into a tab. See <a href='https://bugzil.la/444222'>bug 444222</a>."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Firefox 82, <code>window.name</code> is reset if a new page from another domain is loaded into a tab. See <a href='https://bugzil.la/444222'>bug 444222</a>."
             },
             "ie": {
               "version_added": "4"

--- a/api/Window.json
+++ b/api/Window.json
@@ -4396,7 +4396,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "From Firefox 82, <code>window.name</code> is reset if a new page from another domain is loaded into a tab. See <a href='https://bugzil.la/444222'>bug 444222</a>."
+              "notes": "From Firefox 82, if a new page from another domain is loaded into a tab, then <code>window.name</code> is set to the empty string. This change prevents some cross-site attacks. See <a href='https://bugzil.la/444222'>bug 444222</a>."
             },
             "firefox_android": {
               "version_added": "4",


### PR DESCRIPTION
This adds a note to api.window.name that the `window.name` is reset (set to empty string) if a new page is loaded from a different domain - from FF82.

There is a very long and old bug on this https://bugzilla.mozilla.org/show_bug.cgi?id=444222 . A bit of context on the change can be found in https://github.com/mdn/sprints/issues/3731#issuecomment-704017095, but in summary
- About 12 years ago some people were storing data in windows.name because it has a lot of space and some people were advising this as a way for cross-domain sharing. They should not be.
- This is also used by some _frameworks_ as a method for cross domain messaging. There are now better ways to do this.
- A bad actor loaded into same tab might previously have accessed information from a page previously loaded into the same tab.
- A bad actor might also write to that data, and if old page is reloaded it could be impacted.

People really should not be adding data to window.name. I decided primarily that this was useful to add here because it might affect some of those frameworks. i.e for visibility. Hope that makes sense!

FYI, the corresponding new note [in the docs here](https://developer.mozilla.org/en-US/docs/Web/API/Window/name#Notes) is:

![image](https://user-images.githubusercontent.com/5368500/95694152-1d2e8c80-0c7c-11eb-888c-570ed014d500.png)
