### PR TITLE
Update Safari data for visibilityState

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10891,14 +10891,10 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": "Doesn't fire the <code>visibilitychange</code> event when <code>document.visibilityState</code> transitions to <code>hidden</code>, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+              "version_added": "7"
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This change updates the Safari data for `visibilityState` in light of related changes made to the `visibilitychange` data in https://github.com/mdn/browser-compat-data/pull/6849.

Specifically, testing indicates the following note isn’t accurate:

> Doesn't fire the `visibilitychange` event when `document.visibilityState` transitions to `hidden`

But what’s instead accurate is the following:

> Doesn't fire the `visibilitychange` event when navigating way from a document

However, that information applies only to `visibilitychange` and not to `visibilityState` — so it’s also not accurate to keep the `visibilityState` support marked as partial.

Therefore, this change drops the `partial_implementation` flag, as well as dropping the note entirely.