### PR TITLE
Correct Firefox data for HTMLContentElement API

### DIFF
--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -15,25 +15,11 @@
           },
           "firefox": {
             "version_added": "28",
-            "version_removed": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_removed": "52"
           },
           "firefox_android": {
             "version_added": "28",
-            "version_removed": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_removed": "52"
           },
           "ie": {
             "version_added": false
@@ -78,25 +64,11 @@
             },
             "firefox": {
               "version_added": "28",
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "52"
             },
             "firefox_android": {
               "version_added": "28",
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "52"
             },
             "ie": {
               "version_added": false
@@ -142,25 +114,11 @@
             },
             "firefox": {
               "version_added": "28",
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "52"
             },
             "firefox_android": {
               "version_added": "28",
-              "version_removed": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "52"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR corrects the Firefox data for the HTMLContentElement API using results from the mdn-bcd-collector project.  The collector indicated that this API was supported by default without the need of enabling the flag, but it was disabled by default in Firefox 52.  While the flag is present in Firefox 53, it was removed in Firefox 59, which is close to the flag removal requirement, so I figured it made sense to just remove the flag data.