### PR TITLE
window#[focus|blur] events: document Firefox compat issue

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -927,7 +927,8 @@
             },
             "firefox": [
               {
-                "version_added": true
+                "version_added": true,
+                "notes": "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>."
               },
               {
                 "version_added": true,
@@ -2348,7 +2349,8 @@
             },
             "firefox": [
               {
-                "version_added": true
+                "version_added": true,
+                "notes": "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>."
               },
               {
                 "version_added": true,


### PR DESCRIPTION
Quickly testing against Chrome and Safari, Firefox is the only browser firing `focus` on `document`.
Also the parity flags on https://bugzilla.mozilla.org/show_bug.cgi?id=1228802 show that.