### PR TITLE
Deprecate script element "type" attribute (and "charset" and "type" IDL attributes of HTMLScriptElement)

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -137,7 +137,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -588,7 +588,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -551,7 +551,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           },
           "module": {


### PR DESCRIPTION
This PR marks the `type` attribute of the `script` element as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines that attribute as obsolete.

Other than that, we’ve already marked as deprecated all other `script` attributes that the HTML spec defines as obsolete.

This PR also marks as deprecated the `charset` and `type` IDL attributes of the `HTMLScriptElement` interface, because the HTML spec defines the corresponding content/markup attributes as obsolete.

Other than those attributes, we’ve already marked as deprecated all other `HTMLScriptElement` IDL attributes for which the HTML spec defines the corresponding content/markup attributes as obsolete.

Relates to https://github.com/mdn/browser-compat-data/issues/7255