### PR TITLE
Deprecate the style element "type" attribute

### DIFF
--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -321,7 +321,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -296,7 +296,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
This change marks the `type` attribute of the `script` element as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines that attribute as obsolete.

This change also marks as deprecated the corresponding `type` IDL attribute of the `HTMLScriptElement` interface.

Relates to https://github.com/mdn/browser-compat-data/issues/7255