### PR TITLE
Data guideline for initial versions

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -216,7 +216,7 @@ This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-dat
 
 The schema docs list [initial versions](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#initial-versions) for BCD browsers. These are the earliest possible version numbers allowed to be used.
 
-If the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", BCD requires you to record the intial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number.
+If the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", record the initial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number.
 
 If you're adding new data for Node.js, use `0.10.0` or later. If a feature was added in a version before `0.10.0`, use `0.10.0` anyway.
 

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -214,24 +214,10 @@ This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-dat
 
 ## Initial versions for browsers
 
-The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used.
+The schema docs list [initial versions](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#initial-versions) for BCD browsers. These are the earliest possible version numbers allowed to be used.
 
-For example, if the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", BCD requires you to record the intial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number. Usually initial version numbers are "1" or "1.0"; the table below provides explanations when this is not the case.
+If the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", BCD requires you to record the intial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number.
 
-| Browser          | Initial version | Notes                                                                                                                    |
-| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Chrome           | 1               |                                                                                                                          |
-| Chrome Android   | 18              | First stable release using Chromium 18; older Android versions are ignored or listed under WebView Android.              |
-| Edge             | 12              | EdgeHTML, continuation of IE 11 (another initial version is Edge 79 when Edge switched to Chromium).                     |
-| Firefox          | 1               |                                                                                                                          |
-| Firefox Android  | 4               | ?!                                                                                                                       |
-| IE               | 1               |                                                                                                                          |
-| Node.js          | 0.1.100         | Subject to change to 0.10.0 which is the first stable version (LTS status was retrospectively applied). See issue #6861. |
-| Opera            | 2               | ?!                                                                                                                       |
-| Opera Android    | 10.1            | ?!                                                                                                                       |
-| Safari           | 1               |                                                                                                                          |
-| iOS Safari       | 1               |                                                                                                                          |
-| Samsung Internet | 1.0             |                                                                                                                          |
-| WebView Android  | 1               |                                                                                                                          |
+If you're adding new data for Node.js, use `0.10.0` or later. If a feature was added in a version before `0.10.0`, use `0.10.0` anyway.
 
 This guideline was proposed in [#6861](https://github.com/mdn/browser-compat-data/pull/6861).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -17,6 +17,7 @@ This file contains recommendations to help you record data in a consistent and u
   - [Safari for iOS versioning](#safari-for-ios-versioning)
   - [Removal of irrelevant features](#removal-of-irrelevant-features)
   - [Removal of irrelevant flag data](#removal-of-irrelevant-flag-data)
+  - [Initial versions for browsers](#initial-versions-for-browsers)
 
 <!-- BEGIN TEMPLATE
 
@@ -210,3 +211,27 @@ Valid support statements containing flags can be removed from BCD if it is consi
 These conditions represent minimum requirements for the removal of valid flag data; other considerations may result in flag data continuing to be relevant, even after the guideline conditions are met.
 
 This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-data/pull/6670).
+
+## Initial versions for browsers
+
+The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used.
+
+For example, if the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", BCD requires you to record the intial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number. Usually initial version numbers are "1" or "1.0"; the table below provides explanations when this is not the case.
+
+| Browser          | Initial version | Notes                                                                                                                    |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Chrome           | 1               |                                                                                                                          |
+| Chrome Android   | 18              | First stable release using Chromium 18; older Android versions are ignored or listed under WebView Android.              |
+| Edge             | 12              | EdgeHTML, continuation of IE 11 (another initial version is Edge 79 when Edge switched to Chromium).                     |
+| Firefox          | 1               |                                                                                                                          |
+| Firefox Android  | 4               | ?!                                                                                                                       |
+| IE               | 1               |                                                                                                                          |
+| Node.js          | 0.1.100         | Subject to change to 0.10.0 which is the first stable version (LTS status was retrospectively applied). See issue #6861. |
+| Opera            | 2               | ?!                                                                                                                       |
+| Opera Android    | 10.1            | ?!                                                                                                                       |
+| Safari           | 1               |                                                                                                                          |
+| iOS Safari       | 1               |                                                                                                                          |
+| Samsung Internet | 1.0             |                                                                                                                          |
+| WebView Android  | 1               |                                                                                                                          |
+
+This guideline was proposed in [#6861](https://github.com/mdn/browser-compat-data/pull/6861).

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -120,7 +120,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 
 - `chrome`, Google Chrome (on desktops)
 - `chrome_android`, Google Chrome (on Android)
-- `edge`, MS Edge (on Windows), based on the EdgeHTML version
+- `edge`, MS Edge (on Windows), based on the EdgeHTML version, and later on Chromium versions
 - `firefox`, Mozilla Firefox (on desktops)
 - `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
 - `ie`, Microsoft Internet Explorer (discontinued)
@@ -248,6 +248,26 @@ Examples:
   "version_removed": false
 }
 ```
+
+### Initial versions
+
+The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. These are not naturally "1" or "1.0" as explained in the notes column.
+
+| Browser          | Initial version | Notes                                                                                                                      |
+| ---------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Chrome           | 1               |                                                                                                                            |
+| Chrome Android   | 18              | First stable release started at 18. No Chrome Android 17 or earlier was ever released.                                     |
+| Edge             | 12              | EdgeHTML, continuation of IE 11 (another initial version is Edge 79 when Edge switched to Chromium).                       |
+| Firefox          | 1               |                                                                                                                            |
+| Firefox Android  | 4               | First stable release started at 4. Earlier non-Android mobile versions are ignored.                                        |
+| IE               | 1               |                                                                                                                            |
+| Node.js          | 0.1.100         | Subject to change to `0.10.0` which is the first stable version (LTS status was retrospectively applied). See issue #6861. |
+| Opera            | 2               | Opera 1 was demoed at a conference, but never publicly released.                                                           |
+| Opera Android    | 10.1            | First stable release started at 10.1.                                                                                      |
+| Safari           | 1               |                                                                                                                            |
+| iOS Safari       | 1               |                                                                                                                            |
+| Samsung Internet | 1.0             |                                                                                                                            |
+| WebView Android  | 1               |                                                                                                                            |
 
 ### Ranged versions
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -253,21 +253,21 @@ Examples:
 
 The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. When the earliest version is not naturally "1" or "1.0", see the _Notes_ column for an explanation.
 
-| Browser          | Initial version | Notes                                                                                                                                                                                  |
-| ---------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Chrome           | 1               |                                                                                                                                                                                        |
-| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                                                                                    |
-| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme.               |
-| Firefox          | 1               |                                                                                                                                                                                        |
-| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                                       |
-| IE               | 1               |                                                                                                                                                                                        |
+| Browser          | Initial version | Notes                                                                                                                                                                                |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Chrome           | 1               |                                                                                                                                                                                      |
+| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                                                                                  |
+| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme.             |
+| Firefox          | 1               |                                                                                                                                                                                      |
+| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                                     |
+| IE               | 1               |                                                                                                                                                                                      |
 | Node.js          | 0.1.100         | Subject to change to 0.10.0. This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied. See issue #6861. |
-| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                                       |
-| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                                     |
-| Safari           | 1               |                                                                                                                                                                                        |
-| iOS Safari       | 1               |                                                                                                                                                                                        |
-| Samsung Internet | 1.0             |                                                                                                                                                                                        |
-| WebView Android  | 1               |                                                                                                                                                                                        |
+| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                                     |
+| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                                   |
+| Safari           | 1               |                                                                                                                                                                                      |
+| iOS Safari       | 1               |                                                                                                                                                                                      |
+| Samsung Internet | 1.0             |                                                                                                                                                                                      |
+| WebView Android  | 1               |                                                                                                                                                                                      |
 
 ### Ranged versions
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -120,7 +120,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 
 - `chrome`, Google Chrome (on desktops)
 - `chrome_android`, Google Chrome (on Android)
-- `edge`, MS Edge (on Windows), based on the EdgeHTML version, and later on Chromium versions
+- `edge`, Microsoft Edge (on Windows), based on the EdgeHTML version (before version 79), and later on the Chromium version
 - `firefox`, Mozilla Firefox (on desktops)
 - `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
 - `ie`, Microsoft Internet Explorer (discontinued)
@@ -251,19 +251,19 @@ Examples:
 
 ### Initial versions
 
-The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. These are not naturally "1" or "1.0" as explained in the notes column.
+The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. When the earliest version is not not naturally "1" or "1.0", see the _Notes_ column for an explanation.
 
 | Browser          | Initial version | Notes                                                                                                                      |
 | ---------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | Chrome           | 1               |                                                                                                                            |
-| Chrome Android   | 18              | First stable release started at 18. No Chrome Android 17 or earlier was ever released.                                     |
-| Edge             | 12              | EdgeHTML, continuation of IE 11 (another initial version is Edge 79 when Edge switched to Chromium).                       |
+| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                     |
+| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme. |
 | Firefox          | 1               |                                                                                                                            |
-| Firefox Android  | 4               | First stable release started at 4. Earlier non-Android mobile versions are ignored.                                        |
+| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                        |
 | IE               | 1               |                                                                                                                            |
-| Node.js          | 0.1.100         | Subject to change to `0.10.0` which is the first stable version (LTS status was retrospectively applied). See issue #6861. |
-| Opera            | 2               | Opera 1 was demoed at a conference, but never publicly released.                                                           |
-| Opera Android    | 10.1            | First stable release started at 10.1.                                                                                      |
+| Node.js          | 0.1.100         | Subject to change to 0.10.0. This project selected 0.10.0 as the first release primarily because the `0.10`-series releases was the first to have LTS status applied. See issue #6861. |
+| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                           |
+| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                      |
 | Safari           | 1               |                                                                                                                            |
 | iOS Safari       | 1               |                                                                                                                            |
 | Samsung Internet | 1.0             |                                                                                                                            |

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -251,23 +251,23 @@ Examples:
 
 ### Initial versions
 
-The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. When the earliest version is not not naturally "1" or "1.0", see the _Notes_ column for an explanation.
+The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. When the earliest version is not naturally "1" or "1.0", see the _Notes_ column for an explanation.
 
-| Browser          | Initial version | Notes                                                                                                                      |
-| ---------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Chrome           | 1               |                                                                                                                            |
-| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                     |
-| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme. |
-| Firefox          | 1               |                                                                                                                            |
-| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                        |
-| IE               | 1               |                                                                                                                            |
-| Node.js          | 0.1.100         | Subject to change to 0.10.0. This project selected 0.10.0 as the first release primarily because the `0.10`-series releases was the first to have LTS status applied. See issue #6861. |
-| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                           |
-| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                      |
-| Safari           | 1               |                                                                                                                            |
-| iOS Safari       | 1               |                                                                                                                            |
-| Samsung Internet | 1.0             |                                                                                                                            |
-| WebView Android  | 1               |                                                                                                                            |
+| Browser          | Initial version | Notes                                                                                                                                                                                  |
+| ---------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chrome           | 1               |                                                                                                                                                                                        |
+| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                                                                                    |
+| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme.               |
+| Firefox          | 1               |                                                                                                                                                                                        |
+| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                                       |
+| IE               | 1               |                                                                                                                                                                                        |
+| Node.js          | 0.1.100         | Subject to change to 0.10.0. This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied. See issue #6861. |
+| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                                       |
+| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                                     |
+| Safari           | 1               |                                                                                                                                                                                        |
+| iOS Safari       | 1               |                                                                                                                                                                                        |
+| Samsung Internet | 1.0             |                                                                                                                                                                                        |
+| WebView Android  | 1               |                                                                                                                                                                                        |
 
 ### Ranged versions
 


### PR DESCRIPTION
This attempts to add some docs about BCD's initial versions.
Background is https://github.com/mdn/browser-compat-data/issues/6861 in which we try to fix the initial version for Node.js data.

@ddbeck sharing this early and as a draft, so we can talk about whether this is going in the direction you imagined.

For Firefox Android and the Operas I actually need to dig a bit to understand why we have these initial versions. I'm sure there are good reasons, I just need to find them :)