### PR TITLE
Mark AudioContext() options Safari-unsupported

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -229,10 +229,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -277,10 +277,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "11.0"


### PR DESCRIPTION
This change marks the *latencyHint* and *sampleRate* options (parameters) for the `AudioContext()` constructor as unsupported in Safari.

Test: https://wpt.live/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html