### PR TITLE
Add media track API data for Safari

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -558,7 +558,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -651,10 +654,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -222,10 +222,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -270,10 +270,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -318,10 +318,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -366,10 +366,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -174,10 +174,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -225,7 +225,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/TrackDefault.json
+++ b/api/TrackDefault.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -77,7 +77,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -221,7 +221,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -317,7 +317,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/TrackDefaultList.json
+++ b/api/TrackDefaultList.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -173,10 +173,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -221,10 +221,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -317,10 +317,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -365,10 +365,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -413,10 +413,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -461,10 +461,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -509,10 +509,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -557,10 +557,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -605,10 +605,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari for various media track APIs (text track, VTT cue, etc.) based upon results from the mdn-bcd-collector project.