### PR TITLE
Update exportparts HTML attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -959,7 +959,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "72"
             },
             "firefox_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -962,7 +962,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Mark `exportparts` HTML attribute as supported since Firefox 72. 

Related issues for part forwarding are resolved & fixed: 

https://bugzilla.mozilla.org/show_bug.cgi?id=1559076
https://bugzilla.mozilla.org/show_bug.cgi?id=1594275
