### PR TITLE
Fix Chrome version for keyframes at-rule

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -12,7 +12,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2"
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -148,7 +148,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "≤37"
+                "version_added": "1"
               }
             ]
           },


### PR DESCRIPTION
A few PRs for the `CSSKeyframesRule` API were merged recently (#6908, #6909, #6910, #6911, and #6913) that had some differences in their prefixing.  To ensure our data was correct, I double-checked both the API and the @keyframes rule to confirm (and as it turns out, we're in the clear).

During those tests, I noticed that the @keyframes rule was actually supported since Chrome 1 rather than Chrome 2.  This data initially came from #4368, where I mirrored Safari data over to Chrome, but it looks like that was a mistake.  Oops!
