### PR TITLE
Remove notes about document.all being readonly

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -342,8 +342,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "64",
-                "notes": "Starting in Chrome 65, this property is readonly."
+                "version_added": "64"
               },
               {
                 "version_added": "3",
@@ -354,8 +353,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "64",
-                "notes": "Starting in Chrome 65, this property is readonly."
+                "version_added": "64"
               },
               {
                 "version_added": "18",
@@ -378,8 +376,7 @@
             },
             "opera": [
               {
-                "version_added": "51",
-                "notes": "Starting in Opera 52, this property is readonly."
+                "version_added": "51"
               },
               {
                 "version_added": "≤12.1",
@@ -390,8 +387,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "47",
-                "notes": "This property is readonly."
+                "version_added": "47"
               },
               {
                 "version_added": "≤12.1",
@@ -408,8 +404,7 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "9.0",
-                "notes": "This property is readonly."
+                "version_added": "9.0"
               },
               {
                 "version_added": "1.0",
@@ -420,8 +415,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "64",
-                "notes": "Starting in Chrome 65, this property is readonly."
+                "version_added": "64"
               },
               {
                 "version_added": "≤37",


### PR DESCRIPTION
These notes were added in https://github.com/mdn/browser-compat-data/pull/3391,
after the change in https://chromium-review.googlesource.com/c/chromium/src/+/823513/.

Previously it was possible to assign document.all, and now it is not.
The uses of document.all that currently work also work with older
browsers, so there isn't anything that web developers need to be aware
of here. The only time when it might have mattered was at the time of
the change, if someone depending on being able to use document.all to
store their own values, which in itself is an unlikely scenario.