### PR TITLE
Add WebGL extensions data for Safari and Safari iOS/iPadOS

### DIFF
--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "8.0"

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "12.0"

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -79,7 +79,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -36,10 +36,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -60,10 +60,10 @@
             }
           ],
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": [
             {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -42,10 +42,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": true
+            "version_added": "9.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "9.3"
           },
           "samsunginternet_android": {
             "version_added": "2.0"

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -37,10 +37,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "14"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -92,10 +92,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -60,10 +60,10 @@
             }
           ],
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": [
             {

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -43,10 +43,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "9"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -104,10 +104,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -60,10 +60,10 @@
             }
           ],
           "safari": {
-            "version_added": null
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "8"
           },
           "samsunginternet_android": [
             {
@@ -126,10 +126,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -181,10 +181,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for the WebGL extensions for both Safari and Safari iOS/iPadOS using results from the mdn-bcd-collector project (Safari 3-14 and Safari iOS 3-14).  Results for Safari iOS were collected and not mirrored, verifying differences between it and Safari Desktop by hand.