### PR TITLE
Rename api.HTMLMarqueeElement.truespeed -> trueSpeed

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -425,7 +425,7 @@
           }
         }
       },
-      "truespeed": {
+      "trueSpeed": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR fixes the capitalization for the `trueSpeed` attribute of the `HTMLMarqueeElement` API.
