### PR TITLE
user-invalid pseudo

### DIFF
--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -1,10 +1,10 @@
 {
   "css": {
     "selectors": {
-      "-moz-ui-invalid": {
+      "invalid": {
         "__compat": {
-          "description": "<code>:-moz-ui-invalid</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-ui-invalid",
+          "description": "<code>:user-invalid</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid",
           "support": {
             "chrome": {
               "version_added": false
@@ -15,12 +15,24 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "::-moz-ui-invalid"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "::-moz-ui-invalid"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -44,8 +56,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "selectors": {
-      "invalid": {
+      "user-invalid": {
         "__compat": {
           "description": "<code>:user-invalid</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-invalid",

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -15,24 +15,14 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": false
-              },
-              {
+            "firefox": {
                 "version_added": "4",
                 "alternative_name": "::-moz-ui-invalid"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
+            },
+            "firefox_android": {
                 "version_added": "4",
                 "alternative_name": "::-moz-ui-invalid"
-              }
-            ],
+            },
             "ie": {
               "version_added": false
             },

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -16,12 +16,12 @@
               "version_added": false
             },
             "firefox": {
-                "version_added": "4",
-                "alternative_name": "::-moz-ui-invalid"
+              "version_added": "4",
+              "alternative_name": "::-moz-ui-invalid"
             },
             "firefox_android": {
-                "version_added": "4",
-                "alternative_name": "::-moz-ui-invalid"
+              "version_added": "4",
+              "alternative_name": "::-moz-ui-invalid"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/sprints/issues/1686

I have moved the non-standard `-moz-ui-invalid` page to the standard `user-invalid`. This PR created BCD for `:user-invalid` with `-moz-ui-invalid` as an alternate name. Then deletes `-moz-ui-invalid`