### PR TITLE
Use `prettier --list-different`

### DIFF
--- a/test/test-format.js
+++ b/test/test-format.js
@@ -4,13 +4,11 @@ const chalk = require('chalk');
 
 const testFormat = () => {
   try {
-    execSync('npx prettier --check "**/*.js" "**/*.ts" "**/*.md"', {
-      stdio: 'inherit',
-    });
+    execSync('npx prettier --list-different "**/*.js" "**/*.ts" "**/*.md"');
   } catch (err) {
     let errorText = err.stdout.toString();
     console.error(chalk`{red   Prettier – formatting errors:}`);
-    console.error(chalk`{red.bold ${errorText}}`);
+    console.error(chalk`{red.bold → ${errorText}}`);
     console.error(
       chalk`{blue Tip: Run {bold npm run fix} to fix formatting automatically}`,
     );


### PR DESCRIPTION
Fixes #6815 

Before:

```
Checking formatting...
test\test-format.js
Code style issues found in the above file(s). Forgot to run Prettier?
C:\Users\Kagami\Documents\GitHub\browser-compat-data\test\test-format.js:11
    let errorText = err.stdout.toString();
                               ^

TypeError: Cannot read property 'toString' of null
    at testFormat (C:\Users\Kagami\Documents\GitHub\browser-compat-data\test\test-format.js:11:32)
    at Object.<anonymous> (C:\Users\Kagami\Documents\GitHub\browser-compat-data\test\lint.js:163:13)
    at Module._compile (node:internal/modules/cjs/loader:1083:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1112:10)
    at Module.load (node:internal/modules/cjs/loader:948:32)
    at Function.Module._load (node:internal/modules/cjs/loader:789:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:72:12)
    at node:internal/main/run_main_module:17:47
```

After:

```
  Prettier – formatting errors:
→ test\test-format.js

Tip: Run npm run fix to fix formatting automatically

Problems in 0 files:
```