### PR TITLE
updating firefox browser versions inline with the Firefox 82 release

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -588,35 +588,35 @@
         "80": {
           "release_date": "2020-08-25",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "80"
         },
         "81": {
           "release_date": "2020-09-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "81"
         },
         "82": {
           "release_date": "2020-10-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/82",
-          "status": "nightly",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "82"
         },
         "83": {
           "release_date": "2020-11-17",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/83",
-          "status": "planned",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "83"
         },
         "84": {
           "release_date": "2020-12-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "84"
         }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -455,19 +455,30 @@
         "81": {
           "release_date": "2020-09-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/81",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "81"
         },
         "82": {
-          "status": "beta",
+          "release_date": "2020-10-20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/82",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "82"
         },
         "83": {
-          "status": "nightly",
+          "release_date": "2020-11-17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/83",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "83"
+        },
+        "84": {
+          "release_date": "2020-12-15",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "84"
         }
       }
     }


### PR DESCRIPTION
Now Firefox 82 has been released, I've updated the Fx/FxA version files to list it as the current version, and updated other version information to suit around that, up to Fx 84 (current nightly). 
