### PR TITLE
Mark Web Locks features unsupported in Safari

### DIFF
--- a/api/Lock.json
+++ b/api/Lock.json
@@ -29,10 +29,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -76,10 +76,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -124,10 +124,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -29,10 +29,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -76,10 +76,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -124,10 +124,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This change marks the `Lock` interface and `LockManager` interface as unsupported in Safari and iOS Safari.
Test: https://wpt.live/web-locks/idlharness.tentative.https.any.html