### PR TITLE
Input color: Firefox on Android doesn't support custom colors.

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -17,8 +17,7 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": "29",
-                "notes": "Firefox doesn't yet support inputs of type <code>color</code> on Windows Touch."
+                "version_added": "29"
               },
               "firefox_android": {
                 "version_added": "27",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -21,7 +21,8 @@
                 "notes": "Firefox doesn't yet support inputs of type <code>color</code> on Windows Touch."
               },
               "firefox_android": {
-                "version_added": "27"
+                "version_added": "27",
+                "notes": "Firefox on Android doesn't allow the user to choose a custom color, only one of the predefined ones."
               },
               "ie": {
                 "version_added": false

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -21,7 +21,7 @@
               },
               "firefox_android": {
                 "version_added": "27",
-                "notes": "Firefox on Android doesn't allow the user to choose a custom color, only one of the predefined ones."
+                "notes": "Firefox for Android doesn't allow the user to choose a custom color, only one of the predefined ones."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

**Summary:** Added a note saying that Firefox on mobile doesn't allow the user to choose a custom color, only one from a predefined list.
**Data:** Tried it on Firefox Mobile Daylight 81.1.5, Nightly 201022 17:03 and Beta 82.0.0-beta.6
**Review:** I don't know what the linter is, but this is a small change so I don't think it's necessary.