### PR TITLE
Update IE data for DocumentType API

### DIFF
--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_removed": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": false
@@ -119,7 +119,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -218,7 +218,7 @@
               "version_removed": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": false
@@ -266,7 +266,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -314,7 +314,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates the Internet Explorer data for the DocumentType API based upon results from the mdn-bcd-collector project.