### PR TITLE
Mark ShadowRoot.prototype.innerHTML standard

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -313,8 +313,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This change marks `ShadowRoot.prototype.innerHTML` as `standard_track:true` and `experimental:false.`

https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin (the `InnerHTML` interface mixin), normatively defines `ShadowRoot.prototype.innerHTML,` and all major browser engines expose `ShadowRoot.prototype.innerHTML,` so it’s not experimental.