### PR TITLE
Add implementation_url to WritableStream in Safari

### DIFF
--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -29,10 +29,12 @@
             "version_added": "44"
           },
           "safari": {
-            "version_added": false
+            "version_added": false,
+            "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": false,
+            "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -77,10 +79,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -125,10 +129,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -173,10 +179,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -221,10 +229,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "implementation_url": "https://trac.webkit.org/changeset/266172/webkit"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This change adds an `implementation_url` value for `WritableStream` in Safari and iOS Safari, per https://trac.webkit.org/changeset/266172/webkit, which says:

> Implementation is now ready and is up to date with the latest specification.

As https://github.com/mdn/browser-compat-data/pull/6873#issuecomment-707688645 notes, that change means this feature shipped in at least TP 114 and probably was also in since TP 113.

---

Note that this is expected to fail CI unless/until https://github.com/mdn/browser-compat-data/pull/7396 gets merged