### PR TITLE
Correct Firefox data for HTMLShadowElement API

### DIFF
--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -14,26 +14,12 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "28",
-            "version_removed": "58",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "29",
+            "version_removed": "52"
           },
           "firefox_android": {
-            "version_added": "28",
-            "version_removed": "58",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webcomponents.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "29",
+            "version_removed": "52"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR corrects the Firefox data for the HTMLShadowElement API using results from the mdn-bcd-collector project. The collector indicated that this API was supported by default without the need of enabling the flag in Firefox 29 (not 28), but it was disabled by default in Firefox 52. While the flag is present in Firefox 53, it was removed in Firefox 58, which is close to the flag removal requirement, so I figured it made sense to just remove the flag data.