### PR TITLE
Upgrade prettier to v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compare-versions": "~3.6.0",
     "mdn-confluence": "~2.2.0",
     "ora": "~4.0.3",
-    "prettier": "~1.19.1",
+    "prettier": "~2.1.2",
     "yargs": "~15.4.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR bumps `prettier` to v2.1.2.  Prettier v2 requires NodeJS v10, and has changed a few defaults for the config (of which we've explicitly set as the v1 defaults in #6110, which will be reverted in the future).

This PR is work towards #7163.