### PR TITLE
Revert change to webextensions.api.downloads.download.saveAs for desktop Firefox

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -1026,8 +1026,7 @@
                 },
                 "firefox": {
                   "notes": "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference.",
-                  "version_added": "52",
-                  "version_removed": "79"
+                  "version_added": "52"
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
#6590 appears to have introduced an erroneous change to desktop Firefox data, when applying changes to many Firefox for Android values. This reverts that change, like #7035 did for `webextensions.api.tabs.discard`.