### PR TITLE
Fix release statuses for NodeJS

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -223,7 +223,7 @@
         "12.11.0": {
           "release_date": "2019-09-25",
           "release_notes": "https://nodejs.org/en/blog/release/v12.11.0/",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.7"
         },
@@ -244,7 +244,7 @@
         "13.2.0": {
           "release_date": "2019-11-21",
           "release_notes": "https://nodejs.org/en/blog/release/v13.2.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.9"
         },
@@ -258,7 +258,7 @@
         "14.6.0": {
           "release_date": "2020-07-21",
           "release_notes": "https://nodejs.org/en/blog/release/v14.6.0/",
-          "status": "retired",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "8.4"
         },


### PR DESCRIPTION
This PR updates the release status information for the NodeJS releases based upon the calendar on https://nodejs.org/en/about/releases/ by doing the following:
- Marks the older of two v12 versions labeled ESR as "retired"
- Marks v13 as "retired" (previously "current")
- Marks v14 as "esr" (previously "retired")
