### PR TITLE
Update IE data for CSSKeyframesRule API

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -109,8 +109,7 @@
               }
             ],
             "ie": {
-              "version_added": "10",
-              "alternative_name": "insertRule"
+              "version_added": "10"
             },
             "opera": {
               "version_added": true,
@@ -176,7 +175,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -224,7 +223,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -272,7 +271,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -320,7 +319,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates the IE data for the CSSKeyframesRule API based upon results from the collector.  Additionally (with manual testing), I found that IE supported the `appendRule` feature with its normal name, never under the `insertRule` alt. name.