### PR TITLE
Update NodeIterator/TreeWalker's expandEntityReferences removal

### DIFF
--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -102,13 +102,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeIterator/expandEntityReferences",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "41"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "3.5",
@@ -122,22 +125,28 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "9",
+              "version_removed": "28"
             },
             "opera_android": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "version_removed": "28"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "41"
             }
           },
           "status": {

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -100,13 +100,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TreeWalker/expandEntityReferences",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "41"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "4",
@@ -120,27 +123,33 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "9",
+              "version_removed": "28"
             },
             "opera_android": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "version_removed": "28"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "41"
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
Removed from Blink here:
https://groups.google.com/a/chromium.org/d/msg/blink-dev/-ZO3eja4maA/86T13XJwQpUJ
https://chromium.googlesource.com/chromium/src/+/058e76d47d075cf29733d78b2f2c8166f374520c

Data was mirrored for all other Blink browsers based on the fact that
the removal was outright, not controlled by any flag.

Removed from WebKit at version 603.1.2:
https://trac.webkit.org/changeset/204134/webkit

However, the code was ifdef'd so this can't be blindly trusted.

Removal versions confirmed for desktop browsers (Chrome, Edge, Firefox,
Safari) using BrowserStack with these tests:
https://mdn-bcd-collector.appspot.com/tests/api/NodeIterator/expandEntityReferences
https://mdn-bcd-collector.appspot.com/tests/api/TreeWalker/expandEntityReferences
