### PR TITLE
Add Safari data for CanvasRenderingContext2D

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1268,10 +1268,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1346,10 +1346,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2192,10 +2192,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2406,10 +2406,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2454,10 +2454,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2612,10 +2612,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2768,10 +2768,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3326,10 +3326,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR uses results from the mdn-bcd-collector project to add real Safari and Safari iOS values for various features of the CanvasRenderingContext2D API.  It is meant to be a continuation from #7422 (which adds Safari ≤4 and Safari iOS ≤3 data).

Note: some Safari iOS data was partially mirrored, specifically data for Safari iOS 9.3 and 10.0, since we do not have a way to collect results for those iOS versions, but can generate a range based upon results for 9.0 and 10.3.