### PR TITLE
Mark DeviceMotionEventAcceleration and DeviceMotionEventRotationRate unsupported in Safari

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -37,10 +37,14 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "5.1",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "5",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "samsunginternet_android": [
             {
@@ -98,10 +102,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -147,10 +155,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -196,10 +208,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -245,10 +261,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -37,10 +37,14 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "5.1",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "5",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
           },
           "samsunginternet_android": [
             {
@@ -99,10 +103,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -148,10 +156,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -197,10 +209,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -245,10 +261,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This change marks the `DeviceMotionEventAcceleration` and `DeviceMotionEventRotationRate` interfaces unsupported in Safari and iOS Safari. Test: https://wpt.live/orientation-event/idlharness.https.window.html