### PR TITLE
Web APIs in Node 15

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "53"
           },
@@ -83,6 +86,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "53"
@@ -146,6 +152,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "53"
             },
@@ -207,6 +216,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "53"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "53"
           },
@@ -69,6 +72,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "53"
@@ -118,6 +124,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "53"
             },
@@ -165,6 +174,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "53"

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -22,6 +22,10 @@
           "ie": {
             "version_added": "11"
           },
+          "nodejs": {
+            "version_added": "15.0.0",
+            "notes": "Exported from the <code>crypto</code> module as <code>webcrypto</code> but not globally available."
+          },
           "opera": {
             "version_added": "15"
           },
@@ -69,6 +73,9 @@
             },
             "ie": {
               "version_added": "11"
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "15"
@@ -145,6 +152,9 @@
               "version_added": "11",
               "partial_implementation": true
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -203,6 +213,9 @@
               },
               "ie": {
                 "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
               },
               "opera": {
                 "version_added": "47"

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "24"
           },
@@ -68,6 +71,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "24"
@@ -117,6 +123,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -164,6 +173,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": "47"
@@ -213,6 +225,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -260,6 +275,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "24"

--- a/api/CryptoKeyPair.json
+++ b/api/CryptoKeyPair.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "24"
           },

--- a/api/Event.json
+++ b/api/Event.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "6"
           },
+          "nodejs": {
+            "version_added": "14.5.0"
+          },
           "opera": {
             "version_added": "4"
           },
@@ -70,6 +73,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "15.0.0"
+              },
+              {
+                "version_added": "14.5.0",
+                "notes": "Only available from the <code>events</code> module"
+              }
+            ],
             "opera": {
               "version_added": "11.6"
             },
@@ -118,6 +130,10 @@
             "ie": {
               "version_added": null
             },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "This is not used in Node.js and is provided purely for completeness."
+            },
             "opera": {
               "version_added": true
             },
@@ -165,6 +181,9 @@
             },
             "ie": {
               "version_added": null
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": true
@@ -218,6 +237,10 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "This is not used in Node.js and is provided purely for completeness."
+            },
             "opera": {
               "version_added": true,
               "notes": "Starting with Chrome 58 and Opera 45, setting this property to false does nothing, as per <a href='https://github.com/whatwg/dom/issues/211'>spec discussion</a>."
@@ -269,6 +292,10 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "This is not used in Node.js and is provided purely for completeness."
             },
             "opera": {
               "version_added": "40"
@@ -331,6 +358,10 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "Returns an array with either the event itself or no contents."
             },
             "opera": [
               {
@@ -416,6 +447,9 @@
                 "notes": "On Internet Explorer 6 through 8, the event model is different. Event listeners are attached with the non-standard <a href='https://developer.mozilla.org/docs/Web/API/EventTarget/attachEvent'><code>EventTarget.attachEvent</code></a> method. In this model, there is no equivalent to <code>event.currentTarget</code> and <code>this</code> is the global object. One solution to emulate the <code>event.currentTarget</code> feature is to wrap your handler in a function calling the handler using <code>Function.prototype.call</code> with the element as a first argument. This way, <code>this</code> will be the expected value."
               }
             ],
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "7"
             },
@@ -463,6 +497,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": "11"
@@ -512,6 +549,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "32"
             },
@@ -558,6 +598,9 @@
               "version_added": true
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -610,6 +653,9 @@
               "notes": "See <a href='https://bugzil.la/691151'>bug 691151</a>."
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -676,6 +722,9 @@
             "ie": {
               "version_added": true
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": true
             },
@@ -726,6 +775,10 @@
             "ie": {
               "version_added": false,
               "notes": "In Internet Explorer, all events are trusted except those that are created with the <code>createEvent()</code> method."
+            },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "This is not used in Node.js and is provided purely for completeness."
             },
             "opera": {
               "version_added": "33",
@@ -779,6 +832,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -827,6 +883,9 @@
               "version_removed": "24"
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -879,6 +938,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -926,6 +988,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": "7"
@@ -977,6 +1042,9 @@
             "ie": {
               "version_added": "6"
             },
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -1024,6 +1092,9 @@
             },
             "ie": {
               "version_added": true
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": true
@@ -1073,6 +1144,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "15"
             },
@@ -1121,6 +1195,10 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "14.5.0",
+              "notes": "This is not used in Node.js and is provided purely for completeness."
+            },
             "opera": {
               "version_added": "7"
             },
@@ -1168,6 +1246,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": "7"
@@ -1222,6 +1303,9 @@
               "version_added": true,
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "36",
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
@@ -1273,6 +1357,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "14.5.0"
             },
             "opera": {
               "version_added": "7"

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "6"
           },
