### PR TITLE
Mark Intl.ListFormat supported in Blink-based Edge

### DIFF
--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -14,7 +14,7 @@
                 "version_added": "72"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "78"
@@ -67,7 +67,7 @@
                   "version_added": "72"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "78"
@@ -126,7 +126,7 @@
                   "version_added": "72"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "78"
@@ -179,7 +179,7 @@
                   "version_added": "72"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "78"
@@ -232,7 +232,7 @@
                   "version_added": "72"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "78"
@@ -285,7 +285,7 @@
                   "version_added": "72"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "78"


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/7022