### PR TITLE
Update Credential API data for Safari

### DIFF
--- a/api/Credential.json
+++ b/api/Credential.json
@@ -131,10 +131,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -32,7 +32,7 @@
             "version_added": "13"
           },
           "safari_ios": {
-            "version_added": "13.3"
+            "version_added": "13"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -79,7 +79,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13.3"
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -127,7 +127,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13.3"
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -186,10 +186,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": [
               {
@@ -248,10 +248,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -29,10 +29,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -77,10 +77,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -125,10 +125,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -173,10 +173,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -29,10 +29,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -77,10 +77,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -125,10 +125,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -173,10 +173,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -221,10 +221,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -269,10 +269,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -317,10 +317,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -365,10 +365,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR updates the Safar data for four Credential APIs based upon results from the mdn-bcd-collector project (tested in Safari 6-14).  Additionally, this corrects the data for the CredentialsContainer API for Safari iOS based upon manual testing (simulator for iPadOS 13.0).