### PR TITLE
Update Safari data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1191,10 +1191,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -1239,10 +1239,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -1699,10 +1699,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1853,10 +1853,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1901,10 +1901,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1949,10 +1949,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1997,10 +1997,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3758,10 +3758,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3806,10 +3806,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3855,10 +3855,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4252,11 +4252,11 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6",
+              "version_added": "1.3",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari_ios": {
-              "version_added": "6",
+              "version_added": "1",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "samsunginternet_android": {
@@ -4363,11 +4363,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6",
+              "version_added": "1.3",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4464,10 +4465,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -4512,10 +4513,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4561,10 +4562,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4681,10 +4682,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -4731,10 +4732,12 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "samsunginternet_android": {
               "version_added": "2.0",
@@ -5112,7 +5115,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "2.0",
@@ -5750,7 +5753,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "2.0",
@@ -5823,10 +5826,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -5903,10 +5906,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -6266,7 +6269,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "2.0",
@@ -6549,10 +6552,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6597,10 +6600,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6905,12 +6908,24 @@
             "opera_android": {
               "version_added": true
             },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "10.3"
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": true
@@ -7014,10 +7029,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -7159,10 +7174,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -7272,10 +7287,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -7335,11 +7350,11 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "6",
+              "version_added": "3",
               "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "safari_ios": {
-              "version_added": "5",
+              "version_added": "1",
               "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "samsunginternet_android": {
@@ -7503,10 +7518,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -7600,10 +7615,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -7696,10 +7711,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -7793,10 +7808,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -7939,10 +7954,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7989,10 +8004,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8037,10 +8052,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8087,10 +8102,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -8242,7 +8257,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -8339,7 +8354,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -8384,10 +8399,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -8432,10 +8447,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR updates and/or corrects the Safari data for the Element API based upon results from the mdn-bcd-collector project (using results from IE 5.5 to 11 with manual testing in Safari 3 and 6 to 14, with manual testing in Safari 1.3 and 2.0). The updates include mirroring of data and notes to Safari iOS, as well as updating a few notes for accuracy.
