### PR TITLE
Remove the HTMLElement noModule and onModule entries

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1904,54 +1904,6 @@
           }
         }
       },
-      "noModule": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/noModule",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "nonce": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/nonce",
@@ -2332,54 +2284,6 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "onModule": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/onModule",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Both were added here:
https://wiki.developer.mozilla.org/en-US/docs/Web/API/HTMLElement$compare?to=1311543&from=1276721

onModule appears to be a typo varation, it's not an event handler
attribute, those are always lowercase.

The api.HTMLScriptElement.noModule entry also exists, and is the correct
one for this:
https://html.spec.whatwg.org/multipage/scripting.html#the-script-element
