### PR TITLE
Add CSS math-style property

### DIFF
--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -15,7 +15,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -31,7 +37,14 @@
               ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.math-style.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -1,0 +1,67 @@
+{
+  "css": {
+    "properties": {
+      "math-style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-style",
+          "support": {
+            "chrome": {
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.math-style.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm working on the CSS updates for Firefox 83 in https://github.com/mdn/sprints/issues/3800

This PR adds BCD for the `math-style` property (I haven't created the page yet). It is behind a flag in Firefox and Chrome.

- Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1665975
- Chromium: https://chromium-review.googlesource.com/c/chromium/src/+/2100787

(Recently added to WebKit but not in Safari yet https://bugs.webkit.org/show_bug.cgi?id=216702)