### PR TITLE
Mark HTMLImageElement.p.lowsrc deprecated

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -804,7 +804,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks `HTMLImageElement.prototype.lowsrc` deprecated.

https://html.spec.whatwg.org/multipage/obsolete.html#attr-img-lowsrc defines the `lowsrc` markup/content attribute as a non-conforming feature (meaning, _“entirely obsolete, and must not be used by authors”_), with the guidance, _“Use a progressive JPEG image (given in the src attribute), instead of using two separate images.”_

This change marks the associated IDL attribute as deprecated.

---

We can also consider marking `lowsrc` with `standard_track:false` too. The reason I didn’t already is that it’s one of those odd cases where it’s deprecated and non-conforming, yet still has specified browser behavior; it’s specified at https://html.spec.whatwg.org/multipage/obsolete.html#dom-img-lowsrc (as just as simple reflection of the markup/content attribute) — so it’s in fact standardized (in the sense of being defined in a specification).