### PR TITLE
Mark SubmitEvent unsupported in Safari

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "13.0"
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -128,10 +128,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
This change marks the `SubmitEvent` interface unsupported in Safari and iOS Safari. Tests:

* https://wpt.live/html/semantics/forms/form-submission-0/SubmitEvent.window.html
* https://wpt.live/html/dom/idlharness.https.html