### PR TITLE
Add versions for Firefox for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -234,10 +234,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -313,10 +313,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -385,10 +385,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -457,10 +457,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -843,10 +843,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "ie": {
               "version_added": false
@@ -1002,10 +1002,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds Firefox versions for the Performance API based upon results from the mdn-bcd-collector project, along with mirroring.  Some Firefox Android versions were overwritten in this PR, however the original data was from the initial migration from the wiki tables.