### PR TITLE
Remove the api.AudioBufferSourceNode.start entry

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -437,54 +437,6 @@
             "deprecated": false
           }
         }
-      },
-      "start": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/start",
-          "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "26"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "6"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
The start() method is inherited from AudioScheduledSourceNode:
https://webaudio.github.io/web-audio-api/#AudioScheduledSourceNode

There's already an api.AudioScheduledSourceNode.start entry.

The MDN article has already been updated:
https://wiki.developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode$compare?to=1655102&from=1655101
