### PR TITLE
Change Prettier "arrowParens" to default (and fix files)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
-  "arrowParens": "avoid",
   "singleQuote": true,
   "trailingComma": "all"
 }

--- a/scripts/fix-browser-order.js
+++ b/scripts/fix-browser-order.js
@@ -38,7 +38,7 @@ const orderSupportBlock = (key, value) => {
 /**
  * @param {Promise<void>} filename
  */
-const fixBrowserOrder = filename => {
+const fixBrowserOrder = (filename) => {
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, orderSupportBlock), null, 2);
 
@@ -75,7 +75,7 @@ if (require.main === module) {
         continue;
       }
 
-      const subFiles = fs.readdirSync(file).map(subfile => {
+      const subFiles = fs.readdirSync(file).map((subfile) => {
         return path.join(file, subfile);
       });
 

--- a/scripts/fix-feature-order.js
+++ b/scripts/fix-feature-order.js
@@ -40,7 +40,7 @@ function orderFeatures(key, value) {
 /**
  * @param {Promise<void>} filename
  */
-const fixFeatureOrder = filename => {
+const fixFeatureOrder = (filename) => {
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   let expected = JSON.stringify(JSON.parse(actual, orderFeatures), null, 2);
 
@@ -77,7 +77,7 @@ if (require.main === module) {
         continue;
       }
 
-      const subFiles = fs.readdirSync(file).map(subfile => {
+      const subFiles = fs.readdirSync(file).map((subfile) => {
         return path.join(file, subfile);
       });
 

--- a/scripts/fix.js
+++ b/scripts/fix.js
@@ -28,7 +28,7 @@ function load(...files) {
       continue;
     }
 
-    const subFiles = fs.readdirSync(file).map(subfile => {
+    const subFiles = fs.readdirSync(file).map((subfile) => {
       return path.join(file, subfile);
     });
 

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -39,7 +39,7 @@ const removeWebViewFlags = (key, value) => {
 /**
  * @param {Promise<void>} filename
  */
-const fixWebViewFlags = filename => {
+const fixWebViewFlags = (filename) => {
   const actual = fs.readFileSync(filename, 'utf-8').trim();
   const expected = JSON.stringify(
     JSON.parse(actual, removeWebViewFlags),
@@ -80,7 +80,7 @@ if (require.main === module) {
         continue;
       }
 
-      const subFiles = fs.readdirSync(file).map(subfile => {
+      const subFiles = fs.readdirSync(file).map((subfile) => {
         return path.join(file, subfile);
       });
 

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -19,7 +19,7 @@ const browsers = require('..').browsers;
 const { argv } = require('yargs').command(
   '$0 <browser> [feature_or_file]',
   'Mirror values onto a specified browser if "version_added" is true/null, based upon its parent or a specified source',
-  yargs => {
+  (yargs) => {
     yargs
       .positional('browser', {
         describe: 'The destination browser',
@@ -178,7 +178,7 @@ const updateNotes = (notes, regex, replace) => {
  * @param {SupportStatement} data
  * @returns {SupportStatement}
  */
-const copyStatement = data => {
+const copyStatement = (data) => {
   let newData = {};
   for (let i in data) {
     newData[i] = data[i];
@@ -459,7 +459,7 @@ const bumpSamsungInternet = (originalData, sourceData, source) => {
 const bumpWebView = (originalData, sourceData, source) => {
   let newData = copyStatement(sourceData);
 
-  const createWebViewRange = version => {
+  const createWebViewRange = (version) => {
     if (Number(version) <= 18) {
       return '1';
     } else if (Number(version) > 18 && Number(version) < 30) {
@@ -680,7 +680,7 @@ function mirrorDataByFile(browser, filepath, source, modify) {
       fs.writeFileSync(file, JSON.stringify(newData, null, 2) + '\n', 'utf-8');
     }
   } else if (fs.statSync(file).isDirectory()) {
-    const subFiles = fs.readdirSync(file).map(subfile => {
+    const subFiles = fs.readdirSync(file).map((subfile) => {
       return path.join(file, subfile);
     });
 
@@ -773,7 +773,7 @@ const mirrorData = (browser, feature_or_file, forced_source, modify) => {
       'mathml',
       'webdriver',
       'webextensions',
-    ].forEach(folder => {
+    ].forEach((folder) => {
       mirrorDataByFile(browser, folder, source, modify);
     });
   }

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -8,7 +8,7 @@ const bcd = require('..');
 const { argv } = require('yargs').command(
   '$0 <version-tag>',
   'Initiate a release of this package on GitHub',
-  yargs => {
+  (yargs) => {
     yargs.positional('version-tag', {
       describe: 'the version tag to generate release notes for',
       type: 'string',
@@ -22,17 +22,17 @@ const { argv } = require('yargs').command(
   },
 );
 
-const getJSON = url =>
+const getJSON = (url) =>
   new Promise((resolve, reject) =>
     http.get(
       url,
       { headers: { 'User-Agent': 'bcd-release-script' } },
-      response => {
+      (response) => {
         let body = '';
-        response.on('data', data => {
+        response.on('data', (data) => {
           body += data;
         });
-        response.on('error', error => reject(error));
+        response.on('error', (error) => reject(error));
         response.on('end', () => {
           resolve(JSON.parse(body));
         });
@@ -40,20 +40,22 @@ const getJSON = url =>
     ),
   );
 
-const question = query => {
+const question = (query) => {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-  return new Promise(resolve => rl.question(query, resolve)).then(response => {
-    rl.close();
-    return response;
-  });
+  return new Promise((resolve) => rl.question(query, resolve)).then(
+    (response) => {
+      rl.close();
+      return response;
+    },
+  );
 };
 
-const confirm = str => !['n', 'no'].includes(str.toLowerCase());
+const confirm = (str) => !['n', 'no'].includes(str.toLowerCase());
 
-const prompt = async questions => {
+const prompt = async (questions) => {
   const results = {};
   for (const q of questions) {
     const options = q.type === confirm ? '(Y/n) ' : '';
@@ -64,7 +66,7 @@ const prompt = async questions => {
 
 const stargazers = () =>
   getJSON('https://api.github.com/repos/mdn/browser-compat-data').then(
-    json => json.stargazers_count,
+    (json) => json.stargazers_count,
   );
 
 const stats = (version, previousVersion) => {
@@ -108,7 +110,7 @@ const contributors = (version, previousVersion) =>
     },
   ]);
 
-const notableChanges = previousReleaseDate => {
+const notableChanges = (previousReleaseDate) => {
   const searchUrl = new URL('https://github.com/mdn/browser-compat-data/pulls');
   const querySafeDate = previousReleaseDate.replace('+', '%2B');
   searchUrl.search = `q=is:pr merged:>=${querySafeDate} label:"needs-release-note :newspaper:"`;
@@ -118,7 +120,7 @@ const notableChanges = previousReleaseDate => {
 
 const countFeatures = () => {
   let count = 0;
-  JSON.parse(JSON.stringify(bcd), k => {
+  JSON.parse(JSON.stringify(bcd), (k) => {
     if (k === '__compat') {
       count++;
     }
@@ -133,7 +135,7 @@ const makeURL = (version, body) => {
   // Adhering to RFC 3986 makes the full link clickable in Terminal.app
   const encodedBody = encodeURIComponent(body).replace(
     /[!'()*]/g,
-    c => `%${c.charCodeAt(0).toString(16)}`,
+    (c) => `%${c.charCodeAt(0).toString(16)}`,
   );
 
   return `${baseURL}?title=${version}&tag=${version}&body=${encodedBody}`;

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -10,7 +10,7 @@ const bcd = require('..');
 const { argv } = require('yargs').command(
   '$0 [folder]',
   'Print a markdown-formatted table displaying the statistics of real, ranged, true, and null values for each browser',
-  yargs => {
+  (yargs) => {
     yargs
       .positional('folder', {
         describe: 'Limit the statistics to a specific folder',
@@ -50,7 +50,7 @@ const checkSupport = (supportData, type) => {
   }
   if (type == '≤') {
     return supportData.some(
-      item =>
+      (item) =>
         (typeof item.version_added == 'string' &&
           item.version_added.startsWith('≤')) ||
         (typeof item.version_removed == 'string' &&
@@ -58,7 +58,7 @@ const checkSupport = (supportData, type) => {
     );
   }
   return supportData.some(
-    item => item.version_added === type || item.version_removed === type,
+    (item) => item.version_added === type || item.version_removed === type,
   );
 };
 
@@ -72,7 +72,7 @@ const checkSupport = (supportData, type) => {
  */
 const processData = (data, browsers, stats) => {
   if (data.support) {
-    browsers.forEach(browser => {
+    browsers.forEach((browser) => {
       stats[browser].all++;
       stats.total.all++;
       if (!data.support[browser]) {
@@ -139,7 +139,7 @@ const getStats = (folder, allBrowsers) => {
 
   /** @type {object.<string, VersionStats>} */
   let stats = { total: { all: 0, true: 0, null: 0, range: 0, real: 0 } };
-  browsers.forEach(browser => {
+  browsers.forEach((browser) => {
     stats[browser] = { all: 0, true: 0, null: 0, range: 0, real: 0 };
   });
 
@@ -184,7 +184,7 @@ const printStats = (stats, folder) => {
 | --- | --- | --- | --- | --- |
 `;
 
-  Object.keys(stats).forEach(entry => {
+  Object.keys(stats).forEach((entry) => {
     table += `| ${entry.replace('_', ' ')} | `;
     table += `${((stats[entry].real / stats[entry].all) * 100).toFixed(2)}% | `;
     table += `${((stats[entry].range / stats[entry].all) * 100).toFixed(

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -4,7 +4,7 @@ const bcd = require('..');
 const { argv } = require('yargs').command(
   '$0 <browser> [folder] [value]',
   'Test for specified values in any specified browser',
-  yargs => {
+  (yargs) => {
     yargs
       .positional('browser', {
         describe: 'The browser to test for',

--- a/test/lint.js
+++ b/test/lint.js
@@ -25,7 +25,7 @@ const filesWithErrors = new Map();
 
 const argv = yargs
   .alias('version', 'v')
-  .usage('$0 [[--] files...]', false, yargs => {
+  .usage('$0 [[--] files...]', false, (yargs) => {
     return yargs.positional('files...', {
       description: 'The files to lint',
       type: 'string',
@@ -120,7 +120,7 @@ function load(...files) {
           hasRealValueErrors,
           hasPrefixErrors,
           hasDescriptionsErrors,
-        ].some(x => !!x);
+        ].some((x) => !!x);
 
         if (fileHasErrors) {
           filesWithErrors.set(relativeFilePath, file);
@@ -133,7 +133,7 @@ function load(...files) {
       return prevHasErrors || fileHasErrors;
     }
 
-    const subFiles = fs.readdirSync(file).map(subfile => {
+    const subFiles = fs.readdirSync(file).map((subfile) => {
       return path.join(file, subfile);
     });
 

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -47,7 +47,7 @@ function processData(
     const support = data.__compat.support;
 
     const invalidEntries = Object.keys(support).filter(
-      value => !displayBrowsers.includes(value),
+      (value) => !displayBrowsers.includes(value),
     );
     if (invalidEntries.length > 0) {
       logger.error(
@@ -58,7 +58,7 @@ function processData(
     }
 
     const missingEntries = requiredBrowsers.filter(
-      value => !(value in support),
+      (value) => !(value in support),
     );
     if (missingEntries.length > 0) {
       logger.error(

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -66,8 +66,8 @@ class ConsistencyChecker {
     }
 
     // Check sub-features.
-    const keys = Object.keys(data).filter(key => key != '__compat');
-    keys.forEach(key => {
+    const keys = Object.keys(data).filter((key) => key != '__compat');
+    keys.forEach((key) => {
       allErrors = [
         ...allErrors,
         ...this.checkSubfeatures(data[key], [...path, key]),
@@ -85,7 +85,7 @@ class ConsistencyChecker {
     /** @type {FeatureError[]} */
     let errors = [];
 
-    const subfeatures = Object.keys(data).filter(key =>
+    const subfeatures = Object.keys(data).filter((key) =>
       this.isFeature(data[key]),
     );
 
@@ -95,16 +95,16 @@ class ConsistencyChecker {
     /** @type {Partial<Record<string, [string, VersionValue][]>>} */
     var inconsistentSubfeaturesByBrowser = {};
 
-    subfeatures.forEach(subfeature => {
+    subfeatures.forEach((subfeature) => {
       const unsupportedInChild = this.extractUnsupportedBrowsers(
         data[subfeature].__compat,
       );
 
       const browsers = unsupportedInParent.filter(
-        x => !unsupportedInChild.includes(x),
+        (x) => !unsupportedInChild.includes(x),
       );
 
-      browsers.forEach(browser => {
+      browsers.forEach((browser) => {
         inconsistentSubfeaturesByBrowser[browser] =
           inconsistentSubfeaturesByBrowser[browser] || [];
         const subfeature_value =
@@ -117,7 +117,7 @@ class ConsistencyChecker {
     });
 
     // Add errors
-    Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
+    Object.keys(inconsistentSubfeaturesByBrowser).forEach((browser) => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'unsupported';
       const parent_value = data.__compat.support[browser].version_added;
@@ -137,16 +137,16 @@ class ConsistencyChecker {
     );
     inconsistentSubfeaturesByBrowser = {};
 
-    subfeatures.forEach(subfeature => {
+    subfeatures.forEach((subfeature) => {
       const supportUnknownInChild = this.extractSupportNotTrueBrowsers(
         data[subfeature].__compat,
       );
 
       const browsers = supportUnknownInParent.filter(
-        x => !supportUnknownInChild.includes(x),
+        (x) => !supportUnknownInChild.includes(x),
       );
 
-      browsers.forEach(browser => {
+      browsers.forEach((browser) => {
         inconsistentSubfeaturesByBrowser[browser] =
           inconsistentSubfeaturesByBrowser[browser] || [];
         const subfeature_value =
@@ -159,7 +159,7 @@ class ConsistencyChecker {
     });
 
     // Add errors
-    Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
+    Object.keys(inconsistentSubfeaturesByBrowser).forEach((browser) => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'support_unknown';
       const parent_value = data.__compat.support[browser].version_added;
@@ -178,8 +178,8 @@ class ConsistencyChecker {
     );
     inconsistentSubfeaturesByBrowser = {};
 
-    subfeatures.forEach(subfeature => {
-      supportInParent.forEach(browser => {
+    subfeatures.forEach((subfeature) => {
+      supportInParent.forEach((browser) => {
         if (
           data[subfeature].__compat.support[browser] != undefined &&
           this.isVersionAddedGreater(
@@ -200,7 +200,7 @@ class ConsistencyChecker {
     });
 
     // Add errors
-    Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
+    Object.keys(inconsistentSubfeaturesByBrowser).forEach((browser) => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'subfeature_earlier_implementation';
       const parent_value = data.__compat.support[browser].version_added;
@@ -231,7 +231,7 @@ class ConsistencyChecker {
   extractUnsupportedBrowsers(compatData) {
     return this.extractBrowsers(
       compatData,
-      data =>
+      (data) =>
         data.version_added === false ||
         (typeof data.version_removed !== 'undefined' &&
           data.version_removed !== false),
@@ -245,7 +245,7 @@ class ConsistencyChecker {
   extractSupportUnknownBrowsers(compatData) {
     return this.extractBrowsers(
       compatData,
-      data => data.version_added === null,
+      (data) => data.version_added === null,
     );
   }
 
@@ -256,7 +256,7 @@ class ConsistencyChecker {
   extractSupportNotTrueBrowsers(compatData) {
     return this.extractBrowsers(
       compatData,
-      data =>
+      (data) =>
         data.version_added === false ||
         data.version_added === null ||
         (typeof data.version_removed !== 'undefined' &&
@@ -270,7 +270,7 @@ class ConsistencyChecker {
   extractSupportedBrowsersWithVersion(compatData) {
     return this.extractBrowsers(
       compatData,
-      data => typeof data.version_added === 'string',
+      (data) => typeof data.version_added === 'string',
     );
   }
 
@@ -339,7 +339,7 @@ class ConsistencyChecker {
    * @return {string[]}
    */
   extractBrowsers(compatData, callback) {
-    return Object.keys(compatData.support).filter(browser => {
+    return Object.keys(compatData.support).filter((browser) => {
       const browserData = compatData.support[browser];
 
       if (Array.isArray(browserData)) {
@@ -390,7 +390,7 @@ function testConsistency(filename) {
           );
         }
 
-        subfeatures.forEach(subfeature => {
+        subfeatures.forEach((subfeature) => {
           console.error(
             chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${
               subfeature[1] === undefined ? '[Array]' : subfeature[1]

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -22,7 +22,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`,
-    match => {
+    (match) => {
       return {
         issue: 'Use shortenable URL',
         expected: `https://bugzil.la/${match[1]}`,
@@ -35,7 +35,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`https?://(bugs\.chromium\.org|code\.google\.com)/p/chromium/issues/detail\?id=(\d+)`,
-    match => {
+    (match) => {
       return {
         issue: 'Use shortenable URL',
         expected: `https://crbug.com/${match[2]}`,
@@ -48,7 +48,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`https?://bugs\.webkit\.org/show_bug\.cgi\?id=(\d+)`,
-    match => {
+    (match) => {
       return {
         issue: 'Use shortenable URL',
         expected: `https://webkit.org/b/${match[1]}`,
@@ -61,7 +61,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`(....)<a href='((https?)://(bugzil\.la|crbug\.com|webkit\.org/b)/(\d+))'>(.*?)</a>`,
-    match => {
+    (match) => {
       const [, before, url, protocol, domain, bugId, linkText] = match;
 
       if (protocol !== 'https') {
@@ -102,7 +102,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`\b(https?)://((?:[a-z][a-z0-9-]*\.)*)developer.mozilla.org/(.*?)(?=["'\s])`,
-    match => {
+    (match) => {
       const [, protocol, subdomain, path] = match;
       const [, locale, expectedPath_] = /^(?:(\w\w(?:-\w\w)?)\/)?(.*)$/.exec(
         path,
@@ -159,7 +159,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`https?://developer.microsoft.com/(\w\w-\w\w)/(.*?)(?=["'\s])`,
-    match => {
+    (match) => {
       return {
         issue: 'Use non-localized Microsoft Developer URL',
         expected: `https://developer.microsoft.com/${match[2]}`,
@@ -171,7 +171,7 @@ function processData(filename) {
     errors,
     actual,
     String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`,
-    match => {
+    (match) => {
       if (url.parse(match[1]).hostname === null) {
         return {
           issue: 'Include hostname in URL',

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -22,7 +22,7 @@ function checkPrefix(data, category, errors, prefix, path = '') {
           category == 'api' && !data[key].startsWith(prefix),
           category == 'css' && !data[key].startsWith(`-${prefix}`),
         ];
-        if (rules.some(x => x === true)) {
+        if (rules.some((x) => x === true)) {
           errors.push(error);
         }
       }

--- a/test/linter/test-schema.js
+++ b/test/linter/test-schema.js
@@ -27,7 +27,7 @@ function testSchema(
     );
     // Output messages by one since better-ajv-errors wrongly joins messages
     // (see https://github.com/atlassian/better-ajv-errors/pull/21)
-    ajv.errors.forEach(e => {
+    ajv.errors.forEach((e) => {
       console.error(betterAjvErrors(schema, data, [e], { indent: 2 }));
     });
     return true;

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -33,10 +33,10 @@ function testToken(feature, matches, misses) {
     feature.__compat.matches.regex_value;
   const regexp = new RegExp(str);
 
-  matches.forEach(match =>
+  matches.forEach((match) =>
     assert.ok(regexp.test(match), `${regexp} did not match ${match}`),
   );
-  misses.forEach(miss =>
+  misses.forEach((miss) =>
     assert.ok(!regexp.test(miss), `${regexp} erroneously matched ${miss}`),
   );
 }
@@ -64,5 +64,5 @@ const tests = [
 ];
 
 tests.forEach(({ features, matches, misses }) => {
-  features.forEach(feature => testToken(lookup(feature), matches, misses));
+  features.forEach((feature) => testToken(lookup(feature), matches, misses));
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -30,7 +30,7 @@ const IS_WINDOWS = platform() === 'win32';
 function escapeInvisibles(str) {
   // This should now be O(n) instead of O(n*m),
   // where n = string length; m = invisible characters
-  return INVISIBLES_REGEXP[Symbol.replace](str, char => {
+  return INVISIBLES_REGEXP[Symbol.replace](str, (char) => {
     return INVISIBLES_MAP[char] || char;
   });
 }


### PR DESCRIPTION
This PR changes the `arrowParens` configuration for Prettier to the new v2 default (which is "always") by removing it.  Additionally, this PR runs a fix to resolve all of the formatting issues in result to this change.

Fixes #7163.