### PR TITLE
Update HTML element API data for IE/Edge using mdn-bcd-collector

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -451,7 +451,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "52"
@@ -547,7 +547,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -595,7 +595,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -691,7 +691,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -739,7 +739,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -787,7 +787,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -451,7 +451,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -499,7 +499,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -547,7 +547,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -643,7 +643,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLBRElement.json
+++ b/api/HTMLBRElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLBaseElement.json
+++ b/api/HTMLBaseElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -202,7 +202,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -261,7 +261,7 @@
               "notes": "In Firefox 56, the implementation has been updated so that the <code>formAction</code> property returns the correct form submission URL, as per spec, when the associated button is being used to submit a form (<a href='https://bugzil.la/1366361'>bug 1366361</a>)."
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -309,7 +309,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -357,7 +357,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -405,7 +405,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -453,7 +453,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -597,7 +597,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -741,7 +741,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -789,7 +789,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -837,7 +837,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -885,7 +885,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -933,7 +933,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -60,7 +60,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "43"

--- a/api/HTMLDListElement.json
+++ b/api/HTMLDListElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLDataElement.json
+++ b/api/HTMLDataElement.json
@@ -11,7 +11,7 @@
             "version_added": "62"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "10"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLDivElement.json
+++ b/api/HTMLDivElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -67,7 +67,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -379,7 +379,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -485,7 +485,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -540,7 +540,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "10.5"
@@ -590,7 +590,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "9"
@@ -739,7 +739,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -787,7 +787,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -878,7 +878,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "79",
@@ -949,7 +949,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -1385,7 +1385,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "77",
@@ -1449,7 +1449,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1809,7 +1809,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2002,7 +2002,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2050,7 +2050,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2098,7 +2098,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2146,7 +2146,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2194,7 +2194,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2242,7 +2242,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2290,7 +2290,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2386,7 +2386,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -3130,7 +3130,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -3178,7 +3178,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -3233,7 +3233,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5.5",
               "partial_implementation": true,
               "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
@@ -3283,7 +3283,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -22,7 +22,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1",

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -403,7 +403,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -451,7 +451,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -20,7 +20,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": null
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -64,7 +64,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -109,7 +109,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -154,7 +154,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -452,7 +452,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -500,7 +500,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -548,7 +548,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -596,7 +596,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -789,7 +789,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -886,7 +886,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -983,7 +983,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -403,7 +403,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -451,7 +451,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -208,7 +208,7 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -255,7 +255,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLHRElement.json
+++ b/api/HTMLHRElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLHeadingElement.json
+++ b/api/HTMLHeadingElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -105,7 +105,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "74"
@@ -152,7 +152,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -333,7 +333,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -372,7 +372,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -593,7 +593,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -641,7 +641,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -689,7 +689,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -737,7 +737,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -785,7 +785,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -833,7 +833,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -932,7 +932,7 @@
               "notes": "Previously, the type of <code>sandbox</code> was a <code>DOMString</code> instead of a <code>DOMSettableTokenList</code>. This has been fixed with Firefox 29. Other browsers may still implement the property as <code>DOMString</code> since it was a late change in the specification."
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true,
@@ -984,7 +984,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1081,7 +1081,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1176,7 +1176,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -161,7 +161,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -209,7 +209,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -257,7 +257,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5.5",
               "notes": "IE reports <code>false</code> for broken images."
             },
             "opera": {
@@ -306,7 +306,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -420,7 +420,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "68"
@@ -465,7 +465,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -569,7 +569,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -617,7 +617,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -665,7 +665,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -762,7 +762,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -855,7 +855,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1170,7 +1170,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1292,7 +1292,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1340,7 +1340,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1388,7 +1388,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -261,7 +261,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -357,7 +357,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -453,7 +453,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -501,7 +501,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -549,7 +549,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -694,7 +694,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -886,7 +886,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -982,7 +982,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1030,7 +1030,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1126,7 +1126,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1319,7 +1319,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "27"
@@ -1450,7 +1450,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1506,7 +1506,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1689,7 +1689,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "50"

--- a/api/HTMLLIElement.json
+++ b/api/HTMLLIElement.json
@@ -22,7 +22,7 @@
             "notes": "Prior to Firefox 10, Gecko incorrectly reflected negative value attributes to 0."
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLLegendElement.json
+++ b/api/HTMLLegendElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "37"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMapElement.json
+++ b/api/HTMLMapElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -256,7 +256,7 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -303,7 +303,7 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -491,7 +491,7 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "10.5"
@@ -128,7 +128,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -229,7 +229,7 @@
               ]
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "24",
@@ -732,7 +732,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -960,7 +960,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "20"
@@ -969,7 +969,7 @@
               "version_added": "15"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -1425,7 +1425,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1727,13 +1727,13 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1757,13 +1757,13 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1835,13 +1835,13 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -2234,7 +2234,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -2245,7 +2245,7 @@
               "version_removed": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -2269,7 +2269,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -2280,7 +2280,7 @@
               "version_removed": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -2983,7 +2983,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -3626,7 +3626,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -20,7 +20,7 @@
             "version_added": "8"
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -17,7 +17,7 @@
             "version_added": "16"
           },
           "ie": {
-            "version_added": "10"
+            "version_added": false
           },
           "opera": {
             "version_added": "11"
@@ -52,7 +52,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -124,7 +124,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -160,7 +160,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -196,7 +196,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -232,7 +232,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -268,7 +268,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"

--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLOListElement.json
+++ b/api/HTMLOListElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -403,7 +403,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -547,7 +547,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -595,7 +595,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -643,7 +643,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -691,7 +691,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -739,7 +739,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -787,7 +787,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -835,7 +835,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "26"
@@ -883,7 +883,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -931,7 +931,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -979,7 +979,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1075,7 +1075,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1123,7 +1123,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1171,7 +1171,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1219,7 +1219,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1267,7 +1267,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1315,7 +1315,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLOptGroupElement.json
+++ b/api/HTMLOptGroupElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -275,7 +275,7 @@
               }
             ],
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -323,7 +323,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -371,7 +371,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -419,7 +419,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "4"

