### PR TITLE
Update Firefox/Fenix data

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -602,23 +602,101 @@
         "82": {
           "release_date": "2020-10-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/82",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "82"
         },
         "83": {
           "release_date": "2020-11-17",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/83",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "83"
         },
         "84": {
           "release_date": "2020-12-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "84"
+        },
+        "85": {
+          "release_date": "2021-01-26",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "85"
+        },
+        "86": {
+          "release_date": "2021-02-23",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "86"
+        },
+        "87": {
+          "release_date": "2021-03-23",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "87"
+        },
+        "88": {
+          "release_date": "2021-04-30",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "88"
+        },
+        "89": {
+          "release_date": "2021-05-18",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "89"
+        },
+        "90": {
+          "release_date": "2021-06-15",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "90"
+        },
+        "91": {
+          "release_date": "2021-07-13",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "91"
+        },
+        "92": {
+          "release_date": "2021-08-10",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "92"
+        },
+        "93": {
+          "release_date": "2021-09-07",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "93"
+        },
+        "94": {
+          "release_date": "2021-10-05",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "94"
+        },
+        "95": {
+          "release_date": "2021-11-02",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "95"
+        },
+        "96": {
+          "release_date": "2021-12-07",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "96"
+        },
+        "97": {
+          "release_date": "2022-01-11",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "97"
         }
       }
     }

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -639,7 +639,7 @@
           "engine_version": "87"
         },
         "88": {
-          "release_date": "2021-04-30",
+          "release_date": "2021-04-20",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "88"

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -462,23 +462,101 @@
         "82": {
           "release_date": "2020-10-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/82",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "82"
         },
         "83": {
           "release_date": "2020-11-17",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/83",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "83"
         },
         "84": {
           "release_date": "2020-12-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "84"
+        },
+        "85": {
+          "release_date": "2021-01-26",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "85"
+        },
+        "86": {
+          "release_date": "2021-02-23",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "86"
+        },
+        "87": {
+          "release_date": "2021-03-23",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "87"
+        },
+        "88": {
+          "release_date": "2021-04-30",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "88"
+        },
+        "89": {
+          "release_date": "2021-05-18",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "89"
+        },
+        "90": {
+          "release_date": "2021-06-15",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "90"
+        },
+        "91": {
+          "release_date": "2021-07-13",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "91"
+        },
+        "92": {
+          "release_date": "2021-08-10",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "92"
+        },
+        "93": {
+          "release_date": "2021-09-07",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "93"
+        },
+        "94": {
+          "release_date": "2021-10-05",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "94"
+        },
+        "95": {
+          "release_date": "2021-11-02",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "95"
+        },
+        "96": {
+          "release_date": "2021-12-07",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "96"
+        },
+        "97": {
+          "release_date": "2022-01-11",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "97"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -499,7 +499,7 @@
           "engine_version": "87"
         },
         "88": {
-          "release_date": "2021-04-30",
+          "release_date": "2021-04-20",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "88"


### PR DESCRIPTION
This PR updates the browser data for Firefox and Fenix.  Firefox 83 has been released recently, so this sets Firefox 83 as "current".  Additionally, this adds new release data for future planned releases based upon data from the Firefox release calendar (https://wiki.mozilla.org/Release_Management/Calendar).