### PR TITLE
Safari 14 added EventTarget constructor support

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -79,10 +79,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
Mentioned in release notes (https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes). Confirmed via manual testing on Safari 14.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
