### PR TITLE
Deprecate the area element hreflang/noHref attrs

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -379,7 +379,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -326,7 +326,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
This change marks the `hreflang` content attribute of the `area` element and `noHref` IDL attribute of the `HTMLAreaElement` interface as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines both of those as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255