### PR TITLE
fit content function

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -286,6 +286,54 @@
             }
           }
         },
+        "fit-content-function": {
+          "__compat": {
+            "description": "<code>fit-content()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "max-content": {
           "__compat": {
             "description": "<code>max-content</code>",

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -300,7 +300,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1312588'>bug 1312588</a>."
               },
               "firefox_android": {
                 "version_added": false

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -286,7 +286,7 @@
             }
           }
         },
-        "fit-content-function": {
+        "fit-content_function": {
           "__compat": {
             "description": "<code>fit-content()</code>",
             "support": {


### PR DESCRIPTION
I am working on splitting out the `fit-content` keyword for width from the `fit-content()` function for width in https://github.com/mdn/sprints/issues/3723

This PR adds the data for the `fit-content()` function for width, which no-one yet supports, however given it is confusing people I think it worth showing that lack of support. As then on the function page I can show that it is well supported for track sizing in grid layout, and not at all for use as a general length, which would have helped the poster of that issue.
