### PR TITLE
Set Chromium to 1 for HTMLEmbedElement

### DIFF
--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLEmbedElement",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "Starting with Chrome 58, this interface can no longer be called as a function."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "Starting with Chrome 58, this interface can no longer be called as a function."
           },
           "edge": {
@@ -39,12 +39,12 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "notes": "Starting with Samsung Internet 7.0, this interface can no longer be called as a function."
           },
           "webview_android": {
-            "version_added": true,
-            "notes": "Starting with Chrome 58, this interface can no longer be called as a function."
+            "version_added": "1",
+            "notes": "Starting with WebView 58, this interface can no longer be called as a function."
           }
         },
         "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLEmbedElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
