### PR TITLE
Remove redundant Safari note from api.Location.origin

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -367,8 +367,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true,
-              "notes": "According to <a href='https://developer.apple.com/documentation/webkitjs/location/1631059-origin'>Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
+              "version_added": true
             },
             "safari_ios": {
               "version_added": "5"


### PR DESCRIPTION
This PR removes a redundant note from `api.Location.origin` from Safari.  The note talks about how https://developer.apple.com/documentation/webkitjs does not have an accurate version number, so the real version cannot be determined reliably.  However, **https://developer.apple.com/documentation/webkitjs is known bad resource as documented on the [Matching web features to browser release version numbers](https://developer.mozilla.org/docs/MDN/Contribute/Processes/Matching_features_to_browser_version) page.**  Furthermore, especially with the mdn-bcd-collector project, we have other ways than reading documentation to obtain the version number.