### PR TITLE
Add note about partial srcset/sizes support in Safari before version 9

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -154,7 +154,8 @@
                 },
                 {
                   "version_added": "7",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
               "safari_ios": [
@@ -163,7 +164,8 @@
                 },
                 {
                   "version_added": "8",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
               "samsunginternet_android": {
@@ -284,7 +286,8 @@
                 },
                 {
                   "version_added": "7",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
               "safari_ios": [
@@ -293,7 +296,8 @@
                 },
                 {
                   "version_added": "8",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
               "samsunginternet_android": {


### PR DESCRIPTION
This change adds notes fields to explain why `html.elements.source.srcset` `html.elements.source.sizes` are marked as `partial_implementation` for Safari 7. Relates to https://github.com/mdn/browser-compat-data/issues/4162.