### PR TITLE
Add FileSystem*Handle APIs

### DIFF
--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -1,0 +1,388 @@
+{
+  "api": {
+    "FileSystemDirectoryHandle": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "entries": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/entries",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getDirectoryHandle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFileHandle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getFileHandle",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keys": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/keys",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeEntry": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resolve": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "values": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/values",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "86"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "86"
           },
           "edge": {
-            "version_added": false
+            "version_added": "86"
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "72"
           },
           "opera_android": {
             "version_added": false
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/entries",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -148,13 +148,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getFileHandle",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -166,7 +166,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -196,13 +196,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/keys",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -214,7 +214,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -244,13 +244,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -292,13 +292,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -310,7 +310,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -340,13 +340,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/values",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -358,7 +358,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "86"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "86"
           },
           "edge": {
-            "version_added": false
+            "version_added": "86"
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "72"
           },
           "opera_android": {
             "version_added": false
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/getFile",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "FileSystemFileHandle": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "createWritable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/getFile",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -1,0 +1,292 @@
+{
+  "api": {
+    "FileSystemHandle": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "isSameEntry": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "kind": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/kind",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/name",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "queryPermission": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/queryPermission",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestPermission": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/requestPermission",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "86"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "86"
           },
           "edge": {
-            "version_added": false
+            "version_added": "86"
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "72"
           },
           "opera_android": {
             "version_added": false
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/kind",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -148,13 +148,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/name",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -166,7 +166,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -196,13 +196,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/queryPermission",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -214,7 +214,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -244,13 +244,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/requestPermission",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "86"
             },
             "edge": {
-              "version_added": false
+              "version_added": "86"
             },
             "firefox": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds data for three file system handler APIs: FileSystemHandle, FileSystemDirectoryHandle, and FileSystemFileHandle.  Versions were determined using the mdn-bcd-collector project, along with a slight bit of manual testing in Chrome Android, WebView, and Opera.

These are a part of a WICG draft:
https://wicg.github.io/file-system-access/#api-filesystemhandle
https://wicg.github.io/file-system-access/#api-filesystemfilehandle
https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle