### PR TITLE
api.HTMLInputElement.stepUp/stepDown supported in Firefox without flags

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1293,17 +1293,13 @@
             },
             "firefox": {
               "version_added": "16",
-              "notes": "Experimental, and without specific UI. There are still differences with the latest spec: <a href='https://bugzil.la/835773'>bug 835773</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.experimental_forms",
-                  "value_to_set": "true"
-                }
-              ]
+              "partial_implementation": true,
+              "notes": "Does not have a specific UI. There are still differences with the latest spec; see <a href='https://bugzil.la/835773'>bug 835773</a>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "16",
+              "partial_implementation": true,
+              "notes": "Does not have a specific UI. There are still differences with the latest spec; see <a href='https://bugzil.la/835773'>bug 835773</a>."
             },
             "ie": {
               "version_added": "10"
@@ -1349,17 +1345,13 @@
             },
             "firefox": {
               "version_added": "16",
-              "notes": "Experimental, and without specific UI. There are still differences with the latest spec: <a href='https://bugzil.la/835773'>bug 835773</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.experimental_forms",
-                  "value_to_set": "true"
-                }
-              ]
+              "partial_implementation": true,
+              "notes": "Does not have a specific UI. There are still differences with the latest spec; see <a href='https://bugzil.la/835773'>bug 835773</a>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "16",
+              "partial_implementation": true,
+              "notes": "Does not have a specific UI. There are still differences with the latest spec; see <a href='https://bugzil.la/835773'>bug 835773</a>."
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates the data for the `stepUp` and `stepDown` features of the HTMLInputElement API for Firefox based upon results from the mdn-bcd-collector project.  The collector reports that the features were always supported without needing to enable any flags (since Firefox 16).