### PR TITLE
Add real data for Safari for HTML element APIs

### DIFF
--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -30,10 +30,12 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4",
+            "version_removed": "10"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "≤3",
+            "version_removed": "10"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -78,10 +80,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -127,10 +131,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -176,10 +182,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -48,7 +48,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -111,7 +111,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -650,10 +650,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -847,10 +847,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -1054,10 +1054,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1933,10 +1933,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -2365,10 +2365,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -701,10 +701,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -170,10 +170,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -246,10 +246,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -799,10 +799,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1603,10 +1603,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -36,10 +36,12 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "5.1",
+            "version_removed": "13.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "5",
+            "version_removed": "13.4"
           },
           "samsunginternet_android": {
             "version_added": true,

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -596,10 +596,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -689,7 +689,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -744,7 +747,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -888,7 +891,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1404,7 +1407,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "version_removed": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "6",
+              "version_removed": "7"
             }
           },
           "status": {
@@ -1685,7 +1693,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -2300,10 +2311,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3371,7 +3382,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -174,10 +174,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -269,10 +269,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -413,10 +413,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -87,7 +87,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR uses Safari (4-14) and Safari iOS (3-14) results from the mdn-bcd-collector project to add real values for the HTML element APIs.