### PR TITLE
Edge 16+ supports ...rest in array destructuring

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -116,15 +116,20 @@
               "chrome_android": {
                 "version_added": "49"
               },
-              "edge": {
-                "version_added": "14",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Javascript features"
-                  }
-                ]
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "14",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Javascript features"
+                    }
+                  ]
+                }
+              ],
               "firefox": {
                 "version_added": "41"
               },

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -118,7 +118,7 @@
               },
               "edge": [
                 {
-                  "version_added": "79"
+                  "version_added": "16"
                 },
                 {
                   "version_added": "14",


### PR DESCRIPTION
Currently the compat data makes it seem like anything that was behind the "Experimental JavaScript Features" flag in pre-Chromium Edge is still behind a flag, which I don't believe is true for any ES features. There may be a few of these cutoffs missing (`AsyncIterator` is another one).

Here's a test in Edge 16:
<img width="874" alt="Screen Shot 2020-10-13 at 2 44 22 PM" src="https://user-images.githubusercontent.com/105127/95902367-b8019680-0d62-11eb-86d3-27d461634f1b.png">

Here's a test in Edge 79:
<img width="244" alt="Screen Shot 2020-10-13 at 2 33 35 PM" src="https://user-images.githubusercontent.com/105127/95901286-1af22e00-0d61-11eb-8b3f-20159846cb56.png">
