### PR TITLE
Correct WebGL extensions data for Safari and Safari iOS/iPadOS

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -29,7 +29,7 @@
             "version_added": "19"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": {
             "version_added": "8"
@@ -76,7 +76,7 @@
               "version_added": "19"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -124,7 +124,7 @@
               "version_added": "19"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -172,7 +172,7 @@
               "version_added": "19"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -40,7 +40,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "3.0"

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -33,7 +33,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "3.0"

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -40,7 +40,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "4.0"

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -30,10 +30,10 @@
             "version_added": "25"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": "3.0"


### PR DESCRIPTION
This PR corrects the data for the WebGL extensions for both Safari and Safari iOS/iPadOS using results from the mdn-bcd-collector project (Safari 3-14 and Safari iOS 3-14). Results for Safari iOS were collected and not mirrored (as may be evident by the diff on Safari iOS but not Safari Desktop), verifying the differences by hand.