### PR TITLE
Mark LargestContentfulPaint experimental

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -89,7 +89,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -137,7 +137,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -185,7 +185,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -233,7 +233,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -281,7 +281,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -329,7 +329,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -377,7 +377,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This change marks the `LargestContentfulPaint` interface and all is subfeatures with `experimental:true`.

---

Also marked https://wiki.developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint with `{{seecompattable}}`

See related discussion at https://github.com/mdn/browser-compat-data/pull/6873#issuecomment-707180136
