### PR TITLE
Added Chrome version for prefer_related_applications

### DIFF
--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/prefer_related_applications",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "44"
             },
             "chrome_android": {
               "version_added": null

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/prefer_related_applications",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "edge": {
               "version_added": null

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -9,7 +9,7 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

# Summary

Added Chrome version for `prefer_related_applications`

# Data

Commits in the chromium repository show `prefer_related_applications` being used as early as Chrome 44:
https://github.com/chromium/chromium/commit/51f7dbdc3d92a014d96f13c3193fed86cd063463

I searched through: https://github.com/chromium/chromium/search?o=asc&q=prefer_related_applications&s=indexed