### PR TITLE
Add color-scheme property

### DIFF
--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -1,0 +1,156 @@
+{
+  "css": {
+    "properties": {
+      "color-scheme": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color-scheme",
+          "spec_url": "https://drafts.csswg.org/css-color-adjust/#color-scheme-prop",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "68"
+            },
+            "opera_android": {
+              "version_added": "58"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "13"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "81"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "only_dark": {
+          "__compat": {
+            "description": "<code>only dark</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "13"
+              },
+              "safari_ios": {
+                "version_added": "13"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "only_light": {
+          "__compat": {
+            "description": "<code>only light</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": "81",
+                "version_removed": "85"
+              },
+              "chrome_android": {
+                "version_added": "81",
+                "version_removed": "85"
+              },
+              "edge": {
+                "version_added": "81",
+                "version_removed": "85"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "68",
+                "version_removed": "71"
+              },
+              "opera_android": {
+                "version_added": "58",
+                "version_removed": "60"
+              },
+              "safari": {
+                "version_added": "13"
+              },
+              "safari_ios": {
+                "version_added": "13"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fun with dark mode and the `color-scheme` property!

Fixes https://github.com/mdn/browser-compat-data/issues/5825 which already pointed out a support matrix. I've expanded it further, though.


|   | IE | Edge | Firefox | Chrome | Safari | Opera | iOS Safari | Android |
|- |-   |-         |-            |-              |-          |-           |-                 |-             |
| `normal` `light` `dark` | - | 81 | - | 81 | 13 | 68 | 13 | 81|
| `only dark` | - | - | - | - | 13 | - | 13 | - |
| `only light` | - | 81-84 | - | 81-84 | 13 | 68-70 | 13 | 81-84 |

Notes on `only`:

Currently, the spec says: 
> Note: Earlier versions of this property also defined an `only` keyword to be specified alongside a preferred color scheme, indicating a stronger author preference. It ended up being unnecessary, and was removed.

This would usually mean marking the two `only` entries as non-standard and deprecated. However, the spec will change again, and add back `only` per https://github.com/w3c/csswg-drafts/issues/5089#issuecomment-714617108, so I've left these statuses alone for now.

As pointed out in https://github.com/mdn/browser-compat-data/issues/5825, `only dark` was only supported in Safari 13, but I also found https://www.chromestatus.com/feature/5653721679659008 which talks about `only light` that Chromiums shipped in versions 81-84.

Once `only` is back per the new definition, this will need updating, but I think for now it would be good to record the current situation (also to fix [Intellisense in VS Code](https://github.com/microsoft/vscode/issues/98351)).