### PR TITLE
Mark navigator.hardwareConcurrency unsupported in Safari

### DIFF
--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -29,10 +29,10 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -76,10 +76,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -124,10 +124,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This change adds real support data for `navigator.hardwareConcurrency` in Safari.

https://trac.webkit.org/changeset/169017/webkit added the support, so per
https://trac.webkit.org/browser/webkit/tags/Safari-601.1.56/Source/WebCore/page/Navigator.idl#L40 that puts in the WebKit version which shipped in Safari 9 — because per https://trac.webkit.org/browser/webkit/tags/Safari-538.35/Source/WebCore/page/Navigator.idl#L38 it did not ship in Safari 8.

However, it shipped behind a build flag — and that build flag was apparently never enabled by Apple for Safari releases.

https://trac.webkit.org/changeset/219372/webkit and https://trac.webkit.org/changeset/219379/webkit eventually removed the support from WebKit altogether. Per https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2011.0#WebCore/page that means it was removed in Safari 11 — because per https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2010.0/WebCore/page it was still present in the WebKit version that shipped with Safari 10.

Test: https://wpt.live/html/dom/idlharness.https.html

---

So there are a couple of complications with this change…

The first complication is that while the WebKit engine got support for this feature, it appears to have never been enabled any shipping Safari builds.  Therefore, we arguably could simply mark it as version_added:false.

The second complication is that if we *do* keep it marked up the way I have it in the initial commit in this branch, then it’s not correct to use `runtime_flag` as the flag type — because the relevant flag is a *build* flag, not a user-settable runtime flag.

<s>But I believe it’d be useful for us to have a `build` flag type — for cases like this one — so I’ll raise a separate PR for that.</s>

I raised https://github.com/mdn/browser-compat-data/pull/7393 but the resolution was that it was already considered in https://github.com/mdn/browser-compat-data/pull/3752 and the policy is that if a feature requires a compile/build flag to be enabled, then for our purposes we consider that feature unsupported.