### PR TITLE
fix repeat for Firefox

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -381,6 +381,9 @@
               },
               "firefox": [
                 {
+                  "version_added": "76"
+                },
+                {
                   "version_added": "57",
                   "version_removed": "76",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -382,6 +382,7 @@
               "firefox": [
                 {
                   "version_added": "57",
+                  "version_removed": "76",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
                   "partial_implementation": true
                 },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -381,6 +381,9 @@
               },
               "firefox": [
                 {
+                  "version_added": "76"
+                },
+                {
                   "version_added": "57",
                   "version_removed": "76",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -382,6 +382,7 @@
               "firefox": [
                 {
                   "version_added": "57",
+                  "version_removed": "76",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
                   "partial_implementation": true
                 },


### PR DESCRIPTION
The BCD for `grid-template-columns` and `grid-template-rows` still shows partial support for Firefox, due to multiple values (a tracklisting) not being used.

This was fixed in 76: https://bugzilla.mozilla.org/show_bug.cgi?id=1341507
