### PR TITLE
document.visibilityState: Safari 7+ supports "prerender"

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11642,7 +11642,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": null


### PR DESCRIPTION
I tested on BrowserStack, every version of desktop Safari from 7 to 14 and each of them actually starts with `visibilityState: prerender`

Test page: https://jg-testpage.netlify.app/document.hidden/
![image](https://user-images.githubusercontent.com/1437027/98734539-5ef94280-23a2-11eb-8926-25832028443a.png)

Scenario to reproduce:

1. Copy `https://jg-testpage.netlify.app/document.hidden/` to clipboard
2. Open new tab
3. Paste URL to the URL bar
4. Navigate to the URL (press enter)



