### PR TITLE
Add HTTP headers for accept-patch and accept-post

### DIFF
--- a/http/headers/accept-patch.json
+++ b/http/headers/accept-patch.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Accept-Patch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Patch",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/accept-post.json
+++ b/http/headers/accept-post.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Accept-Patch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Post",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds _placeholder_ BCD entries for two missing HTTP headers - `Accept-Patch` and `Accept-Post`. At the moment Accept-Patch just adds `true` for items listed [here](https://www.geeksforgeeks.org/http-headers-accept-patch/) while `Accept-Post` is set to null for all browsers - but has the correct MDN link for docs.

I have searched mdn Bugzilla - no mention. FF source has a mention of Accept-Patch but not accept post. Is there anyone you could suggest I talk to for finding out support on this, or is there test code that might be used for verification? Note that even the Accept header docs just use `true`, not versions.
