### PR TITLE
Set Chromium to 1 for HTMLLegendElement

### DIFF
--- a/api/HTMLLegendElement.json
+++ b/api/HTMLLegendElement.json
@@ -5,7 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLegendElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -31,8 +34,11 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLLegendElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
