### PR TITLE
Set Chromium to 1 for HTMLObjectElement

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -628,10 +628,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/getSVGDocument",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -658,10 +658,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLObjectElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
