### PR TITLE
Changed chrome support for devtools.panels.themeName

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -553,7 +553,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/themeName",
               "support": {
                 "chrome": {
-                  "version_added": "54"
+                  "version_added": "59"
                 },
                 "edge": {
                   "version_added": "79"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

## Summary

The browser compatibility data for `devtools.panels.themeName` currently says Chrome 54 while the documentation:
https://developer.chrome.com/extensions/devtools_panels#property-themeName
Clearly says that it has been available **since Chrome 59**.

## Data

The documentation for the `themeName` property: https://developer.chrome.com/extensions/devtools_panels#property-themeName

## Related

Please see #7307 
This pull request fixes the change