### PR TITLE
Navigator/vibrate - Firefox for Android doesn't vibrate

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2276,8 +2276,7 @@
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
                   "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",
-                  "Beginning in Firefox 72, this is not supported in cross-origin iframes.",
-                  "Firefox for Android doesn't support vibration, and always returns `true` when the window is visible."
+                  "Beginning in Firefox 72, this is not supported in cross-origin iframes."
                 ]
               },
               {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2287,15 +2287,17 @@
             ],
             "firefox_android": [
               {
-                "version_added": "16",
-                "notes": [
-                  "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
-                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>)."
-                ]
+                "version_added": "72",
+                "partial_implementation": true,
+                "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). See <a href='https://bugzil.la/1591113'>bug 1591113</code>."
               },
               {
-                "version_added": "14",
-                "prefix": "moz"
+                "version_added": "16",
+                "version_removed": "72",
+                "notes": [
+                  "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
+                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",
+                ]
               }
             ],
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2293,7 +2293,7 @@
               },
               {
                 "version_added": "16",
-                "version_removed": "72",
+                "version_removed": "79",
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
                   "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>)."

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2281,6 +2281,7 @@
               },
               {
                 "version_added": "11",
+                "version_removed": true,
                 "prefix": "moz"
               }
             ],

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2298,6 +2298,11 @@
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
                   "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>)."
                 ]
+              },
+              {
+                "version_added": "14",
+                "version_removed": true,
+                "prefix": "moz"
               }
             ],
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2287,7 +2287,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "72",
+                "version_added": "79",
                 "partial_implementation": true,
                 "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). See <a href='https://bugzil.la/1591113'>bug 1591113</code>."
               },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2296,7 +2296,7 @@
                 "version_removed": "72",
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
-                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",
+                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>)."
                 ]
               }
             ],

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2276,7 +2276,8 @@
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
                   "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",
-                  "Beginning in Firefox 72, this is not supported in cross-origin iframes."
+                  "Beginning in Firefox 72, this is not supported in cross-origin iframes.",
+                  "Firefox for Android doesn't support vibration, and always returns `true` when the window is visible."
                 ]
               },
               {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

**Summary:** Firefox for Android [Daylight, Nightly, Beta] doesn't support vibration, although it always returns true when the window is active
**Data:** Tested on Firefox for Android Daylight, Nightly and Beta on a Galaxy S8 running Android 9. Test it out with [this tool](https://voxelprismatic.github.io/prizm.dev/vibration_api_test)
**Notes:** I tested that same tool out in Samsung Internet, vibration works fine. I also have `mozVibrate()` on that tool just in case.

**Possible help:** Is there a separate note for API/Vibration_API or is it linked? Otherwise all is good