### PR TITLE
Mark MessagePort.prototype.onmessageerror unsupported in Safari

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -293,10 +293,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This change marks `MessagePort.prototype.onmessageerror` unsupported in Safari and iOS Safari.

Test: https://wpt.live/html/dom/idlharness.https.html

See also https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/MessagePort.idl#L39