### PR TITLE
Deprecate the menu element label & type attributes

### DIFF
--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -190,7 +190,7 @@
             "status": {
               "experimental": true,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -241,7 +241,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "deprecated": false
+                "deprecated": true
               }
             }
           },
@@ -289,7 +289,7 @@
               "status": {
                 "experimental": true,
                 "standard_track": true,
-                "deprecated": false
+                "deprecated": true
               }
             }
           }


### PR DESCRIPTION
This change marks the `menu` element `label` and `type` attributes deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines those attributes as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255