### PR TITLE
updating Firefox support for private class fields

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -504,7 +504,19 @@
               ]
             },
             "firefox_android": {
-              "version_added": "81"
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.private_fields",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.private_methods",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -489,7 +489,19 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "81"
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.private_fields",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.private_methods",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "81"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -489,10 +489,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "81"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "81"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1435826 and https://bugzilla.mozilla.org/show_bug.cgi?id=1659134, private class fields are now supported in Firefox 81.