### PR TITLE
Correct versions for Firefox for Window API (P1)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1570,10 +1570,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11",
@@ -2500,7 +2500,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -4204,10 +4204,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "42"
             },
             "ie": {
               "version_added": false
@@ -4656,7 +4658,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "15"
             },
             "firefox_android": {
               "version_added": "15"
@@ -5865,10 +5867,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "32"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "32"
             },
             "ie": {
               "version_added": false
@@ -7589,10 +7593,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "25"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "25"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR is part 1 of a few to correct the versions for Firefox for various features of the Window API based upon results from the mdn-bcd-collector project.  This PR specifically touches data where the version added is reduced, or the data is changed from `false` to a version added+removed range.