### PR TITLE
Mark Safari support for JS public class fields partial, with note

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -560,10 +560,14 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14",
+              "partial_implementation": true,
+              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This change marks the support in Safari for public class fields `partial_implementation:true` — due to the fact that while Safari does support public *instance* fields, it does not yet support public *static* fields.
See https://bugs.webkit.org/show_bug.cgi?id=194095

Fixes https://github.com/mdn/browser-compat-data/issues/6875