### PR TITLE
Update IE data for WebGL APIs

### DIFF
--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": null

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5582,7 +5582,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": false

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR updates the Internet Explorer data for various WebGL APIs based upon results from the mdn-bcd-collector project.