### PR TITLE
Mark AudioBufferSourceNode.p.detune unsupported in iOS Safari

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This change marks `AudioBufferSourceNode.prototype.detune` unsupported in iOS Safari. (Confirmed by manual testing.)