### PR TITLE
Mark Device-Memory CH header unsupported in Safari

### DIFF
--- a/http/headers/device-memory.json
+++ b/http/headers/device-memory.json
@@ -30,10 +30,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This change marks the `Device-Memory` HTTP Client Hint request header unsupported in Safari and iOS Safari. (Confirmed by manual testing and code inspection.)