### PR TITLE
margin, border, padding, inset in Chrome

### DIFF
--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -54,16 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -84,7 +89,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -5,32 +5,42 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform Features",
+                  "name": "enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
               ]

--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-end",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-start",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -90,16 +90,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48",
               "flags": [
@@ -120,7 +125,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -5,26 +5,36 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": false
             },
@@ -70,7 +82,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -5,14 +5,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": false
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox": {
               "version_added": "66"

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -5,33 +5,43 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -5,33 +5,43 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -5,33 +5,43 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -54,9 +54,21 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -70,7 +82,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -5,33 +5,43 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline",
           "support": {
-            "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android":  [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "Experimental Web Platform features",
-                  "value_to_set": "Enabled"
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
                 }
               ]
             },

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -20,7 +20,7 @@
                 ]
               }
             ],
-            "chrome_android":  [
+            "chrome_android": [
               {
                 "version_added": "87"
               },


### PR DESCRIPTION
Working on https://github.com/mdn/sprints/issues/3793

Chrome are shipping the logical margin, border, padding shorthands along with the inset property and shorthands in 87.

This PR updates the BCD.

https://www.chromestatus.com/feature/6618771051511808
