### PR TITLE
Add real values for Firefox for SVG element APIs

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false
@@ -347,10 +347,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGAnimateElement.json
+++ b/api/SVGAnimateElement.json
@@ -14,10 +14,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false

--- a/api/SVGAnimateMotionElement.json
+++ b/api/SVGAnimateMotionElement.json
@@ -14,10 +14,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false

--- a/api/SVGAnimateTransformElement.json
+++ b/api/SVGAnimateTransformElement.json
@@ -14,10 +14,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -14,10 +14,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false
@@ -352,10 +352,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -108,10 +108,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -155,10 +155,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -157,10 +157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "30"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "ie": {
             "version_added": false

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false

--- a/api/SVGGElement.json
+++ b/api/SVGGElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "20"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "20"
           },
           "ie": {
             "version_added": false
@@ -60,14 +60,14 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "20",
               "notes": [
                 "The <code>getBBox()</code> method returns an empty <code>DOMRect</code> when there is no fill (<a href='https://bugzil.la/1019326'>bug 1019326</a>).",
                 "This method doesn't work for <code>&lt;textPath&gt;</code> and <code>&lt;tspan&gt;</code> elements (<a href='https://bugzil.la/937268'>bug 937268</a>)."
               ]
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "20",
               "notes": [
                 "The <code>getBBox()</code> method returns an empty <code>DOMRect</code> when there is no fill (<a href='https://bugzil.la/1019326'>bug 1019326</a>).",
                 "This method doesn't work for <code>&lt;textPath&gt;</code> and <code>&lt;tspan&gt;</code> elements (<a href='https://bugzil.la/937268'>bug 937268</a>)."
@@ -115,10 +115,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false
@@ -162,10 +162,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false
@@ -209,10 +209,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": false

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -158,10 +158,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -206,10 +206,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -254,10 +254,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -302,10 +302,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -350,10 +350,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -398,10 +398,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -446,10 +446,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "20"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "20"
           },
           "ie": {
             "version_added": false

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -248,10 +248,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -295,10 +295,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -63,10 +63,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -117,10 +119,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -171,10 +175,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -225,10 +231,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -279,10 +287,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -333,10 +343,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -387,10 +399,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -441,10 +455,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -495,10 +511,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -549,10 +567,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -603,10 +623,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -657,10 +679,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -711,10 +735,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -765,10 +791,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -819,10 +847,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -873,10 +903,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -927,10 +959,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -981,10 +1015,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -1035,10 +1071,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "59"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "59"
             },
             "ie": {
               "version_added": "9"
@@ -1089,10 +1127,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1141,11 +1179,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "ie": {
@@ -1191,11 +1229,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "From version 53, this method is defined on the parent <a href='https://developer.mozilla.org/docs/Web/API/SVGGeometryElement'><code>SVGGeometryElement</code></a> interface."
             },
             "ie": {
@@ -1241,10 +1279,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -248,10 +248,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -295,10 +295,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -342,10 +342,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -15,11 +15,11 @@
             "notes": "Before Edge 79, this interface only implements the SVG 1.1 specification."
           },
           "firefox": {
-            "version_added": true,
+            "version_added": "1.5",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "firefox_android": {
-            "version_added": true,
+            "version_added": "4",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "ie": {

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -15,11 +15,11 @@
             "notes": "Before Edge 79, this only implements the SVG 1.1 specification of the interface."
           },
           "firefox": {
-            "version_added": true,
+            "version_added": "1.5",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "firefox_android": {
-            "version_added": true,
+            "version_added": "4",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "ie": {

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -15,11 +15,11 @@
             "notes": "Before Edge 79, this interface implements only the SVG 1.1 specification."
           },
           "firefox": {
-            "version_added": true,
+            "version_added": "1.5",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "firefox_android": {
-            "version_added": true,
+            "version_added": "4",
             "notes": "Only implements the SVG 1.1 specification of the interface."
           },
           "ie": {
@@ -64,10 +64,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -111,10 +111,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -158,10 +158,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -205,10 +205,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -252,10 +252,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -299,10 +299,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -107,10 +107,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1.5",
+              "version_removed": "21"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "21"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +156,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1.5",
+              "version_removed": "21"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "21"
             },
             "ie": {
               "version_added": "9"
@@ -201,11 +205,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "20"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "20"
             },
             "ie": {
               "version_added": "9"
@@ -251,11 +256,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "20"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "20"
             },
             "ie": {
               "version_added": "9"
@@ -301,10 +307,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -348,10 +354,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -395,10 +401,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -442,10 +448,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -489,10 +495,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -536,10 +542,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -583,10 +589,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -630,10 +636,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -677,10 +683,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -724,10 +730,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -773,10 +779,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5",
+              "version_removed": "21"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "version_removed": "21"
             },
             "ie": {
               "version_added": false
@@ -824,10 +832,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "ie": {
               "version_added": "9"
@@ -871,10 +879,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -918,10 +926,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1106,10 +1114,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1153,10 +1161,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1203,11 +1211,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "61"
             },
             "ie": {
@@ -1261,11 +1269,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "61"
             },
             "ie": {
@@ -1319,11 +1327,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "61"
             },
             "ie": {
@@ -1377,11 +1385,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "61"
             },
             "ie": {
@@ -1432,10 +1440,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1479,10 +1487,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1526,10 +1534,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1573,10 +1581,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1620,10 +1628,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1720,10 +1728,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "21"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "21"
             },
             "ie": {
               "version_added": "9"
@@ -1769,10 +1779,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1816,10 +1826,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1863,10 +1873,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGSetElement.json
+++ b/api/SVGSetElement.json
@@ -14,10 +14,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -248,10 +248,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -295,10 +295,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -342,10 +342,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -389,10 +389,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "2"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "20"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "20"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -248,10 +248,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -116,10 +116,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -219,10 +219,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -266,10 +266,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -313,10 +313,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "15"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "15"
           },
           "ie": {
             "version_added": "9"


### PR DESCRIPTION
This PR adds version numbers for Firefox for the SVG element APIs and its features based upon results from the mdn-bcd-collector project.  This is a cherry-pick of changes that change null/true into a version number.