### PR TITLE
Set Firefox data for CSSAnimation API

### DIFF
--- a/api/CSSAnimation.json
+++ b/api/CSSAnimation.json
@@ -14,10 +14,10 @@
             "version_added": "84"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "75"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": "84"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR sets Firefox data for the CSSAnimation API based upon data from the mdn-bcd-collector project.  Test used: https://mdn-bcd-collector.appspot.com/tests/api/CSSAnimation