### PR TITLE
Add real values for Firefox for Range API

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -497,10 +497,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -545,10 +545,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1080,10 +1080,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/api/Range.json
+++ b/api/Range.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "4",
+            "version_added": "1",
             "notes": "Starting with Firefox 13, the <code>Range</code> object throws a <code>DOMException</code> as defined in DOM 4, instead of a <code>RangeException</code> defined in prior specifications."
           },
           "firefox_android": {


### PR DESCRIPTION
This PR adds versions for Firefox for a few features of the Range API based upon results from the mdn-bcd-collector project.