### PR TITLE
Add real values for Firefox for HTML Element APIs

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -160,7 +160,7 @@
               "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -641,7 +641,7 @@
               "version_added": "49"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLHRElement.json
+++ b/api/HTMLHRElement.json
@@ -17,7 +17,7 @@
             "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "5.5"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -208,7 +208,7 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10",
@@ -258,7 +258,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -306,7 +306,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": true
@@ -354,7 +354,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -402,7 +402,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -450,7 +450,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -498,7 +498,7 @@
               "version_added": "16"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "16"
             },
             "ie": {
               "version_added": "5.5"
@@ -543,7 +543,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3.6"
             },
             "firefox_android": {
               "version_added": "4"
@@ -643,7 +643,7 @@
               "version_added": "56"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
@@ -739,7 +739,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -835,7 +835,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -883,7 +883,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -979,7 +979,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -1133,7 +1133,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -1181,7 +1181,7 @@
               "version_added": "27"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "ie": {
               "version_added": false
@@ -1399,7 +1399,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -1447,7 +1447,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -1639,7 +1639,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -737,7 +737,7 @@
                 "version_added": "22"
               },
               {
-                "version_added": "12",
+                "version_added": "14",
                 "version_removed": "22",
                 "alternative_name": "crossorigin"
               }
@@ -1642,7 +1642,7 @@
               "version_added": "11"
             },
             "firefox_android": {
-              "version_added": "11"
+              "version_added": "14"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2980,7 +2980,8 @@
               "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "prefix": "moz",
+              "version_added": "20"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -484,8 +484,7 @@
               "notes": "Prior to Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Prior to Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -288,7 +288,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -336,7 +336,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -484,7 +484,8 @@
               "notes": "Prior to Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "notes": "Prior to Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
             },
             "ie": {
               "version_added": "9"
@@ -632,7 +633,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -731,9 +732,16 @@
                 "alternative_name": "crossorigin"
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "22",
+                "alternative_name": "crossorigin"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -780,7 +788,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -828,7 +836,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1020,7 +1028,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1166,7 +1174,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1263,7 +1271,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1634,7 +1642,7 @@
               "version_added": "11"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "ie": {
               "version_added": "9"
@@ -2157,7 +2165,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2206,7 +2214,7 @@
               "notes": "The <code>NETWORK_LOADED</code> state was removed to align with the HTML spec in Firefox 4."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2486,7 +2494,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -2583,7 +2591,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -3120,7 +3128,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"
@@ -3265,7 +3273,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -3570,7 +3578,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -3996,7 +4004,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -17,7 +17,7 @@
             "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "5.5"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -206,7 +206,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -254,10 +254,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "≤6"
@@ -398,10 +398,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "≤6"


### PR DESCRIPTION
This PR adds real values for Firefox for HTML element APIs using results from the mdn-bcd-collector project, including some mirroring to Firefox Android (after confirmation through the collector results).  Some mirroring includes copying notes or alt. name data.  This PR is a cherry-pick of changes that maintain truthiness.