### PR TITLE
UC browser supports Object.create

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -252,6 +252,9 @@
               },
               "webview_android": {
                 "version_added": "1"
+              },
+              "uc_android": {
+                "version_added": true
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -250,11 +250,11 @@
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
-              "webview_android": {
-                "version_added": "1"
-              },
               "uc_android": {
                 "version_added": true
+              },
+              "webview_android": {
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
It is (was?) based on Android Browser 4.x, which supported it. This likely means UC supports most of the other Object.* methods prior to ES2015.