### PR TITLE
Rename api.HTMLMarqueeElement.bgcolor -> bgColor

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -96,7 +96,7 @@
           }
         }
       },
-      "bgcolor": {
+      "bgColor": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR corrects capitalization for the HTMLMarqueeElement API's `bgColor` feature.