### PR TITLE
Add Intl.toString

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -104,6 +104,58 @@
               "deprecated": false
             }
           }
+        },
+        "@@toStringTag": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag",
+            "spec_url": "https://tc39.es/ecma402/#sec-Intl-toStringTag",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": "86"
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": "83"
+              },
+              "firefox_android": {
+                "version_added": "83"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "15.0.0"
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "86"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds BCD info for `Intl.prototype[@@toStringTag]` which was added in FF83. See bug report https://bugzilla.mozilla.org/show_bug.cgi?id=1670053

Docs are here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag

I tried this out on other browsers including latest chrome and opera and it works. However not sure how to record that because when I tried setting values to `true` the test tells me that the I'm not allowed. Similarly `null`. I suspect I could add specific versions, but I don't know when this went in.