### PR TITLE
Deprecate HTMLFrameSetElement

### DIFF
--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -44,7 +44,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "cols": {
@@ -138,7 +138,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -185,7 +185,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -232,7 +232,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks `HTMLFrameSetElement` and all its members `deprecated:true` per https://html.spec.whatwg.org/multipage/obsolete.html#htmlframesetelement. Related: https://github.com/mdn/browser-compat-data/issues/7255