### PR TITLE
Update DOMParser compat data for iOS Safari

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -80,7 +80,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -175,7 +175,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": "3.0"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -80,7 +80,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -175,7 +175,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"


### PR DESCRIPTION
Update DOMParser compat data for iOS Safari. I tested it and the constructor works, as does parsing from HTML.

I used Safari on iOS version 14.1.