### PR TITLE
Drop notes from Safari 14 beta / TP in Locale

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -36,12 +36,10 @@
                 "version_added": "53"
               },
               "safari": {
-                "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": "14",
-                "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object from the minimize and maximize methods."
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -468,12 +466,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"
@@ -523,12 +519,10 @@
                   "version_added": "53"
                 },
                 "safari": {
-                  "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "14",
-                  "notes": "Safari 14 Technology Preview 107-111 returns a string instead of a <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale'>Locale</a> object."
+                  "version_added": "14"
                 },
                 "samsunginternet_android": {
                   "version_added": "11.0"


### PR DESCRIPTION
This patch drops that note since this problem does not exist in shipping Safari 14.