### PR TITLE
Add Intl[@@toStringTag] for Safari

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -138,10 +138,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Based on discussion in #7248, we mark it as Safari 14 feature.
Safari 14.0.1 ships `610.2.11`, and it implements this. https://trac.webkit.org/changeset/266015/webkit