### PR TITLE
Update Credential API data for Edge

### DIFF
--- a/api/Credential.json
+++ b/api/Credential.json
@@ -111,7 +111,7 @@
               "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -168,7 +168,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": true
@@ -230,7 +230,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -11,7 +11,7 @@
             "version_added": "51"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -59,7 +59,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -107,7 +107,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -155,7 +155,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null

--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -11,7 +11,7 @@
             "version_added": "51"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -59,7 +59,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -107,7 +107,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -203,7 +203,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -251,7 +251,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -299,7 +299,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -347,7 +347,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Edge data for four Credential APIs based upon results from the mdn-bcd-collector project (tested in Edge 13-85).