### PR TITLE
Safari 14 does not support `ParentNode.prototype.replaceChildren`.

### DIFF
--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -751,10 +751,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Safari 14 doesn't seem to support `ParentNode.prototype.replaceChildren`. I'm running Safari 14.0 (15610.1.28.1.9, 15610) on macOS 10.15.6 (19G2021) and I don't see this function. (Note that I have not tested iOS specifically.) However, I also have Safari TP (Release 114 (Safari 14.1, WebKit 15611.1.1.3)), which does have it.

Related PR #6343 marked this function as available in 14 and the WebKit changeset linked in that PR isn't behind any type of flag that would prevent `replaceChildren` from being available, AFAICT, so I'm not sure why I'm not seeing it.