### PR TITLE
Remove api.Node.outerText

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1619,54 +1619,6 @@
           }
         }
       },
-      "outerText": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/outerText",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "ownerDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/ownerDocument",


### PR DESCRIPTION
This PR removes `api.Node.outerText`.  This property is set to all false (or null), and the MDN document just says "See HTMLElement.outerText".
