### PR TITLE
Unprefixed CSS ruby-position in Chromiums

### DIFF
--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -5,16 +5,40 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ruby-position",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "18",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "79",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "38"
             },
@@ -25,26 +49,49 @@
               "version_added": false,
               "notes": "Internet Explorer 9 and later support an old draft values: <code>inline</code> (equivalent of having <code>display: inline</code> on the ruby), and <code>above</code> (synonym of the modern <code>over</code>)."
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "15",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "14",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              }
+            ],
             "safari": {
-              "version_added": false,
-              "notes": "Safari implements a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              "version_added": "6.1",
+              "prefix": "-webkit-",
+              "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "Safari implements a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              "version_added": "6.1",
+              "prefix": "-webkit-",
+              "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },
             "samsunginternet_android": {
               "version_added": false
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-",
+                "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
Fun with another compat mess! Presenting the story of `ruby-position`.

| Feature | Chrome | Firefox | Safari |
| - | - | -  | - |
| `ruby-position` | 84 | 38 | - | 
| `-webkit-ruby-position` | 1 | - | 6.1 | 

I've also updated Safari so it is treated the same.

Sources:
- https://www.chromestatus.com/feature/5173237715566592
- https://groups.google.com/a/chromium.org/g/blink-dev/c/dKyoAe_tSQw/m/QP_zehZnAwAJ?pli=1
- Safari: https://trac.webkit.org/changeset/137359/webkit (change in December 2012, Safari 6.1 shipped after this date according to our data).