### PR TITLE
Safari iOS doesn't support api.Element.requestPointerLock

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6935,15 +6935,9 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "10.3"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": [
               {
                 "version_added": true


### PR DESCRIPTION
Based upon results from the mdn-bcd-collector project, I've determined that the `requestPointerLock` feature is actually _not_ supported on Safari iOS.