### PR TITLE
Correct Safari data for HTML Element APIs

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -604,10 +604,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -225,7 +225,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -273,7 +273,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -321,7 +321,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -366,10 +366,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -417,7 +417,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -465,7 +465,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -657,7 +657,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -705,7 +705,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -801,7 +801,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -882,7 +882,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1981,10 +1981,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -400,7 +400,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -703,7 +703,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -799,7 +799,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1154,7 +1154,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1299,7 +1299,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1981,10 +1981,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -2461,10 +2461,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3160,7 +3160,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -415,7 +415,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -463,7 +463,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -511,7 +511,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -223,7 +223,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -608,7 +608,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -946,7 +946,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -1091,7 +1091,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -825,7 +825,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -822,10 +822,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -822,10 +822,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1015,10 +1015,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -175,7 +175,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -225,7 +225,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -273,7 +273,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -318,10 +318,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -369,7 +369,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -414,10 +414,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -465,7 +465,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -513,7 +513,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -658,7 +658,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -850,7 +850,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -994,7 +994,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1148,7 +1148,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1314,7 +1314,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1366,7 +1366,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1414,7 +1414,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1462,7 +1462,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1654,7 +1654,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -318,10 +318,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -321,7 +321,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -79,7 +79,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -124,10 +124,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -359,10 +359,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -406,10 +406,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -77,10 +77,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -171,10 +171,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -218,10 +218,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -268,7 +268,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -315,7 +315,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -359,10 +359,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -406,10 +406,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -503,7 +503,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -547,10 +547,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1649,7 +1649,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -223,7 +223,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -895,7 +895,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1135,7 +1135,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1183,7 +1183,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1327,7 +1327,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -172,10 +172,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -224,10 +224,10 @@
               "notes": "Before Opera 37, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -277,7 +277,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -322,10 +322,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -373,7 +373,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -418,10 +418,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -466,10 +466,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -514,10 +514,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -562,10 +562,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -610,10 +610,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -658,10 +658,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLQuoteElement.json
+++ b/api/HTMLQuoteElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/api/HTMLQuoteElement.json
+++ b/api/HTMLQuoteElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -78,7 +78,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -221,10 +221,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -320,7 +320,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -560,7 +560,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -946,7 +946,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1090,7 +1090,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1234,7 +1234,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1282,7 +1282,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1378,7 +1378,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -801,7 +801,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -175,7 +175,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -271,7 +271,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -140,7 +140,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
This PR uses Safari (4-14) and Safari iOS (3-14) results from the mdn-bcd-collector project to correct the data for the HTML element APIs.  All results were double-checked for accuracy.