### PR TITLE
Deprecate HTMLIFrameElement: allowPaymentRequest

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -260,8 +260,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks the `allowPaymentRequest` property of the `HTMLIFrameElement` interface `standard_track:false` and `deprecated:true`, due to the fact it was removed from the Payment Request spec:

* https://github.com/w3c/payment-request/pull/928
* https://github.com/w3c/payment-request/commit/a4f35e3

https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allowPaymentRequest already updated.

cc @marcoscaceres