### PR TITLE
Set Opera to ≤12.1 for HTMLFontElement

### DIFF
--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -20,7 +20,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -52,7 +55,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -85,7 +91,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -118,7 +127,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `≤12.1` for Opera for the `HTMLFontElement` API and many of its subfeatures.  Data is also mirrored to Opera Android.