### PR TITLE
Add Safari data for a few WebGL APIs

### DIFF
--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -41,10 +41,10 @@
             "version_removed": "48"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true,

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "14"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Safari for a few WebGL APIs based upon results from the mdn-bcd-collector project.