### PR TITLE
WebExtension API browsingData.remove cookieStoreId

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -298,6 +298,30 @@
           }
         },
         "RemovalOptions": {
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "84"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "hostnames": {
             "__compat": {
               "support": {


### PR DESCRIPTION
This Firefox only API was introduced in https://bugzilla.mozilla.org/show_bug.cgi?id=1670811
