### PR TITLE
Set Opera to ≤12.1 for HTMLFrameSetElement

### DIFF
--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -23,10 +23,10 @@
             "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -69,10 +69,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -258,10 +258,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `≤12.1` for Opera for the `HTMLFrameSetElement` API and many of its subfeatures.  Data is also mirrored to Opera Android.