### PR TITLE
Correct Safari data for HTML element APIs (for Safari unsupported)

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -412,7 +412,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1969,10 +1969,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1969,10 +1969,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -172,7 +172,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR corrects the Safari data for the HTML element APIs based upon results from the mdn-bcd-collector project (using results from Safari 3-14), including mirroring to Safari iOS. This particular PR is a cherry-pick for all the changes that set it to `false`.