### PR TITLE
adding missing pseudos

### DIFF
--- a/css/selectors/current.json
+++ b/css/selectors/current.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "current": {
+        "__compat": {
+          "description": "<code>:current</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:current",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/local-link.json
+++ b/css/selectors/local-link.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "local-link": {
+        "__compat": {
+          "description": "<code>:local-link</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:local-link",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/nth-col.json
+++ b/css/selectors/nth-col.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "nth-col": {
+        "__compat": {
+          "description": "<code>:nth-col</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-col",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/nth-last-col.json
+++ b/css/selectors/nth-last-col.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "nth-last-col": {
+        "__compat": {
+          "description": "<code>:nth-last-col</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-col",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I've been working on completing our documentation for the Level 4 Selectors spec in https://github.com/mdn/sprints/issues/1686

While these pseudos don't currently have browser support I think there is an argument to include them in order that folk can see the state of support. There are lots of articles round the web that mention them, sometimes without any detail that they are not supported. 