### PR TITLE
is and where chrome

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -8,6 +8,10 @@
           "support": {
             "chrome": [
               {
+                "version_added": "88"
+              },
+              {
+                "version_removed": "88",
                 "version_added": "68",
                 "flags": [
                   {
@@ -38,6 +42,9 @@
               }
             ],
             "chrome_android": [
+              {
+                "version_added": "88"
+              },
               {
                 "version_added": "66",
                 "version_removed": "71",
@@ -211,11 +218,16 @@
                 "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": "≤37",
-              "alternative_name": ":-webkit-any()",
-              "notes": "Doesn't support combinators."
-            }
+            "webview_android": [
+              {
+                "version_added": "88"
+              },
+              {
+                "version_added": "≤37",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -229,10 +241,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false
@@ -262,7 +274,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "88"
               }
             },
             "status": {

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -6,26 +6,38 @@
           "description": "<code>:where()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
           "support": {
-            "chrome": {
-              "version_added": "72",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "72",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "88"
+              },
+              {
+                "version_added": "72",
+                "version_removed": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "88"
+              },
+              {
+                "version_added": "72",
+                "version_removed": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -67,7 +79,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "88"
             }
           },
           "status": {
@@ -82,10 +94,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:where",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false
@@ -115,7 +127,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "88"
               }
             },
             "status": {


### PR DESCRIPTION
While looking up support info for `:not()` saw that Chrome are shipping support for `is()` and `where()`.

https://groups.google.com/a/chromium.org/g/blink-dev/c/Wodp9dSSdL8/m/OZo2vJqTAwAJ

I also tested the examples on our pages. The intent to ship above also confirms that Safari does not implement the forgiving selector list support (though it is fixed in webkit).
