### PR TITLE
Add Safari iOS 3 as ranged version

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -264,6 +264,8 @@ For certain browsers, ranged versions are allowed as it is sometimes impractical
   - "≤14" (supported in some version of Chromium-based Opera and possibly in Presto-based Opera)
 - Safari
   - "≤4" (earliest Safari version supported in BrowserStack)
+- Safari iOS
+  - "≤3" (earliest Safari iOS version supported in BrowserStack)
 - WebView Android
   - "≤37" (supported in former Android versions prior to Chrome-based WebView)
 

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -21,6 +21,7 @@ const VERSION_RANGE_BROWSERS = {
   opera_android: ['≤12.1', '≤14'],
   edge: ['≤18', '≤79'],
   safari: ['≤4'],
+  safari_ios: ['≤3'],
 };
 
 /** @type string[] */


### PR DESCRIPTION
This PR is a sibling to #6915.  Due to the challenges of testing Safari Desktop 1 through 2, and the lack of Safari Desktop 3 in BrowserStack (plus iOS 1-2), there are quite a few Safari iOS versions that we will not be able to easily mirror data, or otherwise obtain real data, for.  Since iOS 3 is the earliest iOS version available on BrowserStack, I figured it makes sense for us to add it as a ranged version.