### PR TITLE
Set Opera to ≤12.1 for HTMLMarqueeElement

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -259,10 +259,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -306,10 +306,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -494,10 +494,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR uses the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com/) project to set `true` to `≤12.1` for Opera for the `HTMLMarqueeElement` API and many of its subfeatures.  Data is also mirrored to Opera Android.