### PR TITLE
Update @page size support

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -202,13 +202,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page/size",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "15"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "18"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -220,10 +220,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": false
@@ -232,16 +232,114 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "37"
               }
             },
             "status": {
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "jis-b4": {
+            "__compat": {
+              "description": "<code>jis-b4</code> page size",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page/size",
+              "support": {
+                "chrome": {
+                  "version_added": "83"
+                },
+                "chrome_android": {
+                  "version_added": "83"
+                },
+                "edge": {
+                  "version_added": "83"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "69"
+                },
+                "opera_android": {
+                  "version_added": "59"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "13.0"
+                },
+                "webview_android": {
+                  "version_added": "83"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "jis-b5": {
+            "__compat": {
+              "description": "<code>jis-b5</code> page size",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page/size",
+              "support": {
+                "chrome": {
+                  "version_added": "83"
+                },
+                "chrome_android": {
+                  "version_added": "83"
+                },
+                "edge": {
+                  "version_added": "83"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "69"
+                },
+                "opera_android": {
+                  "version_added": "59"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "13.0"
+                },
+                "webview_android": {
+                  "version_added": "83"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
Fun with paged media and the `@page { size }` descriptor!

Fixes https://github.com/mdn/browser-compat-data/issues/4192 where @takenspc is correct in pointing out that Chromiums do support `size` and recently also added support for the `jis-b4` and `jis-b5` sizes.

| Feature | Chrome | Firefox | Safari |
| - | - | -  | - |
| `size` descriptor | 15 | - | - | 
|  `jis-b4` /  `jis-b5` | 83 | - | - | 

Sources:
- [caniuse](https://caniuse.com/css-paged-media) for `size`
- [chromestatus](https://www.chromestatus.com/feature/5112328557166592) for `jis-b4` /  `jis-b5`
