### PR TITLE
Remove note about @keyframes in <style scoped> for Firefox

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -29,8 +29,7 @@
             },
             "firefox": [
               {
-                "version_added": "16",
-                "notes": "<code>@keyframes</code> is unsupported in scoped stylesheets in Firefox (<a href='https://bugzil.la/830056'>bug 830056</a>)."
+                "version_added": "16"
               },
               {
                 "version_added": "49",


### PR DESCRIPTION
https://bugzil.la/830056 was closed WONTFIX, and <style scoped> was never shipped:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#Browser_compatibility