### PR TITLE
Add Safari data for DOMStringList/Map API

### DIFF
--- a/api/DOMStringList.json
+++ b/api/DOMStringList.json
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DOMStringList.json
+++ b/api/DOMStringList.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DOMStringMap.json
+++ b/api/DOMStringMap.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true


### PR DESCRIPTION
This PR adds Safari data for the DOMStringList and DOMStringMap APIs based upon results from the mdn-bcd-collector project.