### PR TITLE
Update scroll-behavior.json

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -30,10 +30,22 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "CSSOM View Smooth Scrolling"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "CSSOM View Smooth Scrolling"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
After updating my Mac OS and testing this feature in Safari 14.0.1, this feature still does not work. I am setting the `version_added` for Safari and iOS to `false`. This is validated [here](https://caniuse.com/css-scroll-behavior).



A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
