### PR TITLE
Correct Firefox 1-4 data for HTML element APIs

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -61,7 +61,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -61,7 +61,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -157,7 +157,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -639,7 +639,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -687,7 +687,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -783,7 +783,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -712,7 +712,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -537,7 +537,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "3",
+              "version_added": "4",
               "notes": [
                 "Before Firefox 5, <code>click()</code> is only defined on buttons and inputs, and has no effect on text and file inputs.",
                 "Starting in Firefox for Android 79, the <code>click()</code> function works even when the element is not attached to a DOM tree."

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -785,7 +785,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "2"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1140,7 +1140,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -3249,7 +3249,7 @@
               }
             ],
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -537,7 +537,11 @@
               ]
             },
             "firefox_android": {
-              "version_added": "5"
+              "version_added": "3",
+              "notes": [
+                "Before Firefox 5, <code>click()</code> is only defined on buttons and inputs, and has no effect on text and file inputs.",
+                "Starting in Firefox for Android 79, the <code>click()</code> function works even when the element is not attached to a DOM tree."
+              ]
             },
             "ie": {
               "version_added": "5.5"
@@ -781,7 +785,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1136,7 +1140,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1443,7 +1447,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -3245,7 +3249,7 @@
               }
             ],
             "firefox": {
-              "version_added": "1"
+              "version_added": "1.5"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -156,7 +156,7 @@
                 "version_added": "≤18"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "4"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -61,7 +61,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -253,7 +253,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -61,7 +61,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -109,7 +109,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -253,7 +253,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -349,7 +349,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -397,7 +397,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -445,7 +445,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -493,7 +493,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1436,7 +1436,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -205,7 +205,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -637,7 +637,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -877,7 +877,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1117,7 +1117,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1165,7 +1165,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1309,7 +1309,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -201,7 +201,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -201,7 +201,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -494,7 +494,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -735,7 +735,7 @@
               "notes": "<code>namedItem</code> does not appear to take the <code>name</code> attribute into account (only the <code>id</code> attribute) on Internet Explorer and Edge. There is a <a href='https://connect.microsoft.com/IE/feedbackdetail/view/2414092/'>bug report</a> to Microsoft about this."
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1168,7 +1168,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -781,7 +781,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3",
+              "version_added": "1",
               "notes": "Starting with Firefox 20, the index argument has been made optional and defaults to -1 as per HTML specification."
             },
             "firefox_android": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "4"
+            "version_added": "3.5"
           },
           "firefox_android": {
             "version_added": "4"
@@ -170,7 +170,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -555,7 +555,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.6"
             },
             "firefox_android": {
               "version_added": "4"
@@ -650,7 +650,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -698,7 +698,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -746,7 +746,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
This PR uses results from the mdn-bcd-collector project to correct Firefox data between versions 1-4 for the HTML element APIs.