### PR TITLE
Update data for document.createTouch

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2615,7 +2615,9 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "25",
+              "version_removed": "68",
+              "notes": "Since Chrome 55, all parameters are optional."
             },
             "edge": {
               "version_added": false
@@ -2634,7 +2636,9 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14",
+              "version_removed": "48",
+              "notes": "Since Opera Android 42, all parameters are optional."
             },
             "safari": {
               "version_added": false
@@ -2643,10 +2647,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.5",
+              "version_removed": "10.0",
+              "notes": "Since Samsung Internet 6.0, all parameters are optional."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37",
+              "version_removed": "68",
+              "notes": "Since WebView 55, all parameters are optional."
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -2611,29 +2611,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createTouch",
           "support": {
-            "chrome": [
-              {
-                "version_added": "22",
-                "version_removed": "66"
-              },
-              {
-                "version_added": "59",
-                "notes": "All parameters optional"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25",
-                "version_removed": "66"
-              },
-              {
-                "version_added": "59",
-                "notes": "All parameters optional"
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "79",
-              "notes": "All parameters optional"
+              "version_added": false
             },
             "firefox": {
               "version_added": "18",
@@ -2646,12 +2631,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "version_removed": "53"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": true,
-              "version_removed": "47"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -2659,26 +2642,12 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5",
-                "version_removed": "9.0"
-              },
-              {
-                "version_added": "7.0",
-                "notes": "All parameters optional"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true,
-                "version_removed": "66"
-              },
-              {
-                "version_added": "59",
-                "notes": "All parameters optional"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates the data for `document.createTouch` based upon results from the mdn-bcd-collector project and some manual testing.  After review, it appears that Chrome never actually supported this method in either desktop or mobile.