### PR TITLE
Remove polyfill notes from MediaDeviceInfo API for Chrome

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -5,12 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo",
         "support": {
           "chrome": {
-            "version_added": "55",
-            "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+            "version_added": "55"
           },
           "chrome_android": {
-            "version_added": "55",
-            "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+            "version_added": "55"
           },
           "edge": {
             "version_added": "12"
@@ -39,12 +37,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0",
-            "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "55",
-            "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+            "version_added": "55"
           }
         },
         "status": {
@@ -58,12 +54,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/deviceId",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "12"
@@ -92,12 +86,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             }
           },
           "status": {
@@ -112,12 +104,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/groupId",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "12"
@@ -148,12 +138,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             }
           },
           "status": {
@@ -168,12 +156,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/kind",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "12"
@@ -202,12 +188,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             }
           },
           "status": {
@@ -222,12 +206,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/label",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "12"
@@ -256,12 +238,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "55",
-              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": "55"
             }
           },
           "status": {


### PR DESCRIPTION
This PR removes the polyfill information from the Chrome browsers.  The polyfill linked is an outdated fork, not to mention that it's for browser versions that are older than two years.  (Data for Opera is taken care of in #7000.)