### PR TITLE
Deprecate MerchantValidationEvent

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -59,8 +59,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "MerchantValidationEvent": {
@@ -109,8 +109,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -160,8 +160,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -210,8 +210,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -260,8 +260,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This change marks `MerchantValidationEvent` and all its subfeatures `standard_track:false` and `deprecated:true,` due to the fact it was all removed from the Payment Request spec:

* https://github.com/w3c/payment-request/pull/929
* https://github.com/w3c/payment-request/commit/8337fee

https://developer.mozilla.org/en-US/docs/Web/API/MerchantValidationEvent and its sub-articles already updated.

cc @marcoscaceres