### PR TITLE
Fixing private class fields compat table data of safari on mac and iOS

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -507,10 +507,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
It fixes #6773.