### PR TITLE
Mark FontFaceSetLoadEvent unsupported in Safari

### DIFF
--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -29,10 +29,10 @@
             "version_added": "22"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -77,10 +77,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -125,10 +125,10 @@
               "version_added": "22"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This change marks the `FontFaceSetLoadEvent` interface unsupported in Safari and iOS Safari.
Test: https://wpt.live/css/css-font-loading/idlharness.https.html