### PR TITLE
Mark css.selectors.selector_list Firefox-supported

### DIFF
--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -63,10 +63,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "84"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This change marks the `css.selectors.selector_list` feature as supported in Firefox 84.

implementation_url: https://hg.mozilla.org/mozilla-central/rev/fd29ba131d13

Fixes https://github.com/mdn/browser-compat-data/issues/7408