### PR TITLE
Update Chrome/Opera data for SVG element APIs using mdn-bcd-collector

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -69,10 +69,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null

--- a/api/SVGAnimateMotionElement.json
+++ b/api/SVGAnimateMotionElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimateMotionElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "19"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "10"
@@ -35,10 +35,10 @@
             "version_added": "9"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGComponentTransferFunctionElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -315,10 +315,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -629,10 +629,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEBlendElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/in1",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/type",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/values",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -166,10 +166,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEComponentTransferElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFECompositeElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEConvolveMatrixElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "6"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDiffuseLightingElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDisplacementMapElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDistantLightElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEFloodElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEFuncAElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEFuncBElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEFuncGElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEFuncRElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEGaussianBlurElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEImageElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEMergeElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEMergeNodeElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEMorphologyElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEOffsetElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEPointLightElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFESpecularLightingElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFESpotLightElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFETileElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFETurbulenceElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFilterElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement",
         "support": {
           "chrome": {
-            "version_added": "30"
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": "30"
+            "version_added": true
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "18"
+            "version_added": true
           },
           "opera_android": {
-            "version_added": "18"
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": true
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": true
           }
         },
         "status": {
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "18"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -89,10 +89,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": true
             }
           },
           "status": {
@@ -106,10 +106,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "18"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -136,10 +136,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": true
             }
           },
           "status": {
@@ -153,10 +153,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "18"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -183,10 +183,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": true
             }
           },
           "status": {
@@ -200,10 +200,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -230,10 +230,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "18"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -89,10 +89,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -106,10 +106,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -136,10 +136,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -183,10 +183,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -200,10 +200,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "15"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": true
@@ -230,10 +230,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -119,10 +119,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": null
@@ -167,10 +167,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": null

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMPathElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "19"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -952,10 +952,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -970,10 +970,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -982,10 +982,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1211,11 +1211,11 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "safari": {
               "version_added": null
@@ -1267,11 +1267,11 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "safari": {
               "version_added": null
@@ -1323,11 +1323,11 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "safari": {
               "version_added": null
@@ -1379,11 +1379,11 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "33"
+              "version_removed": "34"
             },
             "safari": {
               "version_added": null

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -427,10 +427,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -445,10 +445,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -457,10 +457,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -521,10 +521,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -539,10 +539,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -551,10 +551,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -427,10 +427,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -445,10 +445,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": true
@@ -457,10 +457,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -521,10 +521,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -539,10 +539,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": true
@@ -551,10 +551,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -51,10 +51,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "36"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "36"
             },
             "edge": {
               "version_added": "12",
@@ -70,10 +72,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "23"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "24"
             },
             "safari": {
               "version_added": null
@@ -82,10 +86,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -146,10 +152,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "37"
             },
             "edge": {
               "version_added": "12",
@@ -165,10 +173,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "24"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "24"
             },
             "safari": {
               "version_added": null
@@ -177,10 +187,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets results (from true/null to a real value) for Chrome and Opera for various SVG element APIs based upon results from the mdn-bcd-collector project, followed by mirroring to Chrome Android, Opera Android, Samsung Internet, and WebView.  Data comes from the results from Chrome 1-85, as well as Opera 12.14, 15, and 70, on both macOS and Windows.

Notes:
- There are several results that change WebView from `false` to `1` (and one entry from `3` to `1`).  This is because anything that is in Chrome 1 is _guaranteed_ to be in WebView for Android 1 (as stated by Joe Medley).