### PR TITLE
WebKitCSSMatrix: update MDN URL and description to reflect alias

### DIFF
--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -3,7 +3,7 @@
     "WebKitCSSMatrix": {
       "__compat": {
         "description": "<code>WebKitCSSMatrix</code> (alias to <code>DOMMatrix</code>)",
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebKitCSSMatrix",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrix",
         "support": {
           "chrome": {
             "version_added": null

--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -2,6 +2,7 @@
   "api": {
     "WebKitCSSMatrix": {
       "__compat": {
+        "description": "<code>WebKitCSSMatrix</code> (alias to <code>DOMMatrix</code>)",
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebKitCSSMatrix",
         "support": {
           "chrome": {


### PR DESCRIPTION
`WebKitCSSMatrix` is specified as an alias to `DOMMatrix`. This PR updates the description to reflect that relationship and updates the MDN URL to point to the page for `DOMMatrix`.

(I also added a second compat table to the `DOMMatrix` page. It's a poor solution, but it's better than not showing the data at all.)

Fixes #6726.