### PR TITLE
Update Firefox for android video autoplay support

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -125,7 +125,8 @@
                 "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "Will most likely not work. Disabled by default for all users whether the video is silent or not. Users to have manually opt-in for all websites. Developpers can not ask users to opt-in for the feature on their website."
               },
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
**Summary :** Adding note stating the current firefox for android state regarding video autoplay. Currently, the feature is most likely not working for most if not all users.

**Justification :**
It is safe to say that a developper using "caniuse.com" expects to know if the feature will "most likely work for a percentage of users" and on which platform (thus trying to answer to the question "can I use it ?").
In the case of Firefox for android the answer is "it will most likely not work" as
- the setting is disabled by default. 
- At no time during installation are you prompted to opt-in or out of the feature. 
- Web developpers can not ask for user consent to use the feature
- The setting is hidden
Adding this note is the bare minimum and I would even consider changing the status to "partial support" to make it evident in the graphs and stats that you must expect that the feature is not working instead of the opposite.

**Sources:**
The last patch note signaling the an update to the "autoplay" feature dates back to firefox for android version 66.
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66
This update states that any media element **with audio** will be blocked. But this is not the current state of the feature as all media will be blocked.
Every piece of mozilla's documentation states that "muted media element" should autoplay just fine. Which might signify that it is a oversight (or a bug ?). But it is the current state of the browser and is presented as a feature.

**Testing:**
Version tested on : 82.1.3 (Build #2015774643)
Using the Recommended (default) settings : "Block audio and video" loading a page with a video element with autoplay but also without audio track, and muted, and volume at 0 : the video is frozen.
Using the setting "Block only audio" and restarting the browser : the video plays.
Video plays by default on other browsers

**Related:**
Google article on consequences of disabling autoplay and why is it important for developpers to have accurate data on if they can use the feature or not : https://developers.google.com/web/updates/2016/07/autoplay
Dev.com's article on important benefits of the feature over older (but supported) technologies : https://web.dev/replace-gifs-with-videos/
