### PR TITLE
Add beta Safari from iOS 14.2 and Big Sur 11.0.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -169,10 +169,15 @@
         },
         "14": {
           "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"
+        },
+        "14.0.1": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "610.2.11"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -160,10 +160,15 @@
         },
         "14": {
           "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"
+        },
+        "14.2": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "610.2.11"
         }
       }
     }


### PR DESCRIPTION
- iOS 14.2 Release Candidate (18B91)
- macOS Big Sur 11.0.1 beta (20B5012d)

https://developer.apple.com/news/releases/

to list Safari data for `Intl[@@toStringTag]` in #7020.