### PR TITLE
Safari supports Location.toString since ≤4

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -761,10 +761,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
Based upon results from the mdn-bcd-collector project, Safari supports the `toString` method of the `Location` API since Safari ≤4 / Safari iOS ≤3.