### PR TITLE
Correct Firefox data for api.HTMLMediaElement.seekToNextFrame

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3356,24 +3356,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.seekToNextFrame",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "49",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.seekToNextFrame",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "56"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR uses results from the mdn-bcd-collector project to correct and update the Firefox data for the `seekToNextFrame` feature of the HTMLMediaElement API.  Initially, the feature was supported behind a flag; however, it was enabled by default in Firefox 56, but the data was never updated to reflect this.  This PR sets the version to 56 and removes the flag data, as it meets the flag removal requirements.
