### PR TITLE
Update Edge data for CSSGroupingRule

### DIFF
--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "20"


### PR DESCRIPTION
This PR updates the `CSSGroupingRule` API data for Edge based upon results from the mdn-bcd-collector project.