### PR TITLE
Drop window.restore (unspecified & unimplemented)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7525,54 +7525,6 @@
           }
         }
       },
-      "restore": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/restore",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "returnValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/returnValue",


### PR DESCRIPTION
This drops the `window.restore()` method. The method isn’t implemented in any browser engines, and isn’t part of any spec.

---

I think this one was not included yet in any of the *Remove never-supported* PRs that @saschanaz raised so far.