### PR TITLE
Mark Accelerometer experimental

### DIFF
--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -138,7 +138,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -186,7 +186,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -234,7 +234,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This change marks the `Accelerometer` interface and all its subfeatures with `experimental:true`.

---

I’ve also marked https://wiki.developer.mozilla.org/en-US/docs/Web/API/Accelerometer and all its sub-articles with `{{seecompattable}}`.

See related discussion at https://github.com/mdn/browser-compat-data/pull/6873#issuecomment-707180136
