### PR TITLE
Mark CSS "revert" supported in Chrome

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -163,16 +163,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/revert",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+                "version_added": "84"
               },
               "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "67"
@@ -184,10 +181,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "9.1"
@@ -200,8 +197,7 @@
                 "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
               },
               "webview_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/579788'>bug 579788</a>."
+                "version_added": "84"
               }
             },
             "status": {


### PR DESCRIPTION
This change marks the CSS `revert` keyword as supported in Chrome (+Android, +WebView) from version 84 (per https://www.chromestatus.com/feature/5644990145363968), and in the corresponding Edge and Opera versions.

Fixes https://github.com/mdn/browser-compat-data/issues/7037