### PR TITLE
`Node.ownerDocument` has been supported since IE 6

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1699,7 +1699,7 @@
               }
             ],
             "ie": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
A checklist to help your pull request get merged faster:

- [x] Summarize your changes

    Update support of `Node.ownerDocument` under IE8

- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version

    I have tested under IE 6 and 8, and I found that the following snippet worked:

    ```js
    console.log(document.body.ownerDocument === document); // => true
    console.log(document.querySelector('*').ownerDocument === document); // => true
    ``` 

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests if any
