### PR TITLE
Mark appcache (html.manifest) as removed in FF84

### DIFF
--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -63,7 +63,8 @@
               },
               "firefox": [
                 {
-                  "version_added": "3.5"
+                  "version_added": "3.5",
+                  "version_removed": "84"
                 },
                 {
                   "version_added": "3",
@@ -72,7 +73,8 @@
                 }
               ],
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "84"
               },
               "ie": {
                 "version_added": "10"
@@ -116,10 +118,12 @@
                   "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": "60"
+                  "version_added": "60",
+                  "version_removed": "84"
                 },
                 "firefox_android": {
-                  "version_added": "60"
+                  "version_added": "60",
+                  "version_removed": "84"
                 },
                 "ie": {
                   "version_added": null


### PR DESCRIPTION
Appcache has been removed in FF84 as per https://bugzilla.mozilla.org/show_bug.cgi?id=1619673. This adds `version_removed` for the manifest and for the sub feature (secure contexts).  

Note:
- Other docs work for this can be tracked in https://github.com/mdn/sprints/issues/3901
- This won't disappear from [Chromium until v90](https://www.chromestatus.com/feature/6192449487634432). I created https://github.com/mdn/browser-compat-data/issues/7480 to track that. Note though "in effect" it was already removed as only sites with a certain "origin certificate" can use this feature [I have not noted that].
