### PR TITLE
Rename api.HTMLMarqueeElement.scrollamount -> scrollAmount

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -331,7 +331,7 @@
           }
         }
       },
-      "scrollamount": {
+      "scrollAmount": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR corrects capitalization for the HTMLMarqueeElement API's `scrollAmount` feature.