### PR TITLE
Update Safari support for `focus({preventScroll})`

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1005,7 +1005,7 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": null

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1008,7 +1008,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "9.0"


### PR DESCRIPTION
I just tested the embedded example on https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus and Safari (`v14`) doesn't support `focus({preventScroll: true})`. I updated the compatibility table to reflect that. :)

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [X] Link to related issues or pull requests, if any
