### PR TITLE
Add BCD entry for fractionalSecondDigits option in DateTimeFormat

### DIFF
--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -313,6 +313,56 @@
                   "deprecated": false
                 }
               }
+            },
+            "fractionalSecondDigits": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "84"
+                  },
+                  "chrome_android": {
+                    "version_added": "84"
+                  },
+                  "edge": {
+                    "version_added": "84"
+                  },
+                  "firefox": {
+                    "version_added": "84"
+                  },
+                  "firefox_android": {
+                    "version_added": "84"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "70"
+                  },
+                  "opera_android": {
+                    "version_added": "60"
+                  },
+                  "safari": {
+                    "version_added": null
+                  },
+                  "safari_ios": {
+                    "version_added": null
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "84"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "format": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -163,6 +163,56 @@
                 }
               }
             },
+            "fractionalSecondDigits": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "84"
+                  },
+                  "chrome_android": {
+                    "version_added": "84"
+                  },
+                  "edge": {
+                    "version_added": "84"
+                  },
+                  "firefox": {
+                    "version_added": "84"
+                  },
+                  "firefox_android": {
+                    "version_added": "84"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "14.6.0"
+                  },
+                  "opera": {
+                    "version_added": "70"
+                  },
+                  "opera_android": {
+                    "version_added": "60"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "84"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "hourCycle": {
               "__compat": {
                 "support": {
@@ -305,56 +355,6 @@
                   },
                   "webview_android": {
                     "version_added": "76"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "fractionalSecondDigits": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "84"
-                  },
-                  "chrome_android": {
-                    "version_added": "84"
-                  },
-                  "edge": {
-                    "version_added": "84"
-                  },
-                  "firefox": {
-                    "version_added": "84"
-                  },
-                  "firefox_android": {
-                    "version_added": "84"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": null
-                  },
-                  "opera": {
-                    "version_added": "70"
-                  },
-                  "opera_android": {
-                    "version_added": "60"
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": {
-                    "version_added": null
-                  },
-                  "samsunginternet_android": {
-                    "version_added": false
-                  },
-                  "webview_android": {
-                    "version_added": "84"
                   }
                 },
                 "status": {


### PR DESCRIPTION
This adds a new entry for the new option `fractionalSecondDigits` added to the `Intl.DateTimeFormat()` constructor options. 
- Added to Firefox in FF84 - https://bugzilla.mozilla.org/show_bug.cgi?id=1645107
- Added to Chromium in 84 - https://www.chromestatus.com/feature/5704965743968256
- There is not yet a version of SamsungAndroid browser that has this.
- Looks like it is in Webkit/Safarit - but still trying to find out version: https://bugs.webkit.org/show_bug.cgi?id=215840
- It is in Nodejs but need help mapping to a version https://monorail-prod.appspot.com/p/v8/issues/detail?id=9284

Docs work being done for this can be tracked in https://github.com/mdn/sprints/issues/3897#issuecomment-730870217
