### PR TITLE
Fix tabs.discard() WebExtension compatibilty for Firefox Desktop

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1848,8 +1848,7 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": "58",
-                "version_removed": "79"
+                "version_added": "58"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
#6590 accidentally removed tabs.discard() compatibility from Firefox Desktop, but the change was intended for Mobile.
You can view the git blame [here](https://github.com/mdn/browser-compat-data/blame/21bd787bc4b2efe7bfcd48ee2612d6617f30d780/webextensions/api/tabs.json#L1852).