### PR TITLE
Update Opera Presto data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2565,10 +2565,12 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": false
@@ -3752,10 +3754,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -3800,10 +3802,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -3849,10 +3851,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -4356,11 +4358,12 @@
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari": {
               "version_added": "6",
@@ -4506,10 +4509,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -4555,10 +4558,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -4675,10 +4678,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -4898,10 +4901,10 @@
               "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -5103,10 +5106,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "10"
@@ -5740,11 +5743,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "safari": {
               "version_added": "10"
@@ -6257,10 +6261,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "10"
@@ -6543,10 +6547,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -6591,10 +6595,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -7787,10 +7791,10 @@
               "notes": "In Internet Explorer 5 through 7, if padding is set, the value of <code>scrollWidth</code> is equal to the sum of the left and right padding. This behavior was fixed in Internet Explorer 8."
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -7933,10 +7937,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -7983,10 +7987,10 @@
               "notes": "Returns a <code>ClientRectList</code> with <a href='http://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a> objects (which do not contain <code>x</code> and <code>y</code> properties) instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMRect'><code>DOMRect</code></a> objects."
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -8031,10 +8035,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"


### PR DESCRIPTION
This PR updates and/or corrects the Opera Presto data for the Element API based upon results from the mdn-bcd-collector project (using results from Opera 12.14 and 15).  Updates to Blink-based versions of Opera is defered to the Chrome-updating PR.
