### PR TITLE
Correct Safari data for RTC APIs

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -290,10 +290,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -436,10 +436,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -484,10 +484,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -532,10 +532,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -580,10 +580,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -677,10 +677,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -780,10 +780,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -876,10 +876,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1069,10 +1069,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1165,10 +1165,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1213,10 +1213,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -567,7 +567,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -1026,7 +1026,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -2388,10 +2388,12 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2439,7 +2441,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -29,10 +29,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": false


### PR DESCRIPTION
This PR corrects the Safari and Safari iOS data for three RTC APIs based upon results from the mdn-bcd-collector project (Safari 3-14 and Safari iOS 3-14).