### PR TITLE
Rename api.HTMLElement.formEncType -> formEnctype

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -289,9 +289,9 @@
           }
         }
       },
-      "formEncType": {
+      "formEnctype": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formEncType",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formEnctype",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
This PR fixes a capitalization issue for the HTMLElement API's `formEnctype` method.  Inspired by https://github.com/mdn/browser-compat-data/pull/7402#discussion_r527274048.