### PR TITLE
Rename api.HTMLMarqueeElement.scrolldelay -> scrollDelay

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -378,7 +378,7 @@
           }
         }
       },
-      "scrolldelay": {
+      "scrollDelay": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR corrects capitalization for the HTMLMarqueeElement API's `scrollDelay` feature.