### PR TITLE
Add missing nodejs AggregateError constructor support

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -77,7 +77,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "15.0.0"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
This PR complements what has been done with #6997.

The support for AggregateError constructor has been tested by using the following code (as specified in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError) in Node.js 15.0.0 successfully:

```javascript
try {
  throw new AggregateError([
    new Error("some error"),
  ], 'Hello');
} catch (e) {
  console.log(e instanceof AggregateError); // true
  console.log(e.message);                   // "Hello"
  console.log(e.name);                      // "AggregateError"
  console.log(e.errors);                    // [ Error: "some error" ]
}
```

Finally the CHANGELOG of Node.js 15.0.0 to verify the support information: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#v8-86---35415

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
