### PR TITLE
Mark CSS focus-visible with enabled-by-default support in Chrome (86+)

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -6,26 +6,36 @@
           "description": "<code>:focus-visible</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:focus-visible",
           "support": {
-            "chrome": {
-              "version_added": "67",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "67",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
@@ -77,7 +87,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "86"
             }
           },
           "status": {


### PR DESCRIPTION
This change marks the CSS `:focus-visible` pseudo-class as enabled-by-default supported in Chrome (+Android, +WebView) 86+, per https://www.chromestatus.com/feature/5823526732824576

Fixes https://github.com/mdn/browser-compat-data/issues/7009