### PR TITLE
Set Chromium to 1 for HTMLModElement

### DIFF
--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLModElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLModElement/cite",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLModElement/dateTime",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLModElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
