### PR TITLE
Correct Safari data for HTML element APIs (for Safari 3.1 to 4)

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -942,10 +942,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3250,10 +3250,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -499,7 +499,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -300,10 +300,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -348,10 +348,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -496,10 +496,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -644,10 +644,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -789,10 +789,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -837,10 +837,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1029,10 +1029,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1175,10 +1175,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1272,10 +1272,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1443,10 +1443,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2140,10 +2140,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2189,10 +2189,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2463,10 +2463,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2560,10 +2560,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2608,10 +2608,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3097,10 +3097,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3242,10 +3242,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3538,10 +3538,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3961,10 +3961,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR corrects the Safari data for the HTML element APIs based upon results from the mdn-bcd-collector project (using results from Safari 3-14), including mirroring to Safari iOS.  This particular PR is a cherry-pick for all the changes that set it to Safari 3.1, 3.2, or 4.