### PR TITLE
Eliminate remaining null values from css subtree (by dropping null-value browsers from CSS gap properties)

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -31,9 +31,6 @@
               "opera_android": {
                 "version_added": false
               },
-              "qq_android": {
-                "version_added": null
-              },
               "safari": {
                 "version_added": false
               },
@@ -195,9 +192,6 @@
                   ]
                 }
               ],
-              "qq_android": {
-                "version_added": null
-              },
               "safari": [
                 {
                   "version_added": "12.1"
@@ -225,12 +219,6 @@
                   "version_added": "6.0"
                 }
               ],
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
-              },
               "webview_android": [
                 {
                   "version_added": "66"
@@ -329,9 +317,6 @@
                   "version_removed": "14"
                 }
               ],
-              "qq_android": {
-                "version_added": null
-              },
               "safari": [
                 {
                   "version_added": "10"
@@ -359,12 +344,6 @@
                   "version_added": "1.0"
                 }
               ],
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
-              },
               "webview_android": [
                 {
                   "version_added": "50"

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -31,9 +31,6 @@
               "opera_android": {
                 "version_added": false
               },
-              "qq_android": {
-                "version_added": null
-              },
               "safari": {
                 "version_added": false
               },
@@ -42,12 +39,6 @@
               },
               "samsunginternet_android": {
                 "version_added": false
-              },
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
               },
               "webview_android": {
                 "version_added": "84"
@@ -195,9 +186,6 @@
                   ]
                 }
               ],
-              "qq_android": {
-                "version_added": null
-              },
               "safari": [
                 {
                   "version_added": "10.1",
@@ -225,12 +213,6 @@
                   "version_added": "7.0"
                 }
               ],
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
-              },
               "webview_android": [
                 {
                   "version_added": "66"
@@ -391,9 +373,6 @@
               "opera_android": {
                 "version_added": "47"
               },
-              "qq_android": {
-                "version_added": null
-              },
               "safari": {
                 "version_added": false
               },
@@ -402,12 +381,6 @@
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
-              },
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
               },
               "webview_android": {
                 "version_added": "66"

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -194,9 +194,6 @@
                   ]
                 }
               ],
-              "qq_android": {
-                "version_added": null
-              },
               "safari": [
                 {
                   "version_added": "12.1"
@@ -224,12 +221,6 @@
                   "version_added": "6.0"
                 }
               ],
-              "uc_android": {
-                "version_added": null
-              },
-              "uc_chinese_android": {
-                "version_added": null
-              },
               "webview_android": [
                 {
                   "version_added": "66"


### PR DESCRIPTION
This change drops all the remaining null-value entries from the data in the css tree — which were in the data for the `gap`, `column-gap`, and `row-gap` properties. (Those remaining values were for the `qq_android`, `uc_android`, and `uc_chinese_android` browsers — which we don’t record on for most other CSS properties anyway.)

With this change, the css tree has no remaining entries with null values.