### PR TITLE
Mark AudioContextOptions Safari-unsupported

### DIFF
--- a/api/AudioContextOptions.json
+++ b/api/AudioContextOptions.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "8.0"
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -124,10 +124,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "11.0"


### PR DESCRIPTION
This change marks the `AudioContextOptions` dictionary unsupported in Safari; confirmed by manual testing that even with the prefixed `webkitAudioContext()` constructor, any `latencyHint` or `sampleRate` values given in the object argument to the constructor don’t end up affecting any properties for the object that gets created.