### PR TITLE
Set Chromium to 1 for HTMLFontElement

### DIFF
--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -5,7 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -24,6 +27,12 @@
           },
           "safari": {
             "version_added": true
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "1"
           }
         },
         "status": {
@@ -37,7 +46,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/color",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,6 +68,12 @@
             },
             "safari": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {
@@ -70,7 +88,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/face",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -89,6 +110,12 @@
             },
             "safari": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {
@@ -103,7 +130,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFontElement/size",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -122,6 +152,12 @@
             },
             "safari": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLFontElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
