### PR TITLE
Update Safari data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -222,10 +222,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -935,10 +935,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2492,10 +2492,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2917,10 +2917,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -4175,10 +4175,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and/or corrects the Safari data for the Element API based upon results from the mdn-bcd-collector project (using results from Safari 3 and 6 to 14, with manual testing in Safari 1.3 and 2.0). The updates include mirroring of data and notes to Safari iOS, as well as updating a few notes for accuracy.

