### PR TITLE
Add real data for Safari for NodeList API

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for the NodeList API for Safari and Safari iOS/iPadOS based upon results from the mdn-bcd-collector project (Safari 3-14 and Safari iOS 3-14).