### PR TITLE
Update Safari data for api.HTMLElement.nonce

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1971,12 +1971,12 @@
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "Only available on <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code> elements."
+              "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },
             "safari_ios": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "Only available on <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code> elements."
+              "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1969,10 +1969,14 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "Only available on <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code> elements."
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "Only available on <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code> elements."
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR updates the Safari data for the `nonce` feature of the HTMLElement API.  In Safari, the feature was only supported on certain elements (`link`, `script`, and `style`), not all HTML elements.  This sets `partial_implementation` and adds a note, as well as confirms the feature wasn't supported before Safari 10.