### PR TITLE
Add CSSFontFaceRule and CSSImportRule APIs

### DIFF
--- a/api/CSSFontFaceRule.json
+++ b/api/CSSFontFaceRule.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18"
           },
           "edge": {
-            "version_added": false
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "3.5"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
-            "version_added": false
+            "version_added": "≤15"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "≤14"
           },
           "safari": {
-            "version_added": false
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/CSSFontFaceRule.json
+++ b/api/CSSFontFaceRule.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "CSSFontFaceRule": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -1,0 +1,196 @@
+{
+  "api": {
+    "CSSImportRule": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "href": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/href",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "media": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/media",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "styleSheet": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/styleSheet",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18"
           },
           "edge": {
-            "version_added": false
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
-            "version_added": false
+            "version_added": "≤15"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "≤14"
           },
           "safari": {
-            "version_added": false
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/href",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -100,40 +100,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/media",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -148,40 +148,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/styleSheet",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds BCD data for two CSS rule APIs: the font face rule, and the import rule.  Versions were determined using the mdn-bcd-collector project, along with a slight bit of mirroring (Firefox -> Fenix, Chrome -> CrA, Opera, Opera Android, Samsung Internet, WebView).

These two interfaces are a part of DOM Level 2:
https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSFontFaceRule
https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSImportRule