### PR TITLE
Correct Chrome data for HTML*Element.referrerPolicy

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/referrerPolicy",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -406,7 +406,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "40"
             },
             "opera_android": {
               "version_added": "41"
@@ -421,7 +421,7 @@
               "version_added": "7.2"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "53"
             }
           },
           "status": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -406,7 +406,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "40"
             },
             "opera_android": {
               "version_added": "41"
@@ -421,7 +421,7 @@
               "version_added": "7.2"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "53"
             }
           },
           "status": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -866,10 +866,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/referrerPolicy",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -896,10 +896,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "53"
             }
           },
           "status": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1039,10 +1039,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/referrerPolicy",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -1057,7 +1057,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "40"
             },
             "opera_android": {
               "version_added": "41"
@@ -1069,10 +1069,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "53"
             }
           },
           "status": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/referrerPolicy",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "58"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "58"
             },
             "edge": {
               "version_added": "79"
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11.1"
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": "58"
             }
           },
           "status": {


### PR DESCRIPTION
This PR corrects the Chrome data for the `referrerPolicy` property of various HTML elements using results from the mdn-bcd-collector project.  As it turns out, the property was actually implemented in Chrome 53 (or later in some cases).  The original data has all come from the wiki tables.