### PR TITLE
Remove notes about document.all being readonly

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -298,17 +298,11 @@
           "support": {
             "chrome": {
               "version_added": "64",
-              "notes": [
-                "Starting in Chrome 65, this property is readonly.",
-                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
-              ]
+              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "chrome_android": {
               "version_added": "64",
-              "notes": [
-                "Starting in Chrome 65, this property is readonly.",
-                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
-              ]
+              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "edge": {
               "version_added": "12"
@@ -336,17 +330,11 @@
             },
             "samsunginternet_android": {
               "version_added": "9.0",
-              "notes": [
-                "Starting in Samsung Internet 9.0, this property is readonly.",
-                "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
-              ]
+              "notes": "Before Samsung Internet 9.0, this property was accessed through the <code>HTMLDocument</code> alias."
             },
             "webview_android": {
               "version_added": "64",
-              "notes": [
-                "Starting in Chrome 65, this property is readonly.",
-                "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
-              ]
+              "notes": "Before Chrome 64, this property was accessed through the <code>HTMLDocument</code> alias."
             }
           },
           "status": {


### PR DESCRIPTION
These notes were added in https://github.com/mdn/browser-compat-data/pull/3391,
after the change in https://chromium-review.googlesource.com/c/chromium/src/+/823513/.

Previously it was possible to assign document.all, and now it is not.
The uses of document.all that currently work also work with older
browsers, so there isn't anything that web developers need to be aware
of here. The only time when it might have mattered was at the time of
the change, if someone depending on being able to use document.all to
store their own values, which in itself is an unlikely scenario.
