### PR TITLE
Add CSS page property & page-orientation descriptor

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -196,6 +196,55 @@
             }
           }
         },
+        "page-orientation": {
+          "__compat": {
+            "description": "<code>page-orientation</code> descriptor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page/page-orientation",
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": {
+                "version_added": "85"
+              },
+              "edge": {
+                "version_added": "85"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "71"
+              },
+              "opera_android": {
+                "version_added": "60"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "85"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "size": {
           "__compat": {
             "description": "<code>size</code> descriptor",

--- a/css/properties/page.json
+++ b/css/properties/page.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "page": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
+          "spec_url": "https://drafts.csswg.org/css-page-3/#propdef-page",
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "71"
+            },
+            "opera_android": {
+              "version_added": "60"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "85"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
More fun with paged media and two new features: `page` + `page-orientation`.

| Feature | Chrome | Firefox | Safari |
| - | - | -  | - |
| `page` / `page-orientation`| 85 | - | - | 

Sources:
- https://www.chromestatus.com/feature/5173237715566592
- https://drafts.csswg.org/css-page-3/#propdef-page
- https://drafts.csswg.org/css-page-3/#descdef-page-page-orientation
- https://github.com/mstensho/page-orientation/