### PR TITLE
Update Opera data for CSSKeyframesRule API

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -34,14 +34,34 @@
           "ie": {
             "version_added": "10"
           },
-          "opera": {
-            "version_added": "12",
-            "prefix": "o"
-          },
-          "opera_android": {
-            "version_added": "12",
-            "prefix": "o"
-          },
+          "opera": [
+            {
+              "version_added": "18"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "15"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "12.1",
+              "prefix": "O"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "18"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "14"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "12.1",
+              "prefix": "O"
+            }
+          ],
           "safari": {
             "version_added": "4"
           },
@@ -112,14 +132,34 @@
               "version_added": "10",
               "alternative_name": "insertRule"
             },
-            "opera": {
-              "version_added": true,
-              "alternative_name": "insertRule"
-            },
-            "opera_android": {
-              "version_added": true,
-              "alternative_name": "insertRule"
-            },
+            "opera": [
+              {
+                "version_added": "28"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "31",
+                "alternative_name": "insertRule"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "28"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "31",
+                "alternative_name": "insertRule"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": true,
               "alternative_name": "insertRule"
@@ -179,10 +219,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "safari": {
               "version_added": true
@@ -227,10 +267,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": true
@@ -275,10 +315,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": true
@@ -323,10 +363,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari": {
               "version_added": true

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -152,7 +152,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "31",
+                "version_removed": "32",
                 "alternative_name": "insertRule"
               },
               {
@@ -222,7 +222,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": true
@@ -363,10 +363,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "3.1"
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": "3.1"
+              "version_added": "32"
             },
             "safari": {
               "version_added": true

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -39,6 +39,11 @@
               "version_added": "18"
             },
             {
+              "version_added": "15",
+              "version_removed": "18",
+              "prefix": "WebKit"
+            },
+            {
               "version_added": "12.1",
               "version_removed": "15"
             },
@@ -51,6 +56,11 @@
           "opera_android": [
             {
               "version_added": "18"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "18",
+              "prefix": "WebKit"
             },
             {
               "version_added": "12.1",


### PR DESCRIPTION
This PR updates the Opera data for the CSSKeyframesRule API based upon manual testing. I found that Opera prefixed the API in only Opera 12, and then unprefixed it in Opera 12.1.  Additionally, this sets the version numbers for all of the subfeatures based upon both manual testing and mirroring (see #6908 to confirm Chrome-based results).