### PR TITLE
Update Firefox data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6894,15 +6894,9 @@
                 "prefix": "moz"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": true,
-                "prefix": "moz"
-              }
-            ],
+            "firefox_android": {
+              "version_added": true
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -1176,10 +1176,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"
@@ -1224,10 +1224,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -3647,10 +3647,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "23"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "23"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"
@@ -3743,10 +3743,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -3791,10 +3791,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -3839,11 +3839,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Firefox 13, <code>null</code> is always returned instead of the empty string, as per the DOM4 specification. Previously, there were cases in which an empty string could be returned."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "notes": "Starting in Firefox 13, <code>null</code> is always returned instead of the empty string, as per the DOM4 specification. Previously, there were cases in which an empty string could be returned."
             },
             "ie": {
               "version_added": true
@@ -4339,18 +4340,15 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": [
                 "The behavior of <code>element.getElementsByTagNameNS</code> changed between Firefox 3.5 and Firefox 3.6. In Firefox 3.5 and before, this function would automatically case-fold any queries so that a search for \"foo\" would match \"Foo\" or \"foo\". In Firefox 3.6 and later this function is now case-sensitive so that a query for \"foo\" will only match \"foo\" and not \"Foo\". For more background on this, please see the <a href='https://bugzil.la/542185#c5'>comment from Henri Sivonen about the change</a>. You can also look at the <a href='https://developer.mozilla.org/docs/Case_Sensitivity_in_class_and_id_Names'>relevant part of the standard, which states which parts of the API are case-sensitive and which parts aren't.</a>",
                 "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflects the spec change."
               ]
             },
             "firefox_android": {
-              "version_added": true,
-              "notes": [
-                "The behavior of <code>element.getElementsByTagNameNS</code> changed between Firefox 3.5 and Firefox 3.6. In Firefox 3.5 and before, this function would automatically case-fold any queries so that a search for \"foo\" would match \"Foo\" or \"foo\". In Firefox 3.6 and later this function is now case-sensitive so that a query for \"foo\" will only match \"foo\" and not \"Foo\". For more background on this, please see the <a href='https://bugzil.la/542185#c5'>comment from Henri Sivonen about the change</a>. You can also look at the <a href='https://developer.mozilla.org/docs/Case_Sensitivity_in_class_and_id_Names'>relevant part of the standard, which states which parts of the API are case-sensitive and which parts aren't.</a>",
-                "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflects the spec change."
-              ]
+              "version_added": "4",
+              "notes": "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflects the spec change."
             },
             "ie": {
               "version_added": "5.5"
@@ -4399,11 +4397,7 @@
                 "version_added": true
               },
               "firefox_android": {
-                "version_added": true,
-                "notes": [
-                  "The behavior of <code>element.getElementsByTagNameNS</code> changed between Firefox 3.5 and Firefox 3.6. In Firefox 3.5 and before, this function would automatically case-fold any queries so that a search for \"foo\" would match \"Foo\" or \"foo\". In Firefox 3.6 and later this function is now case-sensitive so that a query for \"foo\" will only match \"foo\" and not \"Foo\". For more background on this, please see the <a href='https://bugzil.la/542185#c5'>comment from Henri Sivonen about the change</a>. You can also look at the <a href='https://developer.mozilla.org/docs/Case_Sensitivity_in_class_and_id_Names'>relevant part of the standard, which states which parts of the API are case-sensitive and which parts aren't.</a>",
-                  "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflects the spec change."
-                ]
+                "version_added": true
               },
               "ie": {
                 "version_added": "6"
@@ -4497,10 +4491,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -4545,11 +4539,12 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": true,
-              "notes": "[1] Before Firefox 35, it was implemented on the <code>Node</code> interface."
+              "version_added": "1",
+              "notes": "Before Firefox 35, it was implemented on the <code>Node</code> interface."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "notes": "Before Firefox 35, it was implemented on the <code>Node</code> interface."
             },
             "ie": {
               "version_added": "9"
@@ -4666,10 +4661,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -5734,7 +5729,8 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "48",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "ie": {
               "version_added": null
@@ -6092,18 +6088,23 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "71",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shadow-parts.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.shadow-parts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -6534,10 +6535,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -6582,10 +6583,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -6893,9 +6894,15 @@
                 "prefix": "moz"
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": true,
+                "prefix": "moz"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -7777,10 +7784,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5",
@@ -7924,10 +7931,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -7973,10 +7980,10 @@
               "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true,
@@ -8022,10 +8029,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -8071,10 +8078,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5",
@@ -8369,10 +8376,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and/or corrects the Firefox data for the Element API based upon results from the mdn-bcd-collector project (using results from Firefox 1-82). The updates include mirroring of data and notes to Firefox Android, as well as updating a few notes for accuracy.
