### PR TITLE
' my string '.trim() is not supported in IE9 (but in IE10).

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2893,7 +2893,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "9"
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": "0.1.100"


### PR DESCRIPTION
`String.prototype.trim()` is not working on IE9:

![trim on IE9](https://user-images.githubusercontent.com/86275/97994894-1e1f8d80-1de6-11eb-8538-38cdd10adab1.png)

On IE10 and later it does work:
![trim on IE10](https://user-images.githubusercontent.com/86275/97994884-1b249d00-1de6-11eb-8d9d-cc0da56abd8c.png)
