### PR TITLE
Move width and height mapping to aspect ratio to HTML data

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -78,67 +78,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "aspect_ratio_computed_from_attributes": {
-          "__compat": {
-            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
-            "support": {
-              "chrome": {
-                "version_added": "79"
-              },
-              "chrome_android": {
-                "version_added": "79"
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": [
-                {
-                  "version_added": "71"
-                },
-                {
-                  "version_added": "69",
-                  "version_removed": "71",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": {
-                "version_added": "79"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "66"
-              },
-              "opera_android": {
-                "version_added": "57"
-              },
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "version_added": "14"
-              },
-              "samsunginternet_android": {
-                "version_added": "12.0"
-              },
-              "webview_android": {
-                "version_added": "79"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -115,10 +115,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "66"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "safari": {
                 "version_added": "14"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -81,7 +81,7 @@
         },
         "internal-value": {
           "__compat": {
-            "description": "Internal mapping of width and height",
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
             "support": {
               "chrome": {
                 "version_added": "79"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -79,7 +79,7 @@
             "deprecated": false
           }
         },
-        "internal-value": {
+        "aspect_ratio_computed_from_attributes": {
           "__compat": {
             "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
             "support": {

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -134,7 +134,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -109,7 +109,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -27,13 +27,13 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -46,6 +46,67 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "aspect_ratio_computed_from_attributes": {
+          "__compat": {
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "66"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "height": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -314,6 +314,67 @@
             }
           }
         },
+        "aspect_ratio_computed_from_attributes": {
+          "__compat": {
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "66"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "external_protocol_urls_blocked": {
           "__compat": {
             "description": "External protocol URLs blocked",

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -142,6 +142,67 @@
             }
           }
         },
+        "aspect_ratio_computed_from_attributes": {
+          "__compat": {
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "66"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "border": {
           "__compat": {
             "support": {

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -95,6 +95,67 @@
             }
           }
         },
+        "aspect_ratio_computed_from_attributes": {
+          "__compat": {
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "66"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "border": {
           "__compat": {
             "support": {

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -48,6 +48,67 @@
             "deprecated": false
           }
         },
+        "aspect_ratio_computed_from_attributes": {
+          "__compat": {
+            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "66"
+              },
+              "opera_android": {
+                "version_added": "57"
+              },
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "14"
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "autoplay": {
           "__compat": {
             "support": {


### PR DESCRIPTION
The data about some HTML elements' `width` and `height` attributes mapping to that element's aspect ratio is in in the wrong place. This PR fixes this problem (and fixes #6786) by:

- Changing the description of the misplaced `aspect-ratio` subfeature to describe the attributes' relationship
- Renames the subfeature to `aspect_ratio_computed_from_attributes`
- Mirrors data to complete the Opera and Firefox data
- Moves the data to the HTML elements

Related to #6903. 
