### PR TITLE
Remove the api.Node.rootNode entry

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1876,54 +1876,6 @@
           }
         }
       },
-      "rootNode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/rootNode",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "setUserData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/setUserData",


### PR DESCRIPTION
This was in Gecko, but quickly reverted and renamed to getRootNode():
https://github.com/mozilla/gecko-dev/commit/4967a99f0cf3814469f8ef5f33d142f586d640b6
https://github.com/mozilla/gecko-dev/commit/9adeb967f0a1f1bfe15f927ea5b7201233eedf98
https://github.com/mozilla/gecko-dev/commit/9404a1745dd91937edf7c0be89f1cfc34d2ea252

https://developer.mozilla.org/en-US/docs/Web/API/Node/rootNode
should be redirected to getRootNode instead.
