### PR TITLE
Deprecate the rb and rtc elements

### DIFF
--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -63,7 +63,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -45,7 +45,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This change marks the `rb` and `rtc` elements as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines both elements as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255