### PR TITLE
visibilitychange: Safari bug with window.addEventListener

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11507,7 +11507,8 @@
               "partial_implementation": true,
               "notes": [
                 "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+                "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>.",
+                "In Safari < 14.0, the event didn't bubble, so only <code>document.addEventListener('visibilitychange', ...)</code> would work, and not<code>window.addEventListener('visibilitychange', ...)</code>."
               ]
             },
             "safari_ios": {
@@ -11515,7 +11516,8 @@
               "partial_implementation": true,
               "notes": [
                 "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Edge, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+                "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>.",
+                "In Safari < 14.0, the event didn't bubble, so only <code>document.addEventListener('visibilitychange', ...)</code> would work, and not<code>window.addEventListener('visibilitychange', ...)</code>."
               ]
             },
             "samsunginternet_android": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -11507,8 +11507,7 @@
               "partial_implementation": true,
               "notes": [
                 "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "The <code>onvisibilitychange</code> attribute was not supported until Safari 10.1. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>.",
-                "In Safari < 14.0, the event didn't bubble, so only <code>document.addEventListener('visibilitychange', ...)</code> would work, and not<code>window.addEventListener('visibilitychange', ...)</code>."
+                "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not."
               ]
             },
             "safari_ios": {
@@ -11516,8 +11515,7 @@
               "partial_implementation": true,
               "notes": [
                 "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "The <code>onvisibilitychange</code> attribute was not supported until Safari iOS 10.3. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>.",
-                "In Safari < 14.0, the event didn't bubble, so only <code>document.addEventListener('visibilitychange', ...)</code> would work, and not<code>window.addEventListener('visibilitychange', ...)</code>."
+                "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not."
               ]
             },
             "samsunginternet_android": {


### PR DESCRIPTION
# Scope

- document a bug in Safari < 14
- fix a typo saying "Edge" instead of Safari

# Source
https://github.com/w3c/page-visibility/issues/68#issuecomment-724981272

