### PR TITLE
Update data for CSSSupportsRule API

### DIFF
--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -35,10 +35,10 @@
             }
           ],
           "safari": {
-            "version_added": "10.1"
+            "version_added": "9"
           },
           "safari_ios": {
-            "version_added": "10.3"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "1.5"

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -5,57 +5,54 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSupportsRule",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "41"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "41"
           },
           "edge": {
-            "version_added": "≤18",
-            "version_removed": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "17",
-            "notes": "From Firefox 17 to 19, methods and properties were defined on <code>CSSSupportsRule</code>. From version 20, they were on <code>CSSConditionRule</code>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "layout.css.supports-rule.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "22",
+            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
           },
           "firefox_android": {
-            "version_added": "17",
-            "notes": "From Firefox 17 to 19, methods and properties were defined on <code>CSSSupportsRule</code>. From version 20, they were on <code>CSSConditionRule</code>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "layout.css.supports-rule.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "22",
+            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
           },
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "12.1"
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": [
+            {
+              "version_added": "28"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "28"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "14"
+            }
+          ],
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "41"
           }
         },
         "status": {

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -14,12 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "22",
-            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
+            "version_added": "22"
           },
           "firefox_android": {
-            "version_added": "22",
-            "notes": "Methods and properties are defined on <code>CSSConditionRule</code>."
+            "version_added": "22"
           },
           "ie": {
             "version_added": false

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSupportsRule",
         "support": {
           "chrome": {
-            "version_added": "41"
+            "version_added": "28"
           },
           "chrome_android": {
-            "version_added": "41"
+            "version_added": "28"
           },
           "edge": {
             "version_added": "12"
@@ -22,18 +22,12 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "28"
-            },
-            {
-              "version_added": "12.1",
-              "version_removed": "15"
-            }
-          ],
+          "opera": {
+            "version_added": "12.1"
+          },
           "opera_android": [
             {
-              "version_added": "28"
+              "version_added": "15"
             },
             {
               "version_added": "12.1",
@@ -47,10 +41,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": "4.0"
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "41"
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates the compat data for the `CSSSupportsRule` API based upon a combination of results from the mdn-bcd-collector, as well as manual testing.

Notice: this removes deprecated flag data for Firefox.