### PR TITLE
Mark all MIDI APIs unsupported in Safari

### DIFF
--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -29,10 +29,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -77,10 +77,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -125,10 +125,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -29,7 +29,7 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -77,7 +77,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -29,10 +29,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0"

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -29,7 +29,7 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -77,7 +77,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -29,7 +29,7 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -29,10 +29,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0"

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -29,10 +29,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -76,10 +76,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -124,10 +124,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -172,10 +172,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -220,10 +220,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -268,10 +268,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -316,10 +316,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -364,10 +364,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -413,10 +413,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -461,10 +461,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -509,10 +509,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This change consistently marks all MIDI APIs unsupported in macOS Safari and iOS Safari. (Confirmed by manual testing.)