### PR TITLE
Set Opera to ≤12.1 for HTMLEmbedElement

### DIFF
--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -25,11 +25,11 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true,
+            "version_added": "≤12.1",
             "notes": "Starting with Opera 45, this interface can no longer be called as a function."
           },
           "opera_android": {
-            "version_added": true,
+            "version_added": "≤12.1",
             "notes": "Starting with Opera 45, this interface can no longer be called as a function."
           },
           "safari": {


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `≤12.1` for Opera for the `HTMLEmbedElement` API and many of its subfeatures.  Data is also mirrored to Opera Android.