### PR TITLE
Spread syntax is not experimental

### DIFF
--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -251,7 +251,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -236,7 +236,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
 Spread syntax is a part of [ECMAScript (ECMA-262)](https://tc39.es/ecma262/#sec-object-initializer) for years