### PR TITLE
autocapitalize attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -63,10 +63,24 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "83"
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.forms.autocapitalize",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "83"
+              "version_added": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.forms.autocapitalize",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -54,19 +54,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "83"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "83"
             },
             "ie": {
               "version_added": null
@@ -81,7 +81,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "5"
@@ -96,7 +96,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "43"
             }
           },
           "status": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -95,7 +95,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "5"


### PR DESCRIPTION
Adding support for the HTML global `autocapitalize` attribute:

- Firefox is shipping in 83: https://bugzilla.mozilla.org/show_bug.cgi?id=1425291
- Safari has had since 4/iOS5: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize
- Chrome since 43: https://www.chromestatus.com/feature/4529989986811904

MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize

Part of: https://github.com/mdn/sprints/issues/3802
