### PR TITLE
Update and correct Firefox data for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10798,7 +10798,7 @@
             },
             "firefox_android": [
               {
-                "version_added": "75"
+                "version_added": "79"
               },
               {
                 "version_added": "63",

--- a/api/Document.json
+++ b/api/Document.json
@@ -912,7 +912,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2",
+              "version_added": "1",
               "notes": "The <code>body</code> property was implemented on the <code>HTMLDocument</code> interface in Firefox for a long time, hence <code>document.body</code> would not return the <code>&lt;body&gt;</code> element if the document's <code>Content-Type</code> was not set to <code>text/html</code> or <code>application/xhtml+xml</code> (or if it came from <code>DOMParser.parseFromString</code> without the <code>text/html</code> type being used). This has been fixed in Firefox 60."
             },
             "firefox_android": {
@@ -1760,7 +1760,7 @@
                 "version_added": "44"
               },
               {
-                "version_added": "4",
+                "version_added": "1",
                 "version_removed": "44",
                 "notes": "The parameter was not converted to its lowercase variant."
               }
@@ -2377,10 +2377,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2729,7 +2729,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -4085,7 +4085,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -5885,8 +5885,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": "1",
+              "version_removed": "3.6"
             },
             "firefox_android": {
               "version_added": false
@@ -5982,7 +5982,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -6612,7 +6612,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -9877,7 +9877,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.6"
             },
             "firefox_android": {
               "version_added": "4"
@@ -10494,9 +10494,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "version_added": "47",
+                "version_removed": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.document.scrollingElement.enabled"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -10785,6 +10797,9 @@
               "version_added": "75"
             },
             "firefox_android": [
+              {
+                "version_added": "75"
+              },
               {
                 "version_added": "63",
                 "flags": [


### PR DESCRIPTION
This PR updates the Firefox data for the Document API based upon results from the mdn-bcd-collector project, along with a little bit of mirroring to Firefox Android.  It appears that a number of features were supported just a little bit earlier in Firefox than the data proclaimed; this PR adds the correct data.