### PR TITLE
Updates Edge to version 87

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -98,19 +98,26 @@
         "86": {
           "release_date": "2020-10-09",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-86062238-october-9",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "86"
         },
         "87": {
-          "status": "beta",
+          "release_date": "2020-11-19",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-87066441-november-19",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "87"
         },
         "88": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "88"
+        },
+        "89": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "89"
         }
       }
     }


### PR DESCRIPTION
In that PR, I updated the docs to version 87 of Edge.

https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-87066441-november-19