### PR TITLE
Set Opera to ≤12.1 for HTMLHtmlElement

### DIFF
--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `≤12.1` for Opera for the `HTMLHtmlElement` API and many of its subfeatures.  Data is also mirrored to Opera Android.