### PR TITLE
Correct SVG element API data for IE

### DIFF
--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": "9"
+            "version_added": false
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -20,7 +20,7 @@
             "version_added": "53"
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -69,7 +69,7 @@
               "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -119,7 +119,7 @@
               "notes": "Before version 53, this method was defined on the <a href='https://developer.mozilla.org/docs/Web/API/SVGPathElement'><code>SVGPathElement</code></a> interface, which inherits from this interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR corrects the existing Internet Explorer data for SVG element APIs based upon results from the mdn-bcd-collector project. Results were manually verified for confirmation.