### PR TITLE
Correct <tspan rotate=""> support for Firefox.

### DIFF
--- a/svg/elements/tspan.json
+++ b/svg/elements/tspan.json
@@ -202,10 +202,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": true
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
This has been supported from the outset, and can be verified with:

```
data:text/html,<svg><text x="100" y="100"><tspan rotate="30">abcdef
```