### PR TITLE
Deprecate object element typemustmatch attribute

### DIFF
--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -763,7 +763,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
This change marks the `object` element `typemustmatch` attribute deprecated, because at https://html.spec.whatwg.org/multipage/obsolete.html, the HTML spec defines that attribute as obsolete.

Related: https://github.com/mdn/browser-compat-data/issues/7255