### PR TITLE
Document.all is specified as obsolete

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -459,8 +459,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This flips `api.Document.all`'s status from `standard_track` to `true` and `deprecated` to `true`, reflecting its weird state [as specified but explicitly obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#other-elements,-attributes-and-apis).

Prompted by #7193.