### PR TITLE
Add/correct Firefox real data for DOM* APIs

### DIFF
--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "6"
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9",
@@ -206,11 +206,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Since Firefox 19, <code>hasFeature()</code> mostly returns <code>true</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -65,7 +65,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -113,7 +113,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/DOMStringList.json
+++ b/api/DOMStringList.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -157,10 +157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/DOMStringMap.json
+++ b/api/DOMStringMap.json
@@ -18,7 +18,7 @@
             "version_added": "6"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "6"
           },
           "ie": {
             "version_added": "11"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -157,10 +157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -301,10 +301,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -445,10 +445,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -734,10 +734,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "3"
+            "version_added": "3.6"
           },
           "firefox_android": {
             "version_added": "4"


### PR DESCRIPTION
This PR adds real data for Firefox for various APIs prefixed with `DOM` based upon results from the mdn-bcd-collector project, along with a few corrections.