### PR TITLE
Update Safari data for File APIs

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -43,10 +43,10 @@
             "version_added": "11.5"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -188,10 +188,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6.1",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "7",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -236,10 +238,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -284,10 +286,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -32,7 +32,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3.2"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -33,7 +33,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6.1"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -80,7 +80,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -184,7 +184,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6",
+              "version_added": "6.1",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "safari_ios": {
@@ -446,7 +446,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -494,7 +494,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -542,7 +542,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -590,7 +590,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -638,7 +638,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -738,7 +738,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -786,7 +786,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -835,7 +835,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -883,7 +883,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -928,7 +928,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "6.1"
@@ -976,7 +976,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": "6.1"

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -29,10 +29,12 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6",
+            "version_removed": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6",
+            "version_removed": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +78,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +128,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +178,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +228,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -324,10 +334,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR uses Safari (4-14) and Safari iOS (3-14) results from the mdn-bcd-collector project to update four File APIs.