### PR TITLE
Update Firefox Android support for tracklisting in grid-auto-columns and grid-auto-rows

### DIFF
--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -68,7 +68,11 @@
             ],
             "firefox_android": [
               {
+                "version_added": "79"
+              },
+              {
                 "version_added": "52",
+                "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -68,7 +68,11 @@
             ],
             "firefox_android": [
               {
+                "version_added": "79"
+              },
+              {
                 "version_added": "52",
+                "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },


### PR DESCRIPTION
While working on https://github.com/mdn/sprints/issues/3835 spotted that the support for a tracklisting in `grid-auto-columns` and `grid-auto-rows` for Firefox Android hadn't been updated.

Have tested this using Browserstack also and the value works as expected now.
