### PR TITLE
Mirror Opera data for ContentIndex(Event) and Element.getAnimations()

### DIFF
--- a/api/ContentIndex.json
+++ b/api/ContentIndex.json
@@ -25,7 +25,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/ContentIndexEvent.json
+++ b/api/ContentIndexEvent.json
@@ -25,7 +25,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "60"
           },
           "safari": {
             "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -3504,7 +3504,7 @@
             },
             "opera": [
               {
-                "version_added": "71"
+                "version_added": "70"
               },
               {
                 "version_added": "66",
@@ -3555,7 +3555,20 @@
             ],
             "opera_android": [
               {
+                "version_added": "60"
+              },
+              {
+                "version_added": "57",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
                 "version_added": "48",
+                "version_removed": "57",
                 "partial_implementation": true,
                 "notes": "Does not support the <code>subtree</code> option.",
                 "flags": [


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/6601.
