### PR TITLE
Update Firefox data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2231,11 +2231,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "version_removed": "6"
+              "version_removed": "7"
             },
             "firefox_android": {
               "version_added": "4",
-              "version_removed": "6"
+              "version_removed": "7"
             },
             "ie": {
               "version_added": false
@@ -2905,7 +2905,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -3550,10 +3550,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "6"
             },
             "ie": {
               "version_added": false
@@ -7394,10 +7396,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "8",
+              "version_removed": "23"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "8",
+              "version_removed": "23"
             },
             "ie": {
               "version_added": false
@@ -7442,10 +7446,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "7"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "7"
             },
             "ie": {
               "version_added": false
@@ -7490,10 +7496,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -7538,10 +7544,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -9527,7 +9533,7 @@
                 "version_added": "41"
               },
               {
-                "version_added": "9",
+                "version_added": "1",
                 "version_removed": "41",
                 "notes": "<code>queryCommandEnabled</code> with arguments <code>cut</code>, <code>copy</code> or <code>paste</code> would throw errors unless the script had special privileges."
               }
@@ -9537,7 +9543,7 @@
                 "version_added": "41"
               },
               {
-                "version_added": "9",
+                "version_added": "4",
                 "version_removed": "41",
                 "notes": "<code>queryCommandEnabled</code> with arguments <code>cut</code>, <code>copy</code> or <code>paste</code> would throw errors unless the script had special privileges."
               }
@@ -9685,7 +9691,7 @@
                 "version_added": "41"
               },
               {
-                "version_added": "9",
+                "version_added": "1",
                 "version_removed": "41",
                 "notes": "<code>paste</code> argument incorrectly returned <code>true</code> when the paste feature was available but the calling script had insufficient privileges to actually perform the action."
               }
@@ -9695,7 +9701,7 @@
                 "version_added": "41"
               },
               {
-                "version_added": "9",
+                "version_added": "4",
                 "version_removed": "41",
                 "notes": "<code>paste</code> argument incorrectly returned <code>true</code> when the paste feature was available but the calling script had insufficient privileges to actually perform the action."
               }
@@ -10398,10 +10404,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "25"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "25"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and/or corrects the Firefox data for the Element API based upon results from the mdn-bcd-collector project (using results from Firefox 1-82). The updates include mirroring of data and notes to Firefox Android, as well as updating a few notes for accuracy.
