### PR TITLE
Mark IDBCursor.prototype.request unsupported in Safari

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -607,10 +607,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
This change marks `IDBCursor.prototype.request` unsupported in Safari and iOS Safari.

Test: https://wpt.live/IndexedDB/idlharness.any.html

See also https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Modules/indexeddb/IDBCursor.idl#L37