### PR TITLE
Correct Firefox data for HTMLBaseFontElement

### DIFF
--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -15,10 +15,11 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "4"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": "≤6"
@@ -65,10 +66,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": "≤6"
@@ -116,10 +118,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": "≤6"
@@ -167,10 +170,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": "≤6"

--- a/html/elements/basefont.json
+++ b/html/elements/basefont.json
@@ -16,7 +16,8 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "4"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This PR corrects the Firefox data for the HTMLBaseFontElement API using results from the mdn-bcd-collector project.  As it turns out, this API was supported for a brief period in the first versions of Firefox.