### PR TITLE
Deprecate img element obsolete attributes (and corresponding HTMLImageElement IDL attributes)

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -137,7 +137,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -233,7 +233,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -647,7 +647,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -792,7 +792,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -885,7 +885,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1322,7 +1322,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1370,7 +1370,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -654,7 +654,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -1009,7 +1009,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           },
           "caseless_usemap": {
@@ -1056,7 +1056,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "deprecated": false
+                "deprecated": true
               }
             }
           }


### PR DESCRIPTION
This PR includes a patch that marks the `longdesc` and `usemap` attributes of the `img` element as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines those attributes as obsolete.

Other than those, we’ve already marked as deprecated all other `img` attributes that the HTML spec defines as obsolete.

This PR also includes a patch that marks as deprecated all IDL attributes of the `HTMLImageElement` interface for which the HTML spec defines the corresponding content/markup attributes as obsolete.

The affected IDL attributes are `align`, `border`, `hspace`, `longdesc`, `name`, `useMap`, and `vspace`.

Other than those attributes, we’ve already marked as deprecated all other `HTMLImageElement` IDL attributes for which the HTML spec defines the corresponding content/markup attributes as obsolete.

Relates to https://github.com/mdn/browser-compat-data/issues/7255