### PR TITLE
Update clipboard event data

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1658,10 +1658,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/copy_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -1676,10 +1676,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -1688,10 +1688,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2942,10 +2942,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/cut_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -2960,10 +2960,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -2972,10 +2972,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -8408,10 +8408,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/paste_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8426,10 +8426,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -8438,10 +8438,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2314,10 +2314,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/copy_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -2332,10 +2332,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -2344,10 +2344,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2596,10 +2596,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/cut_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -2614,10 +2614,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -2626,10 +2626,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -6143,10 +6143,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/paste_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6161,10 +6161,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5"
@@ -6173,10 +6173,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2233,10 +2233,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/oncopy",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2263,10 +2263,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2281,10 +2281,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/oncut",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2311,10 +2311,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2377,10 +2377,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/onpaste",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2407,10 +2407,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1465,10 +1465,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/copy_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -1483,10 +1483,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -1495,10 +1495,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1716,10 +1716,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cut_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -1734,10 +1734,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -1746,10 +1746,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {
@@ -6386,10 +6386,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/paste_event",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6404,10 +6404,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -6416,10 +6416,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the Chromium data for the `oncopy`, `oncut`, and `onpaste` events based upon data from the mdn-bcd-collector project.  The original data came from [Confluence](http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Chrome_70.0.3538.67_OSX_10.13.6%22,%22Chrome_70.0.3538.67_Windows_10.0%22,%22Chrome_71.0.3578.80_OSX_10.14.0%22,%22Chrome_71.0.3578.80_Windows_10.0%22%5D&q=%22oncopy%22).  What had happened is that these event handlers were initially implemented on the `Element` API, and then moved down to just the `HTMLElement` API in Chrome 71.

Edit: the copy/cut/paste events in the `Element`, `Document`, and `Window` APIs also had been set to Chrome 71.  This PR corrects the data for it based upon manual testing.