### PR TITLE
set place-self version_added for safari(ios) from false to 11 (#1)

### DIFF
--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -81,10 +81,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This change is a follow up to #6847, which only updated the `place-self` Safari version for the `flex_context` case, but missed updating it for the `grid_context` case also. This change fixes that.