### PR TITLE
Chrome 87 added support for text-underline-offset

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "87"
             },
             "edge": {
               "version_added": false
@@ -52,7 +52,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -6,11 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See Chrome Platform Status entry for <a href='https://chromestatus.com/feature/5747636764147712'>text-decoration-thickness, text-underline-offset and from-font keyword for text-underline-position</a>."
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "87"
             },
             "edge": {
               "version_added": false
@@ -52,7 +51,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -157,10 +157,10 @@
             "description": "<code>from-font</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "87"
               },
               "edge": {
                 "version_added": false
@@ -190,7 +190,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "87"
               }
             },
             "status": {


### PR DESCRIPTION
Changelog:
https://chromium.googlesource.com/chromium/src/+log/86.0.4240.198..87.0.4280.66?pretty=fuller&n=10000
Commit:
https://chromium.googlesource.com/chromium/src/+/6ee93f1d7e463530d9423c79b5a58ca2bf881dcb

Tested manually in Chrome 87’s inspector.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
