### PR TITLE
Fix 15.0.0 version-number typo in browsers/nodejs.json

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -262,7 +262,7 @@
           "engine": "V8",
           "engine_version": "8.4"
         },
-        "15.0.0 (": {
+        "15.0.0": {
           "release_date": "2020-10-20",
           "release_notes": "https://nodejs.org/en/blog/release/v15.0.0/",
           "status": "current",


### PR DESCRIPTION
This change fixes a typo in the node.js 15.0.0 version number added in 795300e (the actual number that change added was literally "`15.0.0 (`", with a stray "` (`" at the end).