### PR TITLE
Update feGaussianBlur IE, Chrome compatibility

### DIFF
--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
               "version_added": "≤18"

--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/feGaussianBlur",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": null
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "9"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
I tested it on IE9/10/11. feGaussianBlur works on IE 10 and on higher versions.
And it also works on Chrome, but the results were missing so i fixed it. Attached are the test result screenshots. https://github.com/mdn/browser-compat-data/issues/7006
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
https://github.com/mdn/browser-compat-data/issues/7006