### PR TITLE
Rename api.HTMLImageElement.lowSrc -> lowsrc

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -796,9 +796,9 @@
           }
         }
       },
-      "lowSrc": {
+      "lowsrc": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/lowSrc",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/lowsrc",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This PR corrects capitalization for the HTMLImageElement API's `lowsrc` feature.