### PR TITLE
Automatically include correct version in statistics script

### DIFF
--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -176,7 +176,7 @@ const printStats = (stats, folder) => {
   }
 
   console.log(
-    chalk`{bold Status as of version ${version} (released on 2020-MM-DD) for ${
+    chalk`{bold Status as of version ${process.env.npm_package_version} (released on 2020-MM-DD) for ${
       folder ? `${folder}/ directory` : 'web platform features'
     }}: \n`,
   );

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -175,7 +175,9 @@ const printStats = (stats, folder) => {
   }
 
   console.log(
-    chalk`{bold Status as of version ${process.env.npm_package_version} (released on 2020-MM-DD) for ${
+    chalk`{bold Status as of version ${
+      process.env.npm_package_version
+    } (released on 2020-MM-DD) for ${
       folder ? `${folder}/ directory` : 'web platform features'
     }}: \n`,
   );

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -6,7 +6,6 @@
 const chalk = require('chalk');
 
 const bcd = require('..');
-const version = require('../package.json').version;
 
 const { argv } = require('yargs').command(
   '$0 [folder]',

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -6,6 +6,7 @@
 const chalk = require('chalk');
 
 const bcd = require('..');
+const version = require('../package.json').version;
 
 const { argv } = require('yargs').command(
   '$0 [folder]',
@@ -175,7 +176,7 @@ const printStats = (stats, folder) => {
   }
 
   console.log(
-    chalk`{bold Status as of version 1.0.xx (released on 2020-MM-DD) for ${
+    chalk`{bold Status as of version ${version} (released on 2020-MM-DD) for ${
       folder ? `${folder}/ directory` : 'web platform features'
     }}: \n`,
   );


### PR DESCRIPTION
This PR updates the statistics script to automatically include the current version set in `package.json`.