### PR TITLE
Remove the api.Node.nodePrincipal entry

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1421,62 +1421,6 @@
           }
         }
       },
-      "nodePrincipal": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/nodePrincipal",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "46",
-              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "46",
-              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "5.0",
-              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "46",
-              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "nodeType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/nodeType",


### PR DESCRIPTION
This is a Gecko "ChromeOnly" attribute not exposed to the web:
https://github.com/mozilla/gecko-dev/blob/8a4aa0c699d9ec281d1f576c9be1c6c1f289e4e7/dom/webidl/Node.webidl#L107

The string "nodePrincipal" does not appear in Chromium or WebKit source,
apart from one instane in a gecko_dom.js as part of a test suite.

The "API was moved" notes for Chromium are from
https://github.com/mdn/browser-compat-data/pull/1179 and must be a
mistake, as the string "nodePrincipal" has never appeared in a commit
message in the entire history of Chromium.

https://developer.mozilla.org/en-US/docs/Web/API/Node/nodePrincipal
should be redirected to Node.
