### PR TITLE
Fix the glob for docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,7 @@ dependencies :chains::
   - "package-lock.json"
   - "package.json"
 docs :writing_hand::
-  - "**.md"
+  - "**/*.md"
 infra :building_construction::
   - ".editorconfig"
   - ".git*"


### PR DESCRIPTION
Closes #7250 

Tested on my fork: negative https://github.com/saschanaz/browser-compat-data/pull/2, positive https://github.com/saschanaz/browser-compat-data/pull/3.