### PR TITLE
WeakRef, FinalizationRegistry: nodejs version

### DIFF
--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -24,15 +24,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "13.0.0",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--harmony-weak-refs"
-                }
-              ]
-            },
+            "nodejs": [
+              {
+                "version_added": "14.6.0"
+              },
+              {
+                "version_added": "13.0.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony-weak-refs"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": false
             },
@@ -82,15 +87,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
+              "nodejs": [
+                {
+                  "version_added": "14.6.0"
+                },
+                {
+                  "version_added": "13.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony-weak-refs"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -140,15 +150,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
+              "nodejs": [
+                {
+                  "version_added": "14.6.0"
+                },
+                {
+                  "version_added": "13.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony-weak-refs"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -198,15 +213,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
+              "nodejs": [
+                {
+                  "version_added": "14.6.0"
+                },
+                {
+                  "version_added": "13.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony-weak-refs"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": false
               },

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -24,15 +24,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "13.0.0",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--harmony-weak-refs"
-                }
-              ]
-            },
+            "nodejs": [
+              {
+                "version_added": "14.6.0"
+              },
+              {
+                "version_added": "13.0.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony-weak-refs"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": false
             },
@@ -82,15 +87,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
+              "nodejs": [
+                {
+                  "version_added": "14.6.0"
+                },
+                {
+                  "version_added": "13.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony-weak-refs"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -140,15 +150,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              },
+              "nodejs": [
+                {
+                  "version_added": "14.6.0"
+                },
+                {
+                  "version_added": "13.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony-weak-refs"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": false
               },


### PR DESCRIPTION
With 14.6.0, flag is enabled by default: https://github.com/nodejs/node/blame/v14.6.0/deps/v8/src/flags/flag-definitions.h#L262