### PR TITLE
Update IE data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -926,7 +926,7 @@
               "notes": "The <code>body</code> property was implemented on the <code>HTMLDocument</code> interface in Firefox for a long time, hence <code>document.body</code> would not return the <code>&lt;body&gt;</code> element if the document's <code>Content-Type</code> was not set to <code>text/html</code> or <code>application/xhtml+xml</code> (or if it came from <code>DOMParser.parseFromString</code> without the <code>text/html</code> type being used). This has been fixed in Firefox 60."
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "9.6"
@@ -1974,7 +1974,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -5092,7 +5092,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true,
+              "version_added": "5.5",
               "version_removed": "11"
             },
             "opera": {
@@ -6306,7 +6306,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "15"
@@ -9957,7 +9957,7 @@
                 "notes": "Internet Explorer 9 and 10 have bugs where the 'interactive' state can be fired too early before the document has finished parsing."
               },
               {
-                "version_added": "8",
+                "version_added": "4",
                 "version_removed": "9",
                 "partial_implementation": true,
                 "notes": "Only supports 'complete'."


### PR DESCRIPTION
This PR updates and/or corrects the Internet Explorer data for the Element API based upon results from the mdn-bcd-collector project (using results from IE 5.5 to 11 with manual testing in IE 4 and 5).
