### PR TITLE
Update MediaQueryList support for Safari. (inheriting EventTarget)

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -126,10 +126,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "!4"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -129,7 +129,7 @@
               "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "!4"
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
Well, it shipped in Safari 14.

I suppose #6745 barely missed making this change, since it updated the `onchange` support.

https://bugs.webkit.org/show_bug.cgi?id=203288#c21 commit landing in april 2020. 

saf 14 shipped in june 2020.

I tested saf 14 and indeed it has it all there:

![image](https://user-images.githubusercontent.com/39191/98911318-4314a000-2479-11eb-82a2-eea53bbc080d.png)


context: i started looking at this because of https://github.com/paulirish/matchMedia.js/issues/86