--- a/api/HTMLParagraphElement.json
+++ b/api/HTMLParagraphElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLParamElement.json
+++ b/api/HTMLParamElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLPreElement.json
+++ b/api/HTMLPreElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLProgressElement.json
+++ b/api/HTMLProgressElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLQuoteElement.json
+++ b/api/HTMLQuoteElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": false
@@ -206,16 +206,9 @@
             "firefox_android": {
               "version_added": "4"
             },
-            "ie": [
-              {
-                "version_added": "10"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "10",
-                "notes": "Non-standard implementation"
-              }
-            ],
+            "ie": {
+              "version_added": "5.5"
+            },
             "opera": {
               "version_added": "≤12.1"
             },
@@ -261,7 +254,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true
@@ -308,7 +301,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true
@@ -420,7 +413,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -476,7 +469,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -523,7 +516,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -570,7 +563,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -68,7 +68,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -155,7 +155,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -356,7 +356,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "9"
@@ -452,7 +452,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -500,7 +500,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -596,7 +596,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -644,7 +644,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -692,7 +692,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -741,7 +741,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "<code>namedItem</code> does not appear to take the <code>name</code> attribute into account (only the <code>id</code> attribute) on Internet Explorer and Edge. There is a <a href='https://connect.microsoft.com/IE/feedbackdetail/view/2414092/'>bug report</a> to Microsoft about this."
             },
             "opera": {
@@ -790,7 +790,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -838,7 +838,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -934,7 +934,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -982,7 +982,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1078,7 +1078,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1126,7 +1126,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1222,7 +1222,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1270,7 +1270,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1318,7 +1318,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1366,7 +1366,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLSpanElement.json
+++ b/api/HTMLSpanElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": true

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -249,7 +249,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -297,7 +297,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableCaptionElement.json
+++ b/api/HTMLTableCaptionElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableCellElement.json
+++ b/api/HTMLTableCellElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -403,7 +403,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -451,7 +451,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -547,7 +547,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -595,7 +595,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -643,7 +643,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -691,7 +691,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -739,7 +739,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableColElement.json
+++ b/api/HTMLTableColElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -400,7 +400,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -445,7 +445,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -493,7 +493,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -541,7 +541,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -589,7 +589,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -637,7 +637,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -685,7 +685,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -733,7 +733,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -831,7 +831,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -879,7 +879,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1011,7 +1011,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1059,7 +1059,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1107,7 +1107,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1155,7 +1155,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1203,7 +1203,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -547,7 +547,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -595,7 +595,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -106,7 +106,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -11,7 +11,7 @@
             "version_added": "62"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLTitleElement.json
+++ b/api/HTMLTitleElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -48,7 +48,7 @@
             }
           ],
           "ie": {
-            "version_added": false
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "12"
@@ -170,7 +170,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -244,7 +244,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -318,7 +318,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -392,7 +392,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "12"
@@ -468,7 +468,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -542,7 +542,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -616,7 +616,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"

--- a/api/HTMLUListElement.json
+++ b/api/HTMLUListElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLUnknownElement.json
+++ b/api/HTMLUnknownElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -513,7 +513,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR updates the data for the HTML element APIs for Internet Explorer and Microsoft Edge using the mdn-bcd-collector project (using results from IE 5.5 to 11, and Edge 13 to 85), aided with some manual adjustments.  Because there is no real way to differentiate whether an element is initialized using the HTMLElement API or its own API until IE 9, the version numbers for the APIs themselves are guesstimated based upon the values from the subfeatures (or when not possible, when the elements themselves were supported).  Additionally, this removes a little useless and inaccurate data on `api.HTMLScriptElement.defer` where it was marked as non-standard implementation since IE 4 -- the HTMLElement API wasn't supported until IE 5.5, and having a note that just reads "Non-standard implementation" is simply unhelpful.