### PR TITLE
Use Chrome Desktop to improve data mirroring for WebView

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,18 +74,18 @@ If the feature you're interested in is a JavaScript API, you can cross-reference
 
 Many browsers within BCD can be derived from other browsers given they share the same engine, for example Opera derives from Chrome, and Firefox Android derives from Firefox. To help cut down time working on copying values between browsers, a mirroring script is provided. You can run `npm run mirror <browser> <feature_or_file> [--source=""] [--modify=""]` to automatically copy values.
 
-The <browser> argument is the destination browser that values will be copied to. The script automatically determines what browser to copy from based upon the destination (see table below), but manual specification is possible through the `--source=""` argument.
+The <browser> argument is the destination browser that values will be copied to. The script automatically determines what browser to copy from based upon the destination (see table below), but manual specification is possible through the `--source=""` argument. (Mirroring data for Edge ignores this argument.)
 
-| Destination      | Default Source    |
-| ---------------- | ----------------- |
-| Chrome Android   | Chrome            |
-| Edge             | Internet Explorer |
-| Firefox Android  | Firefox           |
-| Opera            | Chrome            |
-| Opera Android    | Chrome Android    |
-| Safari iOS       | Safari            |
-| Samsung Internet | Chrome Android    |
-| WebView          | Chrome Android    |
+| Destination      | Default Source             |
+| ---------------- | -------------------------- |
+| Chrome Android   | Chrome                     |
+| Edge             | Internet Explorer + Chrome |
+| Firefox Android  | Firefox                    |
+| Opera            | Chrome                     |
+| Opera Android    | Chrome Android             |
+| Safari iOS       | Safari                     |
+| Samsung Internet | Chrome Android             |
+| WebView          | Chrome Android             |
 
 The <feature_or_filename> argument is either the identifier of the feature to update (i.e. `css.at-rules.namespace`), a filename (`javascript/operators/arithmetic.json`), or an entire folder (`api`).
 

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -447,13 +447,13 @@ const bumpWebView = (originalData, chromeAndroidData, chromeData) => {
   let newData = copyStatement(chromeAndroidData);
 
   const createWebViewRange = (version, desktopVersion) => {
-    if (Number(desktopVersion) == 1) {
+    if (desktopVersion === '1') {
       return '1';
-    } else if (Number(version) < 30) {
+    } else if (version >= 18 && version < 30) {
       return '≤37';
-    } else if (Number(version) >= 30 && Number(version) < 33) {
+    } else if (version >= 30 && version < 33) {
       return '4.4';
-    } else if (Number(version) >= 33 && Number(version) < 37) {
+    } else if (version >= 33 && version < 37) {
       return '4.4.3';
     } else {
       return version;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -223,7 +223,7 @@ const bumpChromeAndroid = (originalData, sourceData, source) => {
  * @returns {SupportStatement}
  */
 const bumpEdge = comp => {
-  let newData = comp['edge'];
+  let newData = copyStatement(comp['edge']);
   let originalData = comp['edge'];
   let ieData = comp['ie'];
   let chromeData = comp['chrome'];
@@ -258,13 +258,15 @@ const bumpEdge = comp => {
             newData.version_added = '≤79';
           }
         } else {
-          newData.version_added == chromeData.version_added;
+          newData.version_added = chromeData.version_added;
         }
       }
     } else if (chromeFalse) {
       if (originalData.version_added && !originalData.version_removed) {
         newData.version_removed = '79';
       }
+    } else if (chromeNull) {
+      newData.version_added = null;
     }
   }
 

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -228,10 +228,12 @@ const bumpEdge = comp => {
   let ieData = comp['ie'];
   let chromeData = comp['chrome'];
 
-  if (ieData.version_removed !== null) {
-    newData.version_added = false;
-  } else if (ieData.version_added !== null) {
-    newData.version_added = ieData.version_added ? '12' : null;
+  if (ieData) {
+    if (ieData.version_removed !== null) {
+      newData.version_added = false;
+    } else if (ieData.version_added !== null) {
+      newData.version_added = ieData.version_added ? '12' : null;
+    }
   }
 
   let chromeFalse =

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -219,14 +219,14 @@ const bumpChromeAndroid = (originalData, sourceData, source) => {
 };
 
 /**
- * @param {SupportStatement} comp
+ * @param {SupportStatement} compData
  * @returns {SupportStatement}
  */
-const bumpEdge = comp => {
-  let newData = copyStatement(comp['edge']);
-  let originalData = comp['edge'];
-  let ieData = comp['ie'];
-  let chromeData = comp['chrome'];
+const bumpEdge = compData => {
+  let newData = copyStatement(compData['edge']);
+  let originalData = compData['edge'];
+  let ieData = compData['ie'];
+  let chromeData = compData['chrome'];
 
   if (ieData) {
     if (ieData.version_removed !== null) {
@@ -557,7 +557,7 @@ const bumpVersion = (data, destination, source, originalData) => {
  @ @returns {Identifier}
  */
 const doSetFeature = (data, newData, rootPath, browser, source, modify) => {
-  let comp = data[rootPath].__compat.support;
+  let compData = data[rootPath].__compat.support;
 
   let doBump = false;
   if (modify == 'always') {
@@ -567,15 +567,15 @@ const doSetFeature = (data, newData, rootPath, browser, source, modify) => {
       modify == 'nonreal'
         ? [true, null, undefined]
         : [true, false, null, undefined];
-    if (Array.isArray(comp[browser])) {
-      for (let i = 0; i < comp[browser].length; i++) {
-        if (triggers.includes(comp[browser][i].version_added)) {
+    if (Array.isArray(compData[browser])) {
+      for (let i = 0; i < compData[browser].length; i++) {
+        if (triggers.includes(compData[browser][i].version_added)) {
           doBump = true;
           break;
         }
       }
-    } else if (comp[browser] !== undefined) {
-      doBump = triggers.includes(comp[browser].version_added);
+    } else if (compData[browser] !== undefined) {
+      doBump = triggers.includes(compData[browser].version_added);
     } else {
       doBump = true;
     }
@@ -584,9 +584,14 @@ const doSetFeature = (data, newData, rootPath, browser, source, modify) => {
   if (doBump) {
     let newValue = null;
     if (browser == 'edge') {
-      newValue = bumpEdge(comp);
+      newValue = bumpEdge(compData);
     } else {
-      newValue = bumpVersion(comp[source], browser, source, comp[browser]);
+      newValue = bumpVersion(
+        compData[source],
+        browser,
+        source,
+        compData[browser],
+      );
     }
     if (newValue !== null) {
       newData[rootPath].__compat.support[browser] = newValue;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -88,6 +88,7 @@ const getSource = (browser, forced_source) => {
 
   switch (browser) {
     case 'chrome_android':
+    case 'edge':
     case 'opera':
       source = 'chrome';
       break;
@@ -98,9 +99,6 @@ const getSource = (browser, forced_source) => {
       break;
     case 'firefox_android':
       source = 'firefox';
-      break;
-    case 'edge':
-      source = 'ie';
       break;
     case 'safari_ios':
       source = 'safari';

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -244,10 +244,9 @@ const bumpEdge = (originalData, chromeData, ieData) => {
     if (originalData.version_added == true) {
       newData.version_added = '≤18';
     } else {
-      if (
-        chromeData.version_added == true ||
-        Number(chromeData.version_added) <= 79
-      ) {
+      if (chromeData.version_added == true) {
+        newData.version_added = true;
+      } else if (Number(chromeData.version_added) <= 79) {
         if (originalData.version_added == false) {
           newData.version_added = '79';
         } else if (originalData.version_added == null) {

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -264,7 +264,7 @@ const bumpEdge = (originalData, chromeData, ieData) => {
 
   let newNotes = combineNotes(
     ieData ? updateNotes(ieData.notes, /Internet Explorer/g, 'Edge') : null,
-    updateNotes(chromeData.notes, /Chrome/g, 'Edge'),
+    updateNotes(chromeData.notes, /Chrome(?! OS)/g, 'Edge'),
     originalData.notes,
   );
 
@@ -331,7 +331,7 @@ const bumpOpera = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome/g, 'Opera');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'Opera');
   }
 
   return newData;
@@ -364,7 +364,7 @@ const bumpOperaAndroid = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome/g, 'Opera');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'Opera');
   }
 
   return newData;
@@ -428,7 +428,7 @@ const bumpSamsungInternet = (originalData, sourceData, source) => {
   if (typeof sourceData.notes === 'string') {
     newData.notes = updateNotes(
       sourceData.notes,
-      /Chrome/g,
+      /Chrome(?! OS)/g,
       'Samsung Internet',
     );
   }
@@ -471,7 +471,7 @@ const bumpWebView = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome/g, 'WebView');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'WebView');
   }
 
   return newData;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -228,7 +228,7 @@ const bumpEdge = comp => {
   let ieData = comp['ie'];
   let chromeData = comp['chrome'];
 
-  if (ieData.version_removed && ieData.version_removed !== null) {
+  if (ieData.version_removed !== null) {
     newData.version_added = false;
   } else if (ieData.version_added !== null) {
     newData.version_added = ieData.version_added ? '12' : null;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -226,9 +226,9 @@ const bumpEdge = (originalData, chromeData, ieData) => {
   let newData = copyStatement(originalData);
 
   if (ieData) {
-    if (ieData.version_removed !== null) {
+    if (ieData.version_removed || ieData.version_added === false) {
       newData.version_added = false;
-    } else if (ieData.version_added !== null) {
+    } else if (ieData.version_added) {
       newData.version_added = ieData.version_added ? '12' : null;
     }
   }
@@ -239,20 +239,21 @@ const bumpEdge = (originalData, chromeData, ieData) => {
   let chromeNull = chromeData.version_added === null;
 
   if (!chromeFalse && !chromeNull) {
-    if (originalData.version_added == true) {
+    if (originalData.version_added === true) {
       newData.version_added = '≤18';
-    } else {
-      if (chromeData.version_added == true) {
-        newData.version_added = true;
-      } else if (Number(chromeData.version_added) <= 79) {
-        if (originalData.version_added == false) {
-          newData.version_added = '79';
-        } else if (originalData.version_added == null) {
-          newData.version_added = '≤79';
-        }
-      } else {
-        newData.version_added = chromeData.version_added;
+    } else if (chromeData.version_added === true) {
+      newData.version_added = true;
+    } else if (Number(chromeData.version_added) <= 79) {
+      if (
+        originalData.version_added === false ||
+        newData.version_added === false
+      ) {
+        newData.version_added = '79';
+      } else if (originalData.version_added === null) {
+        newData.version_added = '≤79';
       }
+    } else {
+      newData.version_added = chromeData.version_added;
     }
   } else if (chromeFalse) {
     if (originalData.version_added && !originalData.version_removed) {

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -745,6 +745,10 @@ const mirrorData = (browser, feature_or_file, forced_source, modify) => {
     return false;
   }
 
+  if (browser === 'edge' && forced_source) {
+    console.warn('Warning: Edge does not support --source parameter.');
+  }
+
   let source = getSource(browser, forced_source);
 
   if (feature_or_file) {

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -264,7 +264,7 @@ const bumpEdge = (originalData, chromeData, ieData) => {
 
   let newNotes = combineNotes(
     ieData ? updateNotes(ieData.notes, /Internet Explorer/g, 'Edge') : null,
-    updateNotes(chromeData.notes, /Chrome(?! OS)/g, 'Edge'),
+    updateNotes(chromeData.notes, /Chrome(?! ?OS)/g, 'Edge'),
     originalData.notes,
   );
 
@@ -331,7 +331,7 @@ const bumpOpera = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'Opera');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! ?OS)/g, 'Opera');
   }
 
   return newData;
@@ -364,7 +364,7 @@ const bumpOperaAndroid = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'Opera');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! ?OS)/g, 'Opera');
   }
 
   return newData;
@@ -428,7 +428,7 @@ const bumpSamsungInternet = (originalData, sourceData, source) => {
   if (typeof sourceData.notes === 'string') {
     newData.notes = updateNotes(
       sourceData.notes,
-      /Chrome(?! OS)/g,
+      /Chrome(?! ?OS)/g,
       'Samsung Internet',
     );
   }
@@ -471,7 +471,7 @@ const bumpWebView = (originalData, sourceData, source) => {
   }
 
   if (typeof sourceData.notes === 'string') {
-    newData.notes = updateNotes(sourceData.notes, /Chrome(?! OS)/g, 'WebView');
+    newData.notes = updateNotes(sourceData.notes, /Chrome(?! ?OS)/g, 'WebView');
   }
 
   return newData;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -241,33 +241,29 @@ const bumpEdge = compData => {
     chromeData.version_removed !== undefined;
   let chromeNull = chromeData.version_added === null;
 
-  if (originalData === undefined) {
-    newData.version_added = chromeFalse ? false : chromeNull ? null : '≤79';
-  } else {
-    if (!chromeFalse && !chromeNull) {
-      if (originalData.version_added == true) {
-        newData.version_added = '≤18';
-      } else {
-        if (
-          chromeData.version_added == true ||
-          Number(chromeData.version_added) <= 79
-        ) {
-          if (originalData.version_added == false) {
-            newData.version_added = '79';
-          } else if (originalData.version_added == null) {
-            newData.version_added = '≤79';
-          }
-        } else {
-          newData.version_added = chromeData.version_added;
+  if (!chromeFalse && !chromeNull) {
+    if (originalData.version_added == true) {
+      newData.version_added = '≤18';
+    } else {
+      if (
+        chromeData.version_added == true ||
+        Number(chromeData.version_added) <= 79
+      ) {
+        if (originalData.version_added == false) {
+          newData.version_added = '79';
+        } else if (originalData.version_added == null) {
+          newData.version_added = '≤79';
         }
+      } else {
+        newData.version_added = chromeData.version_added;
       }
-    } else if (chromeFalse) {
-      if (originalData.version_added && !originalData.version_removed) {
-        newData.version_removed = '79';
-      }
-    } else if (chromeNull) {
-      newData.version_added = null;
     }
+  } else if (chromeFalse) {
+    if (originalData.version_added && !originalData.version_removed) {
+      newData.version_removed = '79';
+    }
+  } else if (chromeNull) {
+    newData.version_added = null;
   }
 
   let newNotes = combineNotes(

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -271,7 +271,7 @@ const bumpEdge = compData => {
   }
 
   let newNotes = combineNotes(
-    updateNotes(ieData.notes, /Internet Explorer/g, 'Edge'),
+    ieData ? updateNotes(ieData.notes, /Internet Explorer/g, 'Edge') : null,
     updateNotes(chromeData.notes, /Chrome/g, 'Edge'),
     originalData.notes,
   );

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -219,7 +219,7 @@ const bumpChromeAndroid = (originalData, sourceData, source) => {
 };
 
 /**
- * @param {SupportStatement} compData
+ * @param {SupportStatement} originalData
  * @param {SupportStatement} chromeData
  * @param {SupportStatement} ieData
  * @returns {SupportStatement}

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -523,6 +523,7 @@ const bumpVersion = (data, destination, source, originalData, compData) => {
       case 'edge':
         bumpFunction = (originalData, data, source) =>
           bumpEdge(originalData, data, compData['ie']);
+        break;
       case 'opera':
         bumpFunction = bumpOpera;
         break;
@@ -589,6 +590,7 @@ const doSetFeature = (data, newData, rootPath, browser, source, modify) => {
       browser,
       source,
       compData[browser],
+      compData,
     );
     if (newValue !== null) {
       newData[rootPath].__compat.support[browser] = newValue;


### PR DESCRIPTION
This PR fixes some issues with mirroring WebView data by using data from Chrome Desktop as well as Chrome Android.  Currently, the mirroring script will set WebView to "1" if Chrome Android is "18" -- however, we cannot assume that everything that was added between Chrome 1 and 18 was present in WebView for Android 1.0, only that what was added in Chrome 1 is in WebView for Android 1.0.

Relies on refactoring from #6582 -- please merge that PR before this one.