### PR TITLE
Remove Firefox 3.6.9

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -46,13 +46,6 @@
           "engine": "Gecko",
           "engine_version": "1.9.2"
         },
-        "3.6.9": {
-          "release_date": "2010-09-07",
-          "release_notes": "https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/3.6.9/releasenotes/",
-          "status": "retired",
-          "engine": "Gecko",
-          "engine_version": "1.9.2"
-        },
         "4": {
           "release_date": "2011-03-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/4",

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": true

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6.9"
+              "version_added": "3.6"
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
This PR removes Firefox 3.6.9 from the browser data.  There's only one feature that is explicitly set to Firefox 3.6.9 vs. just 3.6. It doesn't really make sense to keep it around for just that one feature. Furthermore, as per the data guidelines, we don't really say that we record path-level releases as it is.