### PR TITLE
Add/correct Chromium data for HTMLObjectElement API

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": "1"
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -133,7 +133,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/checkValidity",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -226,10 +226,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -277,7 +277,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -373,7 +373,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -406,10 +406,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "10"
@@ -421,7 +421,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -517,7 +517,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -532,10 +532,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/declare",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -562,10 +562,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "1"
             }
           },
           "status": {
@@ -580,10 +580,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/form",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -610,10 +610,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "1"
             }
           },
           "status": {
@@ -661,7 +661,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -709,7 +709,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -724,10 +724,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/hspace",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -754,10 +754,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "1"
             }
           },
           "status": {
@@ -805,7 +805,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -820,10 +820,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/reportValidity",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "edge": {
               "version_added": "18"
@@ -838,10 +838,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "safari": {
               "version_added": "10"
@@ -850,10 +850,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "39"
             }
           },
           "status": {
@@ -868,10 +868,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/setCustomValidity",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -898,10 +898,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -949,7 +949,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -997,7 +997,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1093,7 +1093,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1108,10 +1108,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/validationMessage",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1138,10 +1138,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1156,10 +1156,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/validity",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1186,10 +1186,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1204,10 +1204,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/vspace",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1234,10 +1234,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1285,7 +1285,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1300,10 +1300,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/willValidate",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1330,10 +1330,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds/corrects the Chromium data (and a little bit of Opera Presto) for the HTMLObjectElement API based upon results from the mdn-bcd-collector project (using results from Chrome 1-86 and Opera 12.14, 15, and 70).  Additionally, I noticed that WebView Android was marked as support since "37"; however, Joe mentioned that anything supported in Chrome 1 is also in WebView for Android 1.

Test used: http://mdn-bcd-collector.appspot.com/tests/api/HTMLObjectElement