### PR TITLE
Update data for CSSPrimitiveValue API

### DIFF
--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -5,16 +5,18 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "40"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18",
+            "version_removed": "40"
           },
           "edge": {
             "version_added": false
           },
           "firefox": {
-            "version_added": true,
+            "version_added": "1",
             "version_removed": "62"
           },
           "firefox_android": {
@@ -25,22 +27,26 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "≤12.1",
+            "version_removed": "27"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤12.1",
+            "version_removed": "27"
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤3"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0",
+            "version_removed": "4.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "40"
           }
         },
         "status": {
@@ -54,7 +60,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getCounterValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -63,11 +70,11 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
@@ -80,7 +87,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -104,7 +111,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getFloatValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -113,7 +121,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -130,7 +138,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -154,7 +162,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRectValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -163,7 +172,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -180,7 +189,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -204,7 +213,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRGBColorValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -213,7 +223,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -230,7 +240,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -254,7 +264,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getStringValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -263,7 +274,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -280,7 +291,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -313,7 +324,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -330,7 +341,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤7"
             },
             "safari_ios": {
               "version_added": null
@@ -354,7 +365,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setFloatValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -363,7 +375,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -380,7 +392,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null
@@ -404,7 +416,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setStringValue",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤15",
+              "version_removed": "40"
             },
             "chrome_android": {
               "version_added": false
@@ -413,7 +426,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "version_removed": "62"
             },
             "firefox_android": {
@@ -430,7 +443,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "safari_ios": {
               "version_added": null

--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -35,7 +35,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "≤3"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -60,11 +60,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getCounterValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -81,22 +82,26 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -111,11 +116,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getFloatValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -125,29 +131,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -162,11 +172,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRectValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -176,29 +187,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -213,11 +228,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRGBColorValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -227,29 +243,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -264,11 +284,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getStringValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -278,29 +299,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -328,7 +353,7 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
@@ -338,13 +363,13 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": "≤7"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -365,11 +390,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setFloatValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -379,29 +405,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {
@@ -416,11 +446,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setStringValue",
           "support": {
             "chrome": {
-              "version_added": "≤15",
+              "version_added": "1",
               "version_removed": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "40"
             },
             "edge": {
               "version_added": false
@@ -430,29 +461,33 @@
               "version_removed": "62"
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "20",
               "version_removed": "62"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "27"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "27"
             },
             "safari": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "40"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the compat data for the `CSSPrimitiveValue` API based upon a combination of results from the mdn-bcd-collector, as well as manual testing.