+          "nodejs": {
+            "version_added": "14.5.0"
+          },
           "opera": {
             "version_added": "7"
           },
@@ -72,6 +75,15 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "15.0.0"
+              },
+              {
+                "version_added": "14.5.0",
+                "notes": "Only available from the <code>events</code> module"
+              }
+            ],
             "opera": {
               "version_added": "51"
             },
@@ -130,6 +142,9 @@
                 "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.attachEvent()</code> method."
               }
             ],
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "7"
             },
@@ -179,6 +194,9 @@
               "ie": {
                 "version_added": "9"
               },
+              "nodejs": {
+                "version_added": "14.5.0"
+              },
               "opera": {
                 "version_added": "11.6"
               },
@@ -227,6 +245,9 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": "14.5.0"
+              },
               "opera": {
                 "version_added": true
               },
@@ -273,6 +294,9 @@
                 },
                 "ie": {
                   "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "14.5.0"
                 },
                 "opera": {
                   "version_added": true
@@ -322,6 +346,9 @@
                 "ie": {
                   "version_added": false
                 },
+                "nodejs": {
+                  "version_added": "14.5.0"
+                },
                 "opera": {
                   "version_added": "42"
                 },
@@ -369,6 +396,9 @@
                 },
                 "ie": {
                   "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "14.5.0"
                 },
                 "opera": {
                   "version_added": true
@@ -418,6 +448,9 @@
                 "ie": {
                   "version_added": false
                 },
+                "nodejs": {
+                  "version_added": null
+                },
                 "opera": {
                   "version_added": null
                 },
@@ -465,6 +498,9 @@
                 },
                 "ie": {
                   "version_added": false
+                },
+                "nodejs": {
+                  "version_added": null
                 },
                 "opera": {
                   "version_added": null
@@ -524,6 +560,9 @@
                 "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.fireEvent()</code> method."
               }
             ],
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "9"
             },
@@ -580,6 +619,9 @@
                 "notes": "Older versions of IE supported an equivalent, proprietary <code>EventTarget.detachEvent()</code> method."
               }
             ],
+            "nodejs": {
+              "version_added": "14.5.0"
+            },
             "opera": {
               "version_added": "7"
             },
@@ -629,6 +671,9 @@
               },
               "ie": {
                 "version_added": true
+              },
+              "nodejs": {
+                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -680,6 +725,9 @@
               "ie": {
                 "version_added": "9"
               },
+              "nodejs": {
+                "version_added": "14.5.0"
+              },
               "opera": {
                 "version_added": "11.6"
               },
@@ -727,6 +775,9 @@
               },
               "ie": {
                 "version_added": false
+              },
+              "nodejs": {
+                "version_added": "14.5.0"
               },
               "opera": {
                 "version_added": true

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -22,10 +22,15 @@
           "ie": {
             "version_added": "10"
           },
-          "nodejs": {
-            "version_added": "10.5.0",
-            "notes": "Must be imported from the <code>worker_threads</code> module."
-          },
+          "nodejs": [
+            {
+              "version_added": "15.0.0"
+            },
+            {
+              "version_added": "10.5.0",
+              "notes": "Must be imported from the <code>worker_threads</code> module."
+            }
+          ],
           "opera": {
             "version_added": "10.6"
           },
@@ -74,10 +79,15 @@
             "ie": {
               "version_added": "10"
             },
-            "nodejs": {
-              "version_added": "10.5.0",
-              "notes": "Must be imported from the <code>worker_threads</code> module."
-            },
+            "nodejs": [
+              {
+                "version_added": "15.0.0"
+              },
+              {
+                "version_added": "10.5.0",
+                "notes": "Must be imported from the <code>worker_threads</code> module."
+              }
+            ],
             "opera": {
               "version_added": "10.6"
             },

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -22,6 +22,9 @@
           "ie": {
             "version_added": "9"
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "10.6"
           },
@@ -69,6 +72,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": null

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -180,7 +180,9 @@
               "version_added": null
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "14.5.0",
+              "partial_implementation": true,
+              "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
             },
             "opera": {
               "version_added": "47"

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -50,6 +50,9 @@
             "version_added": "11",
             "partial_implementation": true
           },
+          "nodejs": {
+            "version_added": "15.0.0"
+          },
           "opera": {
             "version_added": "24"
           },
@@ -139,6 +142,9 @@
               "partial_implementation": true,
               "notes": "Returns <code>CryptoOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -217,6 +223,13 @@
             ],
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DH",
+                "Supports: NODE-SCRYPT"
+              ]
             },
             "opera": {
               "version_added": "24"
@@ -297,6 +310,13 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DH",
+                "Supports: NODE-SCRYPT"
+              ]
+            },
             "opera": {
               "version_added": "24"
             },
