### PR TITLE
updating onbefore event and gettargetranges

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -459,7 +459,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -138,7 +138,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -186,7 +186,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -206,10 +206,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "83"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "83"
             },
             "ie": {
               "version_added": false
@@ -234,7 +234,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -282,7 +282,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes

beforeinput and getTargetRanges was shipped in Firefox 83, so updating the information regarding both of these.

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

See https://bugzilla.mozilla.org/show_bug.cgi?id=1609291 and https://bugzilla.mozilla.org/show_bug.cgi?id=1658702

- [x] Data: if you tested something, describe how you tested with details like browser and version

Wrote a code example and works as expected in Firefox

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
Done
