### PR TITLE
Set Safari data for CSSAnimation API

### DIFF
--- a/api/CSSAnimation.json
+++ b/api/CSSAnimation.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR sets Safari data for the CSSAnimation API based upon data from the mdn-bcd-collector project.  Test used: https://mdn-bcd-collector.appspot.com/tests/api/CSSAnimation