### PR TITLE
Correct Firefox version numbers for HTML element APIs

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -635,10 +635,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "8"
             },
             "ie": {
               "version_added": false
@@ -1969,7 +1969,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -2254,10 +2254,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": "5.5"
@@ -2302,10 +2302,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": "5.5"
@@ -2398,10 +2398,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": "5.5"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2254,10 +2254,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5.5"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -738,7 +738,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -61,12 +61,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": "7"
+              "version_added": "1",
+              "version_removed": "4"
             },
             "firefox_android": {
-              "version_added": true,
-              "version_removed": "7"
+              "version_added": false
             },
             "ie": {
               "version_added": "≤6"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -111,7 +111,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -715,7 +715,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -813,7 +813,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -999,11 +999,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51",
-              "notes": "May also be supported in earlier versions."
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "9"
             },
             "ie": {
               "version_added": "≤6"

--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -23,6 +23,7 @@
           },
           "firefox_android": {
             "version_added": "4",
+            "version_removed": "69",
             "partial_implementation": true,
             "notes": "Never fully implemented. See <a href='https://bugzil.la/1315460'>bug 1315460</a>."
           },

--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -23,7 +23,7 @@
           },
           "firefox_android": {
             "version_added": "4",
-            "version_removed": "69",
+            "version_removed": "79",
             "partial_implementation": true,
             "notes": "Never fully implemented. See <a href='https://bugzil.la/1315460'>bug 1315460</a>."
           },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2296,10 +2296,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2296,10 +2296,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "7"
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": "7"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "6"

--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "7"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "7"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -1021,10 +1021,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "27",
+              "version_removed": "68"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "27",
+              "version_removed": "68"
             },
             "ie": {
               "version_added": false

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -120,10 +120,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "15"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -120,10 +120,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "15"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "15"
             },
             "ie": {
               "version_added": "9"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -124,7 +124,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",


### PR DESCRIPTION
This PR corrects the Firefox version numbers for various features within the HTML element APIs based upon results from the mdn-bcd-collector project.  This PR solely changes version numbers, and does not change true -> false or remove flags.