### PR TITLE
Add IE data for WebGL extension interfaces

### DIFF
--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -211,7 +211,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -67,7 +67,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -20,7 +20,7 @@
             "version_added": "53"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null
@@ -67,7 +67,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -30,7 +30,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true,

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -27,7 +27,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -39,7 +39,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": [
             {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -33,7 +33,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
             "version_added": true

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -28,7 +28,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -39,7 +39,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": [
             {

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -34,7 +34,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true
@@ -95,7 +95,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -39,7 +39,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": [
             {
@@ -117,7 +117,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds Internet Explorer data for various WebGL extensions based upon results from the mdn-bcd-collector project.