### PR TITLE
Update IE and EdgeHTML data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1690,7 +1690,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -1844,7 +1844,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -1892,7 +1892,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -1940,7 +1940,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -1988,7 +1988,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -2562,7 +2562,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -3653,7 +3653,7 @@
               "version_added": "23"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -3749,7 +3749,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -3797,7 +3797,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -3846,7 +3846,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -4133,7 +4133,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "9.5"
@@ -4353,7 +4353,7 @@
               ]
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -4406,7 +4406,7 @@
                 ]
               },
               "ie": {
-                "version_added": "6"
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -4503,7 +4503,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -4542,7 +4542,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true,
@@ -4552,7 +4552,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -4672,7 +4672,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -4779,7 +4779,7 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5",
               "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
             },
             "opera": {
@@ -4894,7 +4894,7 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "5",
               "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
             },
             "opera": {
@@ -5089,7 +5089,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "17"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48",
@@ -5737,7 +5737,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -5791,7 +5791,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -5871,7 +5871,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -6254,7 +6254,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -6492,7 +6492,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -6540,7 +6540,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -6588,7 +6588,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -6957,7 +6957,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -7322,7 +7322,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5",
               "notes": [
                 "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function.",
                 "No support for <code>smooth</code> behavior or <code>center</code> options."
@@ -7493,7 +7493,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5",
               "notes": "For right-to-left elements, this property uses 100-0 (most left to most right) instead of negative values."
             },
             "opera": {
@@ -7687,7 +7687,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -7930,7 +7930,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -7979,7 +7979,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true,
+              "version_added": "9",
               "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
             },
             "opera": {
@@ -8028,7 +8028,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -8423,7 +8423,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"

--- a/api/Element.json
+++ b/api/Element.json
@@ -5727,7 +5727,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "17"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "48",


### PR DESCRIPTION
This PR updates and/or corrects the Internet Explorer and EdgeHTML data for the Element API based upon results from the mdn-bcd-collector project (using results from IE 5.5 to 11 with manual testing in IE 5, and Edge 13-79).
