### PR TITLE
Correct Firefox data for Selection API

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -351,7 +351,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4",
+              "version_added": "1",
               "notes": "Before Firefox 35, the method didn't throw if <code>node</code> was <code>null</code>."
             },
             "firefox_android": {
@@ -449,10 +449,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -642,10 +642,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR corrects a few versions for the Selection API for Firefox based upon results from the mdn-bcd-collector project.