### PR TITLE
Mark MediaError.prototype.message unsupported in Safari

### DIFF
--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -124,7 +124,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This change marks `MediaError.prototype.message` unsupported in Safari and iOS Safari.

Test: https://wpt.live/html/dom/idlharness.https.html

See also: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/html/MediaError.idl#L30