### PR TITLE
Update data for CSSNamespaceRule

### DIFF
--- a/api/CSSNamespaceRule.json
+++ b/api/CSSNamespaceRule.json
@@ -14,13 +14,13 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "59"
+            "version_added": "53"
           },
           "firefox_android": {
-            "version_added": "59"
+            "version_added": "53"
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
             "version_added": "36"
@@ -29,10 +29,10 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -67,7 +67,7 @@
               "version_added": "59"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "36"
@@ -76,10 +76,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -115,7 +115,7 @@
               "version_added": "59"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "36"
@@ -124,10 +124,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR updates data for the `CSSNamespaceRule` API using the mdn-bcd-collector project.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/CSSNamespaceRule