### PR TITLE
Some Document API features were only in HTMLDocument on Safari

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -301,12 +301,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1.2"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1.2",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -400,12 +416,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0",
@@ -820,12 +852,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -966,12 +1014,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -1378,12 +1442,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -3110,12 +3190,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "10.3"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.3",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -3950,12 +4046,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "2"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "2",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "10.3"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.3",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -4908,12 +5020,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -6944,12 +7072,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -8149,12 +8293,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -8398,12 +8558,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "3",
+                "version_removed": "10.1",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "10.3"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "10.3",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -10101,12 +10277,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -11593,12 +11785,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"
@@ -11885,12 +12093,28 @@
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
               }
             ],
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "11",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLDocument'><code>HTMLDocument</code></a>, not all <code>Document</code> objects."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "9.0"


### PR DESCRIPTION
Various features for the Document API were only supported on HTML documents in older versions of Chrome and Safari, however this was only documented for Chrome.  This PR fixes this by copying the notes over to Safari.  Version numbers for when non-HTML document support were determined via manual testing, running `document.XXX` (`XXX` being the name of the feature) in the JS console while viewing https://www.w3schools.com/xml/note.xml.