### PR TITLE
Update Safari document.visibilityState "prerender"

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11589,7 +11589,7 @@
               "notes": "Doesn't fire the <code>visibilitychange</code> event when the browser window is minimized, nor when <code>hidden</code> is set to true."
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -11642,10 +11642,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "7"
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
https://trac.webkit.org/changeset/150695/webkit#file13 seems to indicate support for `prerender` was included when Safari first shipped with unprefixed `document.visibilityState` support. Per https://trac.webkit.org/browser/webkit/branches/safari-537.43-branch/Source/WebCore/dom/Document.idl#L381 that means it was included WebKit 537.43, which puts it in macOS Safari 6.1, and in iOS Safari 7. This is a follow-up to https://github.com/mdn/browser-compat-data/pull/7334. cc @jakub-g