### PR TITLE
Mark AmbientLightSensor experimental

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -77,7 +77,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -125,7 +125,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -177,7 +177,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This change marks the `AmbientLightSensor` and all its subfeatures with `experimental:true`

---

I’ve also marked https://wiki.developer.mozilla.org/en-US/docs/Web/API/AmbientLightSensor and all its subarticles with `{{seecompattable}}`

See related discussion at https://github.com/mdn/browser-compat-data/pull/6873#issuecomment-707180136
