### PR TITLE
Update clear-site-data.json

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -45,7 +45,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -54,10 +54,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -117,7 +117,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "48"
@@ -126,10 +126,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -190,7 +190,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "48"
@@ -199,10 +199,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -267,7 +267,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": false
@@ -276,10 +276,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -340,7 +340,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "48"
@@ -349,10 +349,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
- IE11 was released 2013; the feature is from 2016 hence no support
- Safari bug: https://bugs.webkit.org/show_bug.cgi?id=203215