### PR TITLE
Updated Trusted Types support for Chromium-based browsers.

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1643,7 +1643,7 @@
                   }
                 ],
                 "edge": {
-                  "version_added": null
+                  "version_added": "83"
                 },
                 "firefox": {
                   "version_added": false
@@ -1655,7 +1655,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "69"
                 },
                 "opera_android": {
                   "version_added": false


### PR DESCRIPTION
Edge and Opera are based on Chromium and support Trusted Types from their release version that is based on Chromium/83.

Edge follows Chromium's numbering scheme. Opera uses a separate one, 69 is based on Chromium 83. https://blogs.opera.com/desktop/2020/07/opera-69-0-3686-49-stable-update/

I checked that 'window.trustedTypes' object is available on both of these.

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
