### PR TITLE
Set Chromium to 1 for HTMLOptGroupElement

### DIFF
--- a/api/HTMLOptGroupElement.json
+++ b/api/HTMLOptGroupElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement/disabled",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement/label",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLOptGroupElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
