### PR TITLE
Update Safari data for DocumentType API

### DIFF
--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,10 +79,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -128,10 +130,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -176,10 +180,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -227,10 +231,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -275,10 +281,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -323,10 +329,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates the Safari data for the DocumentType API using results from the mdn-bcd-collector project.