### PR TITLE
Change null->false for Firefox for HTML element API features

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1918,10 +1918,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -2350,10 +2350,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -677,7 +677,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -61,10 +61,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR sets lack of support for Firefox for a few features in the HTML element APIs using results from the mdn-bcd-collector project.