### PR TITLE
Rename node.js versions 0.10 to 0.10.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -38,7 +38,7 @@
           "engine": "V8",
           "engine_version": "3.11"
         },
-        "0.10": {
+        "0.10.0": {
           "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",
           "status": "retired",

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -180,7 +180,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "12.1"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -127,7 +127,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -301,7 +301,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -406,7 +406,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -458,7 +458,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -614,7 +614,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -666,7 +666,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -718,7 +718,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -770,7 +770,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -822,7 +822,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -874,7 +874,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -926,7 +926,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -978,7 +978,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1134,7 +1134,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1186,7 +1186,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1238,7 +1238,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1290,7 +1290,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1342,7 +1342,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1394,7 +1394,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1446,7 +1446,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"
@@ -1498,7 +1498,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "12.1"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -29,7 +29,7 @@
                 "version_added": "0.12"
               },
               {
-                "version_added": "0.10",
+                "version_added": "0.10.0",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -92,7 +92,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -255,7 +255,7 @@
                     "version_added": "0.12"
                   },
                   {
-                    "version_added": "0.10",
+                    "version_added": "0.10.0",
                     "flags": [
                       {
                         "type": "runtime_flag",
@@ -371,7 +371,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -538,7 +538,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -601,7 +601,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -769,7 +769,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -545,7 +545,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"
@@ -649,7 +649,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1003,7 +1003,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "17"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -29,7 +29,7 @@
                 "version_added": "0.12"
               },
               {
-                "version_added": "0.10",
+                "version_added": "0.10.0",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -92,7 +92,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -255,7 +255,7 @@
                     "version_added": "0.12"
                   },
                   {
-                    "version_added": "0.10",
+                    "version_added": "0.10.0",
                     "flags": [
                       {
                         "type": "runtime_flag",
@@ -321,7 +321,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -436,7 +436,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -603,7 +603,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -76,7 +76,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -128,7 +128,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -180,7 +180,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -232,7 +232,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -283,7 +283,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -869,7 +869,7 @@
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "nodejs": {
-                "version_added": "0.10",
+                "version_added": "0.10.0",
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "opera": {
@@ -1191,7 +1191,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -1295,7 +1295,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -1346,7 +1346,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -1657,7 +1657,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -1917,7 +1917,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -1969,7 +1969,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.10"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11.6"
@@ -77,7 +77,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -127,7 +127,7 @@
                   "version_added": "10"
                 },
                 "nodejs": {
-                  "version_added": "0.10"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "11.6"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -29,7 +29,7 @@
                 "version_added": "0.12"
               },
               {
-                "version_added": "0.10",
+                "version_added": "0.10.0",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -92,7 +92,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -255,7 +255,7 @@
                     "version_added": "0.12"
                   },
                   {
-                    "version_added": "0.10",
+                    "version_added": "0.10.0",
                     "flags": [
                       {
                         "type": "runtime_flag",
@@ -383,7 +383,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -448,7 +448,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -513,7 +513,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -580,7 +580,7 @@
                   "version_added": "0.12"
                 },
                 {
-                  "version_added": "0.10",
+                  "version_added": "0.10.0",
                   "flags": [
                     {
                       "type": "runtime_flag",

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -751,7 +751,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.10"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/6861#issuecomment-726721195 for background.

We'd like to make the node.js versions consistent and so this renames `0.10` to `0.10.0`.
Will rename  `0.12` to `0.12.0` in another PR in a second.