### PR TITLE
fixing incorrect alternative name for edge

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -38,7 +38,7 @@
                 "version_added": "16"
               },
               {
-                "alternative_name": "-ms-grid-rows",
+                "alternative_name": "-ms-grid-columns",
                 "version_added": "12",
                 "version_removed": "79"
               }


### PR DESCRIPTION
While fixing something else on the `grid-template-columns` page, I noticed that the Edge basic entry wrongly referred to `-ms-grid-rows` as the alternative name.