### PR TITLE
setTimeout: Firefox for android runs immediately.

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1325,7 +1325,10 @@
               },
               {
                 "version_added": "52",
-                "notes": "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
+                "notes": [
+                  "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin.",
+                  "Firefox for Android runs the function immediately rather than waiting for the specified duration."
+                ]
               }
             ],
             "ie": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

**Summary**: Firefox for Android ignores the timeout and runs the function immediately.
**Browser**: Tested on Daylight 82.1.1, Beta 83.0.0-beta.2, Nightly 201103 17:00
**Test**: I found it while working on [my tetris app](https://voxelprismatic.github.io/prizm.dev/games/tetris)
On PC, the piece will gradually fall down when hitting enter. On mobile, there is no animation.
