### PR TITLE
HTTP Upgrade header

### DIFF
--- a/http/headers/upgrade.json
+++ b/http/headers/upgrade.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Upgrade": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade",
+          "support": {
+            "chrome": {
+              "version_added": "true"
+            },
+            "chrome_android": {
+              "version_added": "true"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/upgrade.json
+++ b/http/headers/upgrade.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade",
           "support": {
             "chrome": {
-              "version_added": "true"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "true"
+              "version_added": true
             },
             "edge": {
               "version_added": true


### PR DESCRIPTION
HTTP upgrade header is HTTP1.1 (only) header that can be used to upgrade a connection to using another protocol - e.g. HTTP2. Mostly commonly it is used for upgrading an HTTP or HTTPS connection to a websocket. I just added a new page for this on MDN and it could use a BCD entry. Page is here: https://wiki.developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade

@ddbeck We've had some discussion about whether some headers are relevant; I'm still not certain of "all" the logic for making that decision, but I think this one is. At least it is clear what a browser must do to be compliant - it must switch to the supported protocol it has requested if it gets the switched protocol status from a server.

Anything that supports websockets probably supports this header and there is plenty of better evidence that this header is supported in Firefox and also in Chromium. However, I can't find any version information.

Feeling pretty useless, but decided to post this for discussion.