### PR TITLE
Note behavior of crossorigin attribute with rel="icon"

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -734,7 +734,7 @@
                 },
                 "firefox": {
                   "version_added": "2",
-                  "notes" : "Prior to Firefox 83, the crossorigin attribute was not supported for rel=icon"
+                  "notes": "Prior to Firefox 83, the crossorigin attribute was not supported for rel=icon"
                 },
                 "firefox_android": {
                   "version_added": "4"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -734,7 +734,7 @@
                 },
                 "firefox": {
                   "version_added": "2",
-                  "notes": "Prior to Firefox 83, the crossorigin attribute was not supported for rel=icon"
+                  "notes": "Before Firefox 83, the <code>crossorigin</code> attribute is not supported for <code>rel=\"icon\"</code>."
                 },
                 "firefox_android": {
                   "version_added": "4"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -108,7 +108,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "18"
+                "version_added": "18",
+                "notes": "Prior to Firefox 83, crossorigin was not supported for rel=icon."
               },
               "firefox_android": {
                 "version_added": "18"
@@ -722,7 +723,7 @@
               "support": {
                 "chrome": {
                   "version_added": "4",
-                  "notes": "If both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)"
+                  "notes": "If both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)."
                 },
                 "chrome_android": {
                   "version_added": "18"
@@ -732,7 +733,8 @@
                   "notes": "In version 79 and later (Blink-based Edge), if both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)"
                 },
                 "firefox": {
-                  "version_added": "2"
+                  "version_added": "2",
+                  "notes" : "Prior to Firefox 83, the crossorigin attribute was not supported for rel=icon"
                 },
                 "firefox_android": {
                   "version_added": "4"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -109,7 +109,7 @@
               },
               "firefox": {
                 "version_added": "18",
-                "notes": "Prior to Firefox 83, crossorigin was not supported for rel=icon."
+                "notes": "Before Firefox 83, <code>crossorigin</code> is not supported for <code>rel=\"icon\"</code>."
               },
               "firefox_android": {
                 "version_added": "18"


### PR DESCRIPTION
Adding a note about support for the `crossorigin` attribute for `rel="icon"`

- https://github.com/mdn/sprints/issues/3802#issuecomment-716430764 
- https://bugzilla.mozilla.org/show_bug.cgi?id=1661075
