### PR TITLE
Update Safari data for Location API

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -367,8 +367,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "5.1",
-              "notes": "According to <a href='https://developer.apple.com/documentation/webkitjs/location/1631059-origin'>Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/Location.json
+++ b/api/Location.json
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -316,10 +316,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -367,7 +367,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true,
+              "version_added": "5.1",
               "notes": "According to <a href='https://developer.apple.com/documentation/webkitjs/location/1631059-origin'>Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
             },
             "safari_ios": {
@@ -469,10 +469,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -517,10 +517,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -565,10 +565,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -713,10 +713,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates the Safari data for the Location API using a combination of results from the mdn-bcd-collector project and manual testing.

Furthermore, this PR removes a redundant note from `api.Location.origin` from Safari.  The note talks about how https://developer.apple.com/documentation/webkitjs does not have an accurate version number, so the real version cannot be determined reliably.  However, **https://developer.apple.com/documentation/webkitjs is known bad resource as documented on the [Matching web features to browser release version numbers](https://developer.mozilla.org/docs/MDN/Contribute/Processes/Matching_features_to_browser_version) page.**  Furthermore, especially with the mdn-bcd-collector project, we have other ways than reading documentation to obtain the version number.
