### PR TITLE
Add data for SVG element API features in IE 9

### DIFF
--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -114,7 +114,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -161,7 +161,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -212,7 +212,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -260,7 +260,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -308,7 +308,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -356,7 +356,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -404,7 +404,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -452,7 +452,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -254,7 +254,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -301,7 +301,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "15"

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -69,7 +69,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -123,7 +123,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -177,7 +177,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -231,7 +231,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -285,7 +285,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -339,7 +339,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -393,7 +393,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -447,7 +447,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -501,7 +501,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -555,7 +555,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -609,7 +609,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -663,7 +663,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -717,7 +717,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -771,7 +771,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -825,7 +825,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -879,7 +879,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -933,7 +933,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -987,7 +987,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1041,7 +1041,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1095,7 +1095,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1149,7 +1149,7 @@
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1199,7 +1199,7 @@
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -254,7 +254,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -301,7 +301,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -348,7 +348,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -70,7 +70,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -117,7 +117,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -164,7 +164,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -258,7 +258,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -305,7 +305,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -113,7 +113,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -208,7 +208,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -258,7 +258,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -354,7 +354,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -401,7 +401,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -448,7 +448,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -495,7 +495,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -542,7 +542,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -589,7 +589,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -636,7 +636,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -683,7 +683,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -730,7 +730,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -830,7 +830,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -877,7 +877,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -924,7 +924,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -971,7 +971,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1018,7 +1018,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1065,7 +1065,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1112,7 +1112,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1159,7 +1159,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1211,7 +1211,7 @@
               "version_removed": "61"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1269,7 +1269,7 @@
               "version_removed": "61"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1327,7 +1327,7 @@
               "version_removed": "61"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1385,7 +1385,7 @@
               "version_removed": "61"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -1438,7 +1438,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1485,7 +1485,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1532,7 +1532,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1579,7 +1579,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1626,7 +1626,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1726,7 +1726,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -1775,7 +1775,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1822,7 +1822,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1869,7 +1869,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -254,7 +254,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -301,7 +301,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -348,7 +348,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -395,7 +395,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -442,7 +442,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -489,7 +489,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -536,7 +536,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -113,7 +113,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -160,7 +160,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -207,7 +207,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -254,7 +254,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -69,7 +69,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -122,7 +122,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -225,7 +225,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -272,7 +272,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -319,7 +319,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates the Internet Explorer data for SVG element APIs based upon results from the mdn-bcd-collector project, cherry-picking changes involving IE 9. Results were manually verified for confirmation.