### PR TITLE
Add PerformanceElementTiming API

### DIFF
--- a/api/PerformanceElementTiming.json
+++ b/api/PerformanceElementTiming.json
@@ -1,0 +1,532 @@
+{
+  "api": {
+    "PerformanceElementTiming": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/element",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/id",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "identifier": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/identifier",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "intersectionRect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/intersectionRect",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/loadTime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "naturalHeight": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalHeight",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "naturalWidth": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalWidth",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "renderTime": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/renderTime",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/toJSON",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/url",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PerformanceElementTiming.json
+++ b/api/PerformanceElementTiming.json
@@ -42,8 +42,8 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": true,
+          "experimental": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -89,8 +89,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -137,8 +137,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -185,8 +185,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -233,8 +233,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -281,8 +281,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -329,8 +329,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -377,8 +377,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -425,8 +425,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -473,8 +473,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -521,8 +521,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/PerformanceElementTiming.json
+++ b/api/PerformanceElementTiming.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "77"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "77"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "12.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "77"
           }
         },
         "status": {
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/element",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/id",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -148,13 +148,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/identifier",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -196,13 +196,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/intersectionRect",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -244,13 +244,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/loadTime",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -262,10 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -274,10 +274,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -292,13 +292,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalHeight",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -310,10 +310,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -322,10 +322,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -340,13 +340,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/naturalWidth",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -358,10 +358,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -370,10 +370,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -388,13 +388,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/renderTime",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -406,10 +406,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -418,10 +418,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -436,13 +436,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/toJSON",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -454,10 +454,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -466,10 +466,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -484,13 +484,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/url",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "77"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -502,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -514,10 +514,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds data for the PerformanceElementTiming API. Versions were determined using the mdn-bcd-collector project, along with a slight bit of manual testing in Chrome Android, WebView, and Opera.

These are a part of a WICG draft:
https://wicg.github.io/element-timing/#sec-performance-element-timing