### PR TITLE
Fix HTML element APIs marked as supported before Safari 3

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -31,7 +31,7 @@
             "notes": "Opera Mini 5.0 and later has partial support."
           },
           "safari": {
-            "version_added": "2"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -126,7 +126,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -31,10 +31,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "1.2"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -77,10 +77,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -171,10 +171,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -218,10 +218,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -359,10 +359,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -406,10 +406,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -547,10 +547,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -30,7 +30,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -1183,7 +1183,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
Fixes #7305.  The HTMLElement API itself was supported since Safari 3, however our data marked support for HTML element APIs in versions before Safari 3.  This PR corrects the data accordingly, setting Safari to 3 for the APIs set to earlier versions.