### PR TITLE
Update CredentialsContainer API data for Opera

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "38"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "41"
           },
           "safari": {
             "version_added": "13"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "safari": {
               "version_added": "13"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "safari": {
               "version_added": "13"
@@ -179,12 +179,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "47"
+              },
+              {
+                "alternative_name": "requireUserMediation",
+                "version_added": "38",
+                "version_removed": "47"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "alternative_name": "requireUserMediation",
+                "version_added": "41",
+                "version_removed": "44"
+              }
+            ],
             "safari": {
               "version_added": false
             },
@@ -242,10 +256,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Opera data for the CredentialsContainer API based upon results from the mdn-bcd-collector project (Opera 12.16, 15, and 70) with mirroring from Chrome.