### PR TITLE
Update data for CSSMediaRule API

### DIFF
--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "1"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -5,42 +5,42 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule",
         "support": {
           "chrome": {
-            "version_added": "45"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "45"
+            "version_added": "1"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "17",
+            "version_added": "1",
             "notes": "Before Firefox 20, <code>conditionText</code> could not be set."
           },
           "firefox_android": {
-            "version_added": "17",
+            "version_added": "4",
             "notes": "Before Firefox 20, <code>conditionText</code> could not be set."
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": "5.0"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": "1"
           }
         },
         "status": {
@@ -54,40 +54,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule/media",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -31,7 +31,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤3"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -78,7 +78,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR updates the compat data for the `CSSMediaRule` API based upon a combination of results from the mdn-bcd-collector, as well as manual testing.