### PR TITLE
Publish pre-build bundles to npm (idiomatic npm life cycle script)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /node_modules/
 *.log
+dist/data.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ LICENSE
 .editorconfig
 /package-lock.json
 /CODE_OF_CONDUCT.md
+/dist/data.json

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// Try to load from source, which will be missing in the release on npm.
+try {
+  module.exports = require('../index.js');
+} catch (e) {
+  module.exports = require('./dist/data.json');
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,5 +4,5 @@
 try {
   module.exports = require('../index.js');
 } catch (e) {
-  module.exports = require('./dist/data.json');
+  module.exports = require('./data.json');
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,8 @@
   "name": "@mdn/browser-compat-data",
   "version": "2.0.7",
   "description": "Browser compatibility data provided by MDN Web Docs",
-  "main": "index.js",
+  "main": "dist/index.js",
   "types": "index.d.ts",
-  "dependencies": {
-    "extend": "3.0.2"
-  },
   "engines": {
     "node": ">=10.0.0"
   },
@@ -14,6 +11,14 @@
     "type": "git",
     "url": "git+https://github.com/mdn/browser-compat-data.git"
   },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist/data.json",
+    "dist/index.js",
+    "types.d.ts",
+    "index.d.ts"
+  ],
   "keywords": [
     "bcd",
     "browser-compat-data",
@@ -34,6 +39,7 @@
     "better-ajv-errors": "~0.6.7",
     "chalk": "~4.1.0",
     "compare-versions": "~3.6.0",
+    "extend": "~3.0.2",
     "mdn-confluence": "~2.2.0",
     "mocha": "~8.2.0",
     "ora": "~5.1.0",
@@ -48,6 +54,7 @@
     "mirror": "node scripts/mirror",
     "stats": "node scripts/statistics",
     "release-notes": "node scripts/release-notes",
+    "prepack": "node scripts/release-dist",
     "show-errors": "npm test 1> /dev/null",
     "test": "npm run mocha && npm run lint",
     "traverse": "node scripts/traverse"

--- a/scripts/release-dist.js
+++ b/scripts/release-dist.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const directory = './dist/';
+
+function createDataBundle() {
+  const bcd = require('../index.js');
+  const string = JSON.stringify(bcd);
+  return string;
+}
+
+async function main() {
+  const dest = path.resolve(directory, './data.json');
+  const data = createDataBundle();
+  await fs.writeFile(dest, data);
+}
+
+// This is needed because NodeJS does not support top-level await.
+main().then(() => console.log('Data bundle is ready'));


### PR DESCRIPTION
This PR splits up portion of #7398 to simplify review.

This PR does the following:
 - introduces `prepack` script that gets [triggered automatically](https://docs.npmjs.com/cli/v6/using-npm/scripts) on `npm publish`. This script creates data bundle `dist/data.json` for npm release.
 - introduces new main script `dist/index.js` that automatically chooses between `index.js` (for local development and testing) and `dist/data.json` (for downloads from npm)
 - moves `extend` from actual dependency to `devDependencies` because it's not needed after bundling

This PR does not:
 - remove `package.json` property  `engines`
    I'd really like to see 
 - add tests
    Where would we even plug tests with the limited flexibility of npm life cycle scripts? What would they test?

Background:
https://github.com/mdn/browser-compat-data/issues/7374

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
