### PR TITLE
Update Credential API for Firefox

### DIFF
--- a/api/Credential.json
+++ b/api/Credential.json
@@ -17,7 +17,7 @@
             "version_added": "60"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "ie": {
             "version_added": false
@@ -64,7 +64,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "ie": {
               "version_added": false

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -14,10 +14,10 @@
             "version_added": "18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "61"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "61"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "ie": {
               "version_added": false
@@ -109,10 +109,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "ie": {
               "version_added": false
@@ -171,10 +171,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "ie": {
               "version_added": false
@@ -233,10 +233,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "ie": {
               "version_added": false

--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -62,10 +62,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -110,10 +110,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -158,10 +158,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -62,10 +62,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -110,10 +110,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -158,10 +158,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -206,10 +206,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -254,10 +254,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -302,10 +302,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -350,10 +350,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates the Firefox data for four Credential APIs based upon results from the mdn-bcd-collector project (tested in Firefox 4-82).