### PR TITLE
Deprecate the link element rev attribute

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1107,7 +1107,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
This change marks the `link` element `rev` attribute as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html the HTML spec defines that attribute as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255