### PR TITLE
Update page-margin-boxes mdn_url

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -150,7 +150,7 @@
         "page-margin-boxes": {
           "__compat": {
             "description": "Page-margin boxes",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page#page-margin-box",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
This change updates the `mdn_url` value for the page-margin-boxes feature to include the anchor for the specific Syntax section part for `page-margin-box`.
