### PR TITLE
Remove remaining polyfill notes from MediaDeviceInfo API for Opera

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -265,12 +265,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
These notes don't make sense when the toJSON method was never shipped.

Similar to https://github.com/mdn/browser-compat-data/pull/7002.