### PR TITLE
Notes about Safari around sandbox-allow-same-origin

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1027,6 +1027,55 @@
             }
           }
         },
+        "sandbox-allow-same-origin": {
+          "__compat": {
+            "description": "<code>sandbox=\"allow-same-origin\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true,
+                "notes": "Safari blocks script execution without <code>allow-scripts</code> even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sandbox-allow-storage-access-by-user-activation": {
           "__compat": {
             "description": "<code>sandbox=\"allow-storage-access-by-user-activation\"</code>",


### PR DESCRIPTION
A checklist to help your pull request get merged faster:

- [x] Summarize your changes

    Make a note about sandbox-allow-same-origin in Safari

- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version

     I have tested under Safari 13.1.2 (14609.3.5.1.5) and found that when setting with `sandbox="allow-same-origin"` without `allow-scripts`, we can't bind any event handlers upon nodes inside an iframe via accessing `iframe.contentDocument` because Safari may throw an error:

    ```
   [Error] Blocked script execution in 'xxx' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
    ``` 

    Besides, the same error can be caught when trying to post messages toward such an iframe.

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests if any
