### PR TITLE
Correct Chrome data for HTMLIFrameElement API

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/align",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -270,10 +270,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/contentDocument",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -300,10 +300,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -578,10 +578,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/frameBorder",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -608,10 +608,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -626,10 +626,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/height",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -656,10 +656,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -674,10 +674,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/longDesc",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -704,10 +704,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -722,10 +722,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/marginHeight",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -752,10 +752,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -770,10 +770,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/marginWidth",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -800,10 +800,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -818,10 +818,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/name",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -848,10 +848,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -913,7 +913,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43",
+              "version_added": "5",
               "notes": "Before Chrome 50, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "chrome_android": {
@@ -969,10 +969,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/scrolling",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -999,10 +999,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1066,10 +1066,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/src",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1096,10 +1096,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1113,10 +1113,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -1143,10 +1143,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1161,10 +1161,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/width",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1191,10 +1191,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR corrects the Chrome data for the HTML `<iframe>` element API based upon results from the mdn-bcd-collector project (using results from Chrome 1-86 and Opera 12.14, 15, and 70).  Most of the data was set to "Chrome 43"; however, from my testing, I've found that Chrome 43 was a magic number of when all properties are initialized on the object prototype. (Thus, it's best not to trust results that indicate Chrome 43 as much.)