### PR TITLE
Revert "Remove ConstrainULong/ULongRange (#6936)"

### DIFF
--- a/api/ConstrainULong.json
+++ b/api/ConstrainULong.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "ConstrainULong": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstrainULong",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/ULongRange.json
+++ b/api/ULongRange.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "ULongRange": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ULongRange",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Broadly speaking, we don't have an answer to the question of dictionaries; #7287 is open to address it. Narrowly, I don't how don't know how to extricate this content from MDN without rewriting several pages and we didn't discuss it before merging. See https://github.com/mdn/browser-compat-data/pull/6936#issuecomment-730386016 for additional notes.

This reverts commit ea8e8a7116e1c4751ee3232a2912d289c647648b and #6936.
