### PR TITLE
Deprecate the global attributes dropzone and onshow

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4026,7 +4026,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -864,7 +864,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -866,7 +866,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks the `dropzone` and `onshow` attributes as deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines those attributes as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255