### PR TITLE
Fix data for HTML element APIs for IE/Edge

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "52"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "41"
@@ -499,7 +499,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "41"

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -202,7 +202,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "10"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -485,7 +485,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -540,7 +540,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "10.5"
@@ -590,7 +590,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "9"
@@ -878,7 +878,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "79",
@@ -949,7 +949,7 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -1385,7 +1385,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "77",
@@ -2008,7 +2008,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2056,7 +2056,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2104,7 +2104,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2152,7 +2152,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -2200,7 +2200,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -3184,7 +3184,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -3239,7 +3239,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5.5",
               "partial_implementation": true,
               "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "15"
@@ -355,7 +355,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "15"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -789,7 +789,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -333,7 +333,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -257,7 +257,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "5.5",
               "notes": "IE reports <code>false</code> for broken images."
             },
             "opera": {
@@ -306,7 +306,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1319,7 +1319,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "27"
@@ -1689,7 +1689,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "50"

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -67,7 +67,7 @@
               "version_added": "56"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "37"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "10.5"
@@ -732,7 +732,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -960,7 +960,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "20"
@@ -969,7 +969,7 @@
               "version_added": "15"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -3055,7 +3055,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -17,7 +17,7 @@
             "version_added": "16"
           },
           "ie": {
-            "version_added": "10"
+            "version_added": false
           },
           "opera": {
             "version_added": "11"
@@ -52,7 +52,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -124,7 +124,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -160,7 +160,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -196,7 +196,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -232,7 +232,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"
@@ -268,7 +268,7 @@
               "version_added": "16"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "11"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -835,7 +835,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "26"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -160,7 +160,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -356,7 +356,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "9"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -48,7 +48,7 @@
             }
           ],
           "ie": {
-            "version_added": false
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "12"
@@ -170,7 +170,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -244,7 +244,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -318,7 +318,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -392,7 +392,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "12"
@@ -468,7 +468,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -542,7 +542,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"
@@ -616,7 +616,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -513,7 +513,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -513,7 +513,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION

This PR updates the data for the HTML element APIs for Internet Explorer and Microsoft Edge using the mdn-bcd-collector project (using results from IE 5.5 to 11, and Edge 13 to 85), aided with some manual adjustments.
