### PR TITLE
schema: Allow `build` as a flag type for `flags`

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -329,6 +329,7 @@ An object in the `flags` array consists of three properties:
 - `type` (mandatory): an enum that indicates the flag type:
   - `preference` a flag the user can set (like in `about:config` in Firefox).
   - `runtime_flag` a flag to be set before starting the browser.
+  - `build` a flag to be set when building the browser.
 - `name` (mandatory): a string giving the value which the specified flag must be set to for this feature to work.
 - `value_to_set` (optional): representing the actual value to set the flag to.
   It is a string, that may be converted to the right type

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -24,7 +24,7 @@
               "type": {
                 "type": "string",
                 "description": "An enum that indicates the flag type.",
-                "enum": ["preference", "runtime_flag"]
+                "enum": ["preference", "runtime_flag", "build"]
               },
               "name": {
                 "type": "string",

--- a/types.d.ts
+++ b/types.d.ts
@@ -177,8 +177,9 @@ export interface SimpleSupportStatement {
      * An enum that indicates the flag type:
      * - `preference` a flag the user can set (like in `about:config` in Firefox).
      * - `runtime_flag` a flag to be set before starting the browser.
+     * - `build` a flag to be set when building the browser.
      */
-    type: 'preference' | 'runtime_flag';
+    type: 'preference' | 'runtime_flag' | 'build';
 
     /**
      * A `string` representing the flag or preference to modify.


### PR DESCRIPTION
This change updates our project compat-data schema to allow `build` as a flag type for the `flags` array, and updates to the accompanying schema docs to define the meaning of the flag.

https://github.com/mdn/browser-compat-data/pull/7392 is a case where having this `build` flag is useful.