### PR TITLE
Update Chrome data for CSSKeyframesRule API

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -4,12 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": "31"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "31",
+              "prefix": "WebKit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "31"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "31",
+              "prefix": "WebKit"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -48,12 +62,26 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "version_added": "1.0",
+              "version_removed": "2.0",
+              "prefix": "WebKit"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "4.4.3"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "4.4.3",
+              "prefix": "WebKit"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -67,20 +95,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "41"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "45",
                 "alternative_name": "insertRule"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "41"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "version_removed": "45",
                 "alternative_name": "insertRule"
               }
@@ -130,20 +158,20 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "4.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "version_removed": "5.0",
                 "alternative_name": "insertRule"
               }
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "41"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "45",
                 "alternative_name": "insertRule"
               }
@@ -161,10 +189,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/cssRules",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "edge": {
               "version_added": "12"
@@ -191,10 +219,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {
@@ -209,10 +237,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/deleteRule",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -239,10 +267,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -257,10 +285,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/findRule",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -287,10 +315,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -305,10 +333,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "edge": {
               "version_added": "12"
@@ -335,10 +363,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the Chromium data for the CSSKeyframesRule API based upon manual testing.  I found that Chrome supported the API since version 1, which was then unprefixed in Chrome 31 (the prefixed version was removed in the same version).