### PR TITLE
Mark unsupported SVG element API features in IE

### DIFF
--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -22,7 +22,7 @@
             "notes": "partial support, see <a href='https://bugzil.la/456286'>bug 456286</a> and <a href='https://bugzil.la/571808'>bug 571808</a>."
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "10.6"
@@ -69,7 +69,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "10.6"
@@ -117,7 +117,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "10.6"

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGColorProfileElement.json
+++ b/api/SVGColorProfileElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -116,7 +116,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "52"
@@ -164,7 +164,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "52"

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -779,7 +779,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true,
@@ -1675,7 +1675,7 @@
               "version_added": "15"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true,

--- a/api/SVGSolidcolorElement.json
+++ b/api/SVGSolidcolorElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null

--- a/api/SVGVKernElement.json
+++ b/api/SVGVKernElement.json
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR updates the Internet Explorer data for SVG element APIs based upon results from the mdn-bcd-collector project, cherry-picking changes that indicate no support. Results were manually verified for confirmation.