### PR TITLE
Update dragexit data to match ondragexit data

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3354,25 +3354,26 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
-              "version_added": false
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This change updates the incomplete version info we had in the support data for the `dragexit` event; the change just copies over the more-complete version info from the support data for the `ondragexit` event handler.

Relates to https://github.com/mdn/browser-compat-data/issues/6826

---

Since in #6826 we decided to keep `dragexit` in BCD, we should at least make the support data for it accurate — by syncing it up with what we already have for the `ondragexit` event handler.