### PR TITLE
Add data guideline: partial_implementation requires a note

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -155,7 +155,7 @@ If you set `"partial_implementation": true`, then write a note describing how th
 
 For historical reasons, some support statements have the flag set to `true` without a note. Avoid this in new data or revised data. We intend to require this in the schema, after the features which do not conform to this guideline have been removed. Read [#4162](https://github.com/mdn/browser-compat-data/issues/4162) for details.
 
-This guideline was proposed in [#TK](https://tk.example/).
+This guideline was proposed in [#7332](https://github.com/mdn/browser-compat-data/pull/7332).
 
 ## Non-functional defined names imply `partial_implementation`
 

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -26,6 +26,14 @@ If it's helpful to understanding the rule, summarize the rationale. Definitely c
 
 -- END TEMPLATE -->
 
+## `"partial_implementation"` requires a note
+
+If you set `"partial_implementation": true`, then write a note describing how the implementation is incomplete.
+
+For historical reasons, some support statements have the flag set to `true` without a note. Avoid this in new data or revised data. We intend to require this in the schema, after the features which do not conform to this guideline have been removed. Read [#4162](https://github.com/mdn/browser-compat-data/issues/4162) for details.
+
+This guideline was proposed in [#TK](https://tk.example/).
+
 ## Constructors
 
 Name a constructor for an API feature the same as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -5,6 +5,7 @@ This file contains recommendations to help you record data in a consistent and u
 <!-- You can quickly regenerate this TOC by running: npx markdown-toc@1.2.0 --bullets='-' docs/data-guidelines.md -->
 
 - [Data guidelines](#data-guidelines)
+  - [`"partial_implementation"` requires a note](#partial_implementation-requires-a-note)
   - [Constructors](#constructors)
   - [DOM events (`eventname_event`)](#dom-events-eventname_event)
   - [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -5,12 +5,12 @@ This file contains recommendations to help you record data in a consistent and u
 <!-- You can quickly regenerate this TOC by running: npx markdown-toc@1.2.0 --bullets='-' docs/data-guidelines.md -->
 
 - [Data guidelines](#data-guidelines)
-  - [`"partial_implementation"` requires a note](#partial_implementation-requires-a-note)
   - [Constructors](#constructors)
   - [DOM events (`eventname_event`)](#dom-events-eventname_event)
   - [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)
   - [Web Workers (`worker_support`)](#web-workers-worker_support)
   - [Permissions API permissions (`permissionname_permission`)](#permissions-api-permissions-permissionname_permission)
+  - [`"partial_implementation"` requires a note](#partial_implementation-requires-a-note)
   - [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply-partial_implementation)
   - [Release lines and backported features](#release-lines-and-backported-features)
   - [Safari for iOS versioning](#safari-for-ios-versioning)
@@ -26,14 +26,6 @@ A description of what to do, preferably in the imperative. If applicable, includ
 If it's helpful to understanding the rule, summarize the rationale. Definitely cite the issue or pull request where this was decided (it may be the PR that merges the policy).
 
 -- END TEMPLATE -->
-
-## `"partial_implementation"` requires a note
-
-If you set `"partial_implementation": true`, then write a note describing how the implementation is incomplete.
-
-For historical reasons, some support statements have the flag set to `true` without a note. Avoid this in new data or revised data. We intend to require this in the schema, after the features which do not conform to this guideline have been removed. Read [#4162](https://github.com/mdn/browser-compat-data/issues/4162) for details.
-
-This guideline was proposed in [#TK](https://tk.example/).
 
 ## Constructors
 
@@ -156,6 +148,14 @@ For example, the Geolocation permission is named `geolocation_permission` with t
 ```
 
 This guideline was proposed in [#6156](https://github.com/mdn/browser-compat-data/pull/6156).
+
+## `"partial_implementation"` requires a note
+
+If you set `"partial_implementation": true`, then write a note describing how the implementation is incomplete.
+
+For historical reasons, some support statements have the flag set to `true` without a note. Avoid this in new data or revised data. We intend to require this in the schema, after the features which do not conform to this guideline have been removed. Read [#4162](https://github.com/mdn/browser-compat-data/issues/4162) for details.
+
+This guideline was proposed in [#TK](https://tk.example/).
 
 ## Non-functional defined names imply `partial_implementation`
 


### PR DESCRIPTION
This makes something explicit we've largely adhered to already. A step toward completing #4162.
