### PR TITLE
Correct Chromium data for PasswordCredential.iconURL/name

### DIFF
--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -149,13 +149,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/iconURL",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -167,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "39"
+              "version_added": "38"
             },
             "opera_android": {
               "version_added": "41"
@@ -179,10 +179,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "51"
             }
           },
           "status": {
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/name",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "51"
             },
             "edge": {
               "version_added": "≤79"
@@ -263,7 +263,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "39"
+              "version_added": "38"
             },
             "opera_android": {
               "version_added": "41"
@@ -275,10 +275,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "51"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the Chromium data for the `iconURL` and `name` properties of the `PasswordCredential` API based upon results from the mdn-bcd-collector project (tested in Chrome 2-84).