### PR TITLE
Fix api.HTMLScriptElement.defer data for IE

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -206,16 +206,10 @@
             "firefox_android": {
               "version_added": "4"
             },
-            "ie": [
-              {
-                "version_added": "10"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "10",
-                "notes": "Non-standard implementation"
-              }
-            ],
+            "ie": {
+              "version_added": "10",
+              "notes": "In versions prior to Internet Explorer 10, it implemented <code>defer</code> by a proprietary specification. Since version 10 it conforms to the W3C specification."
+            },
             "opera": {
               "version_added": "≤12.1"
             },


### PR DESCRIPTION
This PR fixes the data for the `defer` property of the `HTMLScriptElement` API.  In #7246, the data was simplified as a note that simply states "Non-standard implementation" is simply unhelpful.  Before it was merged, it was reverted to its original state before changes were made, which is causing a linter failure.  This is a quick fix to make the data match what's in `html/elements/script.json`.

Fixes #7258.