### PR TITLE
Mirror Chrome -> Opera for MediaDeviceInfo API

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -25,12 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false,
-            "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+            "version_added": "42"
           },
           "opera_android": {
-            "version_added": false,
-            "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+            "version_added": "42"
           },
           "safari": {
             "version_added": false
@@ -78,12 +76,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -134,12 +130,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -188,12 +182,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -242,12 +234,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": "42"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR mirrors Chrome to Opera for the MediaDeviceInfo API, as well as removes the now-redundant note about needing a polyfill (plus the linked polyfill is an outdated fork).