### PR TITLE
Compat data for scrollbar-gutter

### DIFF
--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -1,0 +1,66 @@
+{
+  "css": {
+    "properties": {
+      "scrollbar-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter",
+          "support": {
+            "chrome": {
+              "version_added": "88.0.4289.0",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+            },
+            "chrome_android": {
+              "version_added": "88.0.4289.0",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable experimental Web Platform features"
+                  }
+                ]
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "properties": {
-      "scrollbar-width": {
+      "scrollbar-gutter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter",
           "support": {

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -7,21 +7,21 @@
           "support": {
             "chrome": {
               "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "edge": {
               "version_added": false

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -55,7 +55,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter",
           "support": {
             "chrome": {
-              "version_added": "88.0.4289.0",
+              "version_added": "88",
                 "flags": [
                   {
                     "type": "preference",
@@ -15,7 +15,7 @@
                 ]
             },
             "chrome_android": {
-              "version_added": "88.0.4289.0",
+              "version_added": "88",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
This PR adds compat data for the scrollbar-gutter CSS property, defined in the CSS4 Overflow spec.

This feature will be available in Chrome from version 88.0.4289.0 onwards (it is already available in Chrome Canary) by enabling the "Experimental Web Platform features" flag.

* Spec: https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property
* MDN entry: https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter
  * Related issue: https://github.com/mdn/sprints/issues/3849
* Explainer: https://github.com/felipeerias/scrollbar-gutter-explainer
* Chromium bug: https://crbug.com/710214
* Change making the feature available behind a flag: https://crrev.com/a8c0c42e8340b922689b6b802585fafc196933b7

Thank you very much for your review. This is my first contribution, I hope I haven't missed anything 🙂
