### PR TITLE
Correct Safari data for SVG element APIs

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -218,7 +218,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -34,7 +34,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,7 +81,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -129,7 +129,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/SVGAnimateMotionElement.json
+++ b/api/SVGAnimateMotionElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "9"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.5"

--- a/api/SVGAnimateTransformElement.json
+++ b/api/SVGAnimateTransformElement.json
@@ -29,7 +29,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "≤4"
           },
           "safari_ios": {
             "version_added": "3"

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -174,10 +174,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -222,10 +222,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -125,10 +125,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -372,10 +372,12 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -425,10 +427,12 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -478,10 +482,12 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -531,10 +537,12 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -584,10 +592,12 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -980,7 +980,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/SVGVKernElement.json
+++ b/api/SVGVKernElement.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "5.1"
           },
           "safari_ios": {
             "version_added": "5"


### PR DESCRIPTION
This PR uses Safari (4-14) and Safari iOS (3-14) results from the mdn-bcd-collector project to correct the data for the SVG element APIs. All results were double-checked for accuracy.