### PR TITLE
Correct Safari data for HTML element APIs (for Safari 5 to 6.1)

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -79,7 +79,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -796,10 +796,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1151,7 +1151,7 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -2452,7 +2452,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3145,10 +3145,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3699,7 +3699,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -943,10 +943,10 @@
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1259,10 +1259,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": "2.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -252,10 +252,10 @@
               ]
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3761,10 +3761,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3913,10 +3913,10 @@
               ]
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -26,7 +26,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "6"
+          },
+          "safari_ios": {
+            "version_added": "6"
           }
         },
         "status": {
@@ -61,7 +64,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {
@@ -136,7 +142,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {
@@ -172,7 +181,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {
@@ -208,7 +220,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {
@@ -244,7 +259,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {
@@ -280,7 +298,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             }
           },
           "status": {

--- a/api/HTMLOListElement.json
+++ b/api/HTMLOListElement.json
@@ -124,10 +124,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -220,10 +220,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -892,10 +892,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1132,10 +1132,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1180,10 +1180,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1324,10 +1324,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -169,10 +169,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "8"
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": "8"
+            "version_added": "6.1"
           },
           "samsunginternet_android": {
             "version_added": "1.5"
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -268,10 +268,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR corrects the Safari data for the HTML element APIs based upon results from the mdn-bcd-collector project (using results from Safari 3-14), including mirroring to Safari iOS. This particular PR is a cherry-pick for all the changes that set it to Safari 5 to 6.1.