### PR TITLE
Mark ImageBitmapRenderingContext unsupported in iOS Safari

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -32,7 +32,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -93,7 +93,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
This change marks the `ImageBitmapRenderingContext` interface unsupported in iOS Safari. (Confirmed by manual testing.)