### PR TITLE
Add real data for Safari for Node API

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -132,10 +132,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -397,7 +397,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
               "version_added": true
@@ -495,10 +495,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -543,10 +543,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -738,10 +738,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -834,10 +834,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -882,10 +882,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -930,10 +930,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -990,10 +990,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1040,10 +1040,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1088,10 +1090,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1196,10 +1198,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1244,10 +1246,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1400,10 +1402,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1552,10 +1554,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1600,10 +1602,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1660,10 +1662,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1863,10 +1865,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for the Node API for Safari and Safari iOS/iPadOS based upon results from the mdn-bcd-collector project (Safari 3-14 and Safari iOS 3-14).