### PR TITLE
Set Firefox data for api.CSS.paintWorklet

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1043,10 +1043,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR sets the Firefox data for the `paintWorklet` feature of the CSS API, based upon results from the mdn-bcd-collector project.  Test used: https://mdn-bcd-collector.appspot.com/tests/api/CSS/paintWorklet