### PR TITLE
Rename node.js versions 0.12 to 0.12.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -45,7 +45,7 @@
           "engine": "V8",
           "engine_version": "3.14"
         },
-        "0.12": {
+        "0.12.0": {
           "release_date": "2015-02-06",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md",
           "status": "retired",

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -233,7 +233,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -341,7 +341,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -456,7 +456,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -519,7 +519,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -1005,7 +1005,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1894,7 +1894,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -1948,7 +1948,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2172,7 +2172,7 @@
                   ]
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "version_removed": "4.0.0"
                 }
               ],
@@ -2254,7 +2254,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -2369,7 +2369,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -127,7 +127,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -286,7 +286,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "12.1"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1272,7 +1272,7 @@
                   "version_added": "9"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "6"
@@ -2418,7 +2418,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2472,7 +2472,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -2525,7 +2525,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2631,7 +2631,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2685,7 +2685,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -2738,7 +2738,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2844,7 +2844,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2898,7 +2898,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -2951,7 +2951,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -29,7 +29,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -195,7 +195,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12"
+              "version_added": "0.12.0"
             },
             "opera": {
               "version_added": "25"
@@ -817,7 +817,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -26,7 +26,7 @@
             },
             "nodejs": [
               {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               {
                 "version_added": "0.10",
@@ -89,7 +89,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -149,7 +149,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -200,7 +200,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -252,7 +252,7 @@
                 },
                 "nodejs": [
                   {
-                    "version_added": "0.12"
+                    "version_added": "0.12.0"
                   },
                   {
                     "version_added": "0.10",
@@ -315,7 +315,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -368,7 +368,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -430,7 +430,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -482,7 +482,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -535,7 +535,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -598,7 +598,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -711,7 +711,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -766,7 +766,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -830,7 +830,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -882,7 +882,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -962,7 +962,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "30"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -546,7 +546,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -650,7 +650,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -806,7 +806,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -858,7 +858,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -962,7 +962,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1066,7 +1066,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1170,7 +1170,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1274,7 +1274,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1326,7 +1326,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1378,7 +1378,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "16"
@@ -1482,7 +1482,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1534,7 +1534,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1586,7 +1586,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1898,7 +1898,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -2002,7 +2002,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -2158,7 +2158,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -2210,7 +2210,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -76,7 +76,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -128,7 +128,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -232,7 +232,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -597,7 +597,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -701,7 +701,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -753,7 +753,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -805,7 +805,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -1019,7 +1019,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -1072,7 +1072,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -847,7 +847,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1681,7 +1681,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12"
+              "version_added": "0.12.0"
             },
             "opera": {
               "version_added": "19"
@@ -79,7 +79,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "notes": "Constructor requires a new operator since version 4."
               },
               "opera": {
@@ -135,7 +135,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"
@@ -399,7 +399,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"
@@ -452,7 +452,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"
@@ -505,7 +505,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"
@@ -558,7 +558,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "19"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -26,7 +26,7 @@
             },
             "nodejs": [
               {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               {
                 "version_added": "0.10",
@@ -89,7 +89,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -149,7 +149,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -200,7 +200,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -252,7 +252,7 @@
                 },
                 "nodejs": [
                   {
-                    "version_added": "0.12"
+                    "version_added": "0.12.0"
                   },
                   {
                     "version_added": "0.10",
@@ -318,7 +318,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -380,7 +380,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -433,7 +433,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -495,7 +495,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -547,7 +547,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -600,7 +600,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -715,7 +715,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -767,7 +767,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -847,7 +847,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "30"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -446,7 +446,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -561,7 +561,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -832,7 +832,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -1273,7 +1273,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -1326,7 +1326,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -1483,7 +1483,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "21"
@@ -1717,7 +1717,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -2144,7 +2144,7 @@
                   "version_added": "4.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -2519,7 +2519,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -2631,7 +2631,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the function silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -2977,7 +2977,7 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "alternative_name": "trimRight"
                 }
               ],
@@ -3084,7 +3084,7 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "alternative_name": "trimLeft"
                 }
               ],
@@ -3293,7 +3293,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12"
+              "version_added": "0.12.0"
             },
             "opera": {
               "version_added": "25"
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -246,7 +246,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "27"
@@ -413,7 +413,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "30"
@@ -465,7 +465,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "27"
@@ -945,7 +945,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1112,7 +1112,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "32"
@@ -1164,7 +1164,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -387,7 +387,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "36"
@@ -1085,7 +1085,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -1397,7 +1397,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "15"
@@ -1865,7 +1865,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -2021,7 +2021,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"
@@ -2101,7 +2101,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -229,7 +229,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -26,7 +26,7 @@
             },
             "nodejs": [
               {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               {
                 "version_added": "0.10",
@@ -89,7 +89,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -149,7 +149,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -200,7 +200,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "23"
@@ -252,7 +252,7 @@
                 },
                 "nodejs": [
                   {
-                    "version_added": "0.12"
+                    "version_added": "0.12.0"
                   },
                   {
                     "version_added": "0.10",
@@ -318,7 +318,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "version_removed": "4.0.0"
               },
               "opera": {
@@ -380,7 +380,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -445,7 +445,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -510,7 +510,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",
@@ -577,7 +577,7 @@
               },
               "nodejs": [
                 {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 {
                   "version_added": "0.10",

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12"
+              "version_added": "0.12.0"
             },
             "opera": {
               "version_added": "23"
@@ -77,7 +77,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "23"
@@ -127,7 +127,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "25"
@@ -178,7 +178,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.12"
+                  "version_added": "0.12.0"
                 },
                 "opera": {
                   "version_added": "23"
@@ -231,7 +231,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "23"
@@ -342,7 +342,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "23"
@@ -394,7 +394,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.12"
+                "version_added": "0.12.0"
               },
               "opera": {
                 "version_added": "23"

--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
               },
               "opera": {
@@ -83,7 +83,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Collator</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -136,7 +136,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": "0.12"
+                    "version_added": "0.12.0"
                   },
                   "opera": {
                     "version_added": "15"
@@ -189,7 +189,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -242,7 +242,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator'>the <code>Collator()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -299,7 +299,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
               },
               "opera": {
@@ -83,7 +83,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -339,7 +339,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -560,7 +560,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -668,7 +668,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }

--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -25,7 +25,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "0.12",
+              "version_added": "0.12.0",
               "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>Intl</code> APIs silently fall back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
             },
             "opera": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -26,7 +26,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
               },
               "opera": {
@@ -83,7 +83,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }
@@ -446,7 +446,7 @@
                   "notes": "In Internet Explorer 11, numbers are rounded to 15 decimal digits. For example, <code>new Intl.NumberFormat('en-US').format(1000000000000005)</code> returns <code>\"1,000,000,000,000,010\"</code>."
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -552,7 +552,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "0.12",
+                  "version_added": "0.12.0",
                   "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat'>the <code>NumberFormat()</code> constructor</a> for more details."
                 },
                 "opera": {
@@ -609,7 +609,7 @@
                     "version_added": "13.0.0"
                   },
                   {
-                    "version_added": "0.12",
+                    "version_added": "0.12.0",
                     "partial_implementation": true,
                     "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
                   }

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -81,7 +81,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",
@@ -519,7 +519,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -37,7 +37,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -32,7 +32,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1048,7 +1048,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.12"
+              "version_added": "0.12.0"
             },
             "opera": {
               "version_added": "25"
@@ -1310,7 +1310,7 @@
                 "version_added": "4.0.0"
               },
               {
-                "version_added": "0.12",
+                "version_added": "0.12.0",
                 "flags": [
                   {
                     "type": "runtime_flag",


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/6861#issuecomment-726721195 for background.

We'd like to make the node.js versions consistent and so this renames `0.12` to `0.12.0`.

https://github.com/mdn/browser-compat-data/pull/7491 renames `0.10` to `0.10.0`.