### PR TITLE
Correct Chrome data for api.HTMLElement.spellcheck

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3121,10 +3121,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "9"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3151,10 +3151,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
Cherry-picked from #7179.  This PR updates the Chromium data for the `spellcheck` feature of the `HTMLElement` API based upon results from the mdn-bcd-collector project.  The original data that had marked this as `43` came from [Confluence](http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Chrome_42.0.2311.135_OSX_10.11.6%22,%22Chrome_42.0.2311.135_Windows_10.0%22,%22Chrome_43.0.2357.65_OSX_10.11.6%22,%22Chrome_43.0.2357.81_Windows_10.0%22%5D&q=%22spellcheck%22), however a quick test revealed that the feature was supported in every HTML element, _including_ unknown elements (which would inherit `HTMLElement` and not have any custom properties).

Test code used:

```js
var tags = ['a', 'area', 'audio', 'base', 'basefont', 'body', 'br', 'button', 'canvas', 'content', 'data', 'datalist', 'details', 'dialog', 'div', 'dl', 'embed', 'fieldset', 'font', 'form', 'frame', 'frameset', 'head', 'h1', 'hr', 'html', 'iframe', 'img', 'input', 'isindex', 'keygen', 'label', 'legend', 'li', 'link', 'map', 'marquee', 'menu', 'menuitem', 'meta', 'meter', 'del', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'blockquote', 'script', 'select', 'shadow', 'slot', 'source', 'span', 'style', 'caption', 'td', 'col', 'table', 'tr', 'tbody', 'template', 'textarea', 'time', 'title', 'track', 'ul', 'unknown', 'video', 'foo'];

var result = "";

for (var i = 0; i < tags.length; i++) {
	var tag = tags[i];

	var el = document.createElement(tag);
	var sc = el.spellcheck;

	if (!sc) {
		sc = "<span style='color: red;'>FALSE</span>";
	}

	result += tag + ": " + sc + "<br />";
}

var r = document.createElement('p');
r.innerHTML = result;
document.body.appendChild(r);
```