### PR TITLE
Update Safari data for CSSKeyframesRule API

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -46,7 +46,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -131,7 +131,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               {
                 "version_added": "3.2",
@@ -198,7 +198,7 @@
               "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -342,7 +342,7 @@
               "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -120,14 +120,24 @@
               "version_added": true,
               "alternative_name": "insertRule"
             },
-            "safari": {
-              "version_added": true,
-              "alternative_name": "insertRule"
-            },
-            "safari_ios": {
-              "version_added": true,
-              "alternative_name": "insertRule"
-            },
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "insertRule"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "version_added": "3.2",
+                "alternative_name": "insertRule"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": true
@@ -185,10 +195,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -233,10 +243,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -281,10 +291,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -329,10 +339,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -42,12 +42,26 @@
             "version_added": "12",
             "prefix": "o"
           },
-          "safari": {
-            "version_added": "4"
-          },
-          "safari_ios": {
-            "version_added": "3.2"
-          },
+          "safari": [
+            {
+              "version_added": "9.1"
+            },
+            {
+              "version_added": "4",
+              "version_removed": "9.1",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "9.3"
+            },
+            {
+              "version_added": "3.2",
+              "version_removed": "9.3",
+              "prefix": "WebKit"
+            }
+          ],
           "samsunginternet_android": {
             "version_added": true
           },


### PR DESCRIPTION
This PR updates the Safari data for the CSSKeyframesRule API based upon manual testing. I found that support for the API was originally behind the WebKit prefix, which was then unprefixed in Safari 9.1 (which removed the prefixed version in the same Safari version).  Additionally, this sets versions for the subfeatures based upon manual testing.