### PR TITLE
Correct Safari data for HTML element APIs (for Safari 9 to 14)

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -412,10 +412,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "7.2"

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -654,10 +654,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": false
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "1.5"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -316,10 +316,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -184,10 +184,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -890,10 +890,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -389,10 +389,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1063,10 +1063,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1137,10 +1137,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": false
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -943,10 +943,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -460,10 +460,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -844,10 +844,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -370,7 +370,7 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -384,10 +384,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -895,10 +895,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -87,10 +87,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": "10.1"
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": "10.3"
+            "version_added": "10"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -240,10 +240,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -346,10 +346,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -220,10 +220,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR corrects the Safari data for the HTML element APIs based upon results from the mdn-bcd-collector project (using results from Safari 3-14), including mirroring to Safari iOS. This particular PR is a cherry-pick for all the changes that set it to Safari 9 to 14.