### PR TITLE
Update Safari data for CSSValue + CSSValueList

### DIFF
--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -31,10 +31,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -80,10 +80,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -31,10 +31,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -80,10 +80,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR uses the mdn-bcd-collector project to update the Safari data for the CSSValue and CSSValueList APIs, including mirroring to Safari iOS.  (Note: Ranges for ≤4 were actually determined as ≤3, but I haven't tested any further back.)
