### PR TITLE
Update Safari 14 release notes URL

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -169,7 +169,7 @@
         },
         "14": {
           "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -160,7 +160,7 @@
         },
         "14": {
           "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"


### PR DESCRIPTION
The PR changes the `release_notes` for Safari 14. The old value was referring to the beta release notes.

I would be inclined to change the `release_date` to be aligned with the macOS Big Sur release but I'm not 100% sure this is the official value. Anyone able to assist here?