### PR TITLE
Update data for CSSKeyframeRule API

### DIFF
--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -19,7 +19,7 @@
               "version_added": "31"
             },
             {
-              "version_added": "1",
+              "version_added": "18",
               "version_removed": "31",
               "prefix": "WebKit"
             }

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -80,21 +80,21 @@
           ],
           "safari": [
             {
-              "version_added": "9.1"
+              "version_added": "9"
             },
             {
               "version_added": "4",
-              "version_removed": "9.1",
+              "version_removed": "9",
               "prefix": "WebKit"
             }
           ],
           "safari_ios": [
             {
-              "version_added": "9.3"
+              "version_added": "9"
             },
             {
               "version_added": "3.2",
-              "version_removed": "9.3",
+              "version_removed": "9",
               "prefix": "WebKit"
             }
           ],

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -4,12 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": "45"
-          },
+          "chrome": [
+            {
+              "version_added": "31"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "31",
+              "prefix": "WebKit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "31"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "31",
+              "prefix": "WebKit"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -19,7 +33,8 @@
             },
             {
               "version_added": "5",
-              "prefix": "moz"
+              "version_removed": "48",
+              "prefix": "Moz"
             }
           ],
           "firefox_android": [
@@ -28,31 +43,81 @@
             },
             {
               "version_added": "5",
-              "prefix": "moz"
+              "version_removed": "48",
+              "prefix": "Moz"
             }
           ],
           "ie": {
             "version_added": "10"
           },
-          "opera": {
-            "version_added": "12",
-            "prefix": "o"
-          },
-          "opera_android": {
-            "version_added": true
-          },
-          "safari": {
-            "version_added": "4"
-          },
-          "safari_ios": {
-            "version_added": true
-          },
-          "samsunginternet_android": {
-            "version_added": "5.0"
-          },
-          "webview_android": {
-            "version_added": "45"
-          }
+          "opera": [
+            {
+              "version_added": "18"
+            },
+            {
+              "version_added": "15",
+              "version_removed": "18",
+              "prefix": "WebKit"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "18"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "18",
+              "prefix": "WebKit"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "14"
+            }
+          ],
+          "safari": [
+            {
+              "version_added": "9.1"
+            },
+            {
+              "version_added": "4",
+              "version_removed": "9.1",
+              "prefix": "WebKit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "9.3"
+            },
+            {
+              "version_added": "3.2",
+              "version_removed": "9.3",
+              "prefix": "WebKit"
+            }
+          ],
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "version_added": "1.0",
+              "version_removed": "2.0",
+              "prefix": "WebKit"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "4.4.3"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "4.4.3",
+              "prefix": "WebKit"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -65,19 +130,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/keyText",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"
@@ -86,19 +151,19 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "1"
             }
           },
           "status": {
@@ -113,19 +178,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/style",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"
@@ -134,19 +199,19 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the data for the `CSSKeyframeRule` API.  I recently updated the `CSSKeyframesRule` API data (note the plural word form) in a few PRs, however it seems that the `CSSKeyframeRule` API (singular form) was also implemented at the same time.  This PR updates the `CSSKeyframeRule` API accordingly, as well as its subfeatures, based upon manual testing.