### PR TITLE
Mark Save-Data CH header unsupported in Safari

### DIFF
--- a/http/headers/save-data.json
+++ b/http/headers/save-data.json
@@ -30,10 +30,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This change marks the `Save-Data` Client Hints HTTP request header unsupported in Safari and iOS Safari. (Determined through code inspection.)