@@ -375,6 +395,9 @@
               "partial_implementation": true,
               "notes": "Returns <code>CryptoOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -452,6 +475,9 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Returns <code>CryptoOperation</code> instead of <code>Promise</code>"
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "24"
@@ -534,6 +560,14 @@
               "partial_implementation": true,
               "notes": "Returns <code>KeyOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DSA",
+                "Supports: NODE-DH",
+                "Supports: NODE-SCRYPT"
+              ]
+            },
             "opera": {
               "version_added": "24"
             },
@@ -614,6 +648,13 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Returns <code>KeyOperation</code> instead of <code>Promise</code>"
+            },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DSA",
+                "Supports: NODE-DH"
+              ]
             },
             "opera": {
               "version_added": "24"
@@ -696,6 +737,14 @@
               "partial_implementation": true,
               "notes": "Returns <code>KeyOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DSA",
+                "Supports: NODE-DH",
+                "Supports: NODE-SCRYPT"
+              ]
+            },
             "opera": {
               "version_added": "24"
             },
@@ -743,6 +792,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": null
             },
             "opera": {
               "version_added": "47"
@@ -822,6 +874,10 @@
               "partial_implementation": true,
               "notes": "Returns <code>CryptoOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": "Supports: NODE-DSA"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -900,6 +956,13 @@
               "partial_implementation": true,
               "notes": "Returns <code>KeyOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": [
+                "Supports: NODE-DSA",
+                "Supports: NODE-DH"
+              ]
+            },
             "opera": {
               "version_added": "24"
             },
@@ -975,6 +1038,10 @@
               "partial_implementation": true,
               "notes": "Returns <code>CryptoOperation</code> instead of <code>Promise</code>"
             },
+            "nodejs": {
+              "version_added": "15.0.0",
+              "notes": "Supports: NODE-DSA"
+            },
             "opera": {
               "version_added": "24"
             },
@@ -1015,6 +1082,9 @@
               "version_added": "48"
             },
             "ie": {
+              "version_added": null
+            },
+            "nodejs": {
               "version_added": null
             },
             "opera": {
@@ -1082,6 +1152,9 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Returns <code>KeyOperation</code> instead of <code>Promise</code>"
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "24"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -262,6 +262,13 @@
           "engine": "V8",
           "engine_version": "8.3"
         },
+        "14.5.0": {
+          "release_date": "2020-06-30",
+          "release_notes": "https://nodejs.org/en/blog/release/v14.5.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "8.3"
+        },
         "14.6.0": {
           "release_date": "2020-07-21",
           "release_notes": "https://nodejs.org/en/blog/release/v14.6.0/",


### PR DESCRIPTION
Adds more support info and small updates to existing node support info in web APIs. Some of them were added in 14.5.0, as such I have added that node version to the node version list.

The following table lists API json files and accompanying documentation. Compatibility versions are based purely on the version provided in the node documentation.

| API | Documentation |
|-------|--------------------|
|  `Worker` `messageerror` event | https://nodejs.org/dist/latest-v15.x/docs/api/worker_threads.html#worker_threads_event_messageerror_1 |
| `AbortController` | https://nodejs.org/dist/latest-v15.x/docs/api/globals.html#globals_class_abortcontroller |
| `AbortSignal` | https://nodejs.org/dist/latest-v15.x/docs/api/globals.html#globals_class_abortsignal |
| `Event` | https://nodejs.org/docs/latest-v15.x/api/events.html#events_class_event |
| `EventTarget` | https://nodejs.org/docs/latest-v15.x/api/events.html#events_class_eventtarget |
| `MessagePort`  | https://nodejs.org/dist/latest-v15.x/docs/api/globals.html#globals_messageport |
| `MessageEvent`  | https://nodejs.org/dist/latest-v15.x/docs/api/globals.html#globals_messageevent |
| `Crypto` | https://nodejs.org/dist/latest-v15.x/docs/api/webcrypto.html#webcrypto_class_crypto |
| `CryptoKey` | https://nodejs.org/dist/latest-v15.x/docs/api/webcrypto.html#webcrypto_class_cryptokey |
| `CryptoKeyPair` | https://nodejs.org/dist/latest-v15.x/docs/api/webcrypto.html#webcrypto_class_cryptokeypair |
| `SubtleCrypto` | https://nodejs.org/dist/latest-v15.x/docs/api/webcrypto.html#webcrypto_class_subtlecrypto |
