### PR TITLE
Mark createImageBitmap unsupported in iOS Safari

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -405,7 +405,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -452,7 +452,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
@@ -500,7 +500,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
@@ -548,7 +548,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This change marks the `createImageBitmap()` method of `WindowOrWorkerGlobalScope` unsupported in iOS Safari. (Confirmed by manual testing.)