### PR TITLE
Chromium-based Opera supports trailing commas in function parameters

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -1005,10 +1005,10 @@
                 "version_added": "8.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "45"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "43"
               },
               "safari": {
                 "version_added": "10"


### PR DESCRIPTION
The grammar data was out of sync with the [corresponding entry in `functions.json`](https://github.com/mdn/browser-compat-data/blob/69eca07b733d2709ed2cfa03ed08ad0fbeaf1119/javascript/functions.json#L350-L355). [Opera 45 is Chromium 58](https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Opera_2017), which introduced trailing commas for parameter lists ([compat data](https://github.com/mdn/browser-compat-data/blob/69eca07b733d2709ed2cfa03ed08ad0fbeaf1119/javascript/functions.json#L330)).