### PR TITLE
Remove the api.Node.baseURIObject entry

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -151,54 +151,6 @@
           }
         }
       },
-      "baseURIObject": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/baseURIObject",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "childNodes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/childNodes",


### PR DESCRIPTION
This is a Gecko "ChromeOnly" attribute not exposed to the web:
https://github.com/mozilla/gecko-dev/blob/8a4aa0c699d9ec281d1f576c9be1c6c1f289e4e7/dom/webidl/Node.webidl#L109

The string "baseURIObject" does not appear in Chromium or WebKit source,
apart from one instane in a gecko_dom.js as part of a test suite.

https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURIObject
should be redirected to Node.
