### PR TITLE
Set Chromium to 1 for HTMLTableElement

### DIFF
--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -5,7 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -31,8 +34,11 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -46,7 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/align",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -72,8 +81,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -88,7 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/bgColor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -114,8 +129,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -130,7 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/border",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -156,8 +177,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -172,7 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/caption",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -198,8 +225,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -214,7 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/cellPadding",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -240,8 +273,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -256,7 +292,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/cellSpacing",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -282,8 +321,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -298,7 +340,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createCaption",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -324,8 +369,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -382,7 +430,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createTFoot",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -408,8 +459,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -424,7 +478,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createTHead",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -450,8 +507,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -466,7 +526,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteCaption",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -492,8 +555,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -508,7 +574,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteRow",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -534,8 +603,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -550,7 +622,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteTFoot",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -576,8 +651,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -592,7 +670,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteTHead",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -618,8 +699,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -634,7 +718,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/frame",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -660,8 +747,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -726,7 +816,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/rows",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -752,8 +845,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -768,7 +864,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/rules",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -794,8 +893,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -894,7 +996,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/summary",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -920,8 +1025,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -936,7 +1044,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tBodies",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -962,8 +1073,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -978,7 +1092,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tFoot",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1004,8 +1121,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1020,7 +1140,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tHead",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1046,8 +1169,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1062,7 +1188,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTableElement/width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1088,8 +1217,11 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `1` for Chrome for the `HTMLTableElement` API and many of its subfeatures.  Data is also mirrored to Chrome Android, Samsung Internet, and WebView Android.
