### PR TITLE
Mark InstallEvent and subfeatures non-standard

### DIFF
--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -44,8 +44,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "InstallEvent": {
@@ -93,8 +93,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -142,8 +142,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This change marks the `InstallEvent` interface and all its subfeatures `standard_track:false` and `deprecated:true`.

https://github.com/w3c/ServiceWorker/commit/4d17228 (in 2015) completely dropped `InstallEvent` from the spec.