### PR TITLE
Drop reference to wpt.fyi results for api.Animation.commitStyles

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -277,9 +277,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "13.4",
-              "partial_implementation": true,
-              "notes": "Passes 13/27 <a href='https://wpt.fyi/results/web-animations/interfaces/Animation/commitStyles.html?label=master&label=stable&product=safari'>web platform tests</a>."
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
The test results are for Safari on macOS. But more importantly, the
existence of failing tests doesn't in itself indicate that there's a
problem that matters to web developers. To make that claim, we would
have to understand what's causing the failures, and whether the thing
they're testing is something that's likely to matter.

This came from https://github.com/mdn/browser-compat-data/pull/5963.