### PR TITLE
Update Firefox data for CSSKeyframesRule API

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -19,7 +19,8 @@
             },
             {
               "version_added": "5",
-              "prefix": "moz"
+              "version_removed": "48",
+              "prefix": "Moz"
             }
           ],
           "firefox_android": [
@@ -28,7 +29,8 @@
             },
             {
               "version_added": "5",
-              "prefix": "moz"
+              "version_removed": "48",
+              "prefix": "Moz"
             }
           ],
           "ie": {
@@ -170,10 +172,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": null
@@ -218,10 +220,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": null
@@ -266,10 +268,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": null
@@ -314,10 +316,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Firefox data for the CSSKeyframesRule API based upon manual testing.  The prefixed version was removed in the same version it became unprefixed.  Additionally, this fixes the capitalization in the prefix, and sets version numbers for all of the subfeatures (also based upon manual testing, running `[Moz]CSSKeyframesRule.prototype.[subfeature]` in console and checking if it's defined).