### PR TITLE
Correct data for Window.convertPointFromNodeToPage/PageToNode

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1321,41 +1321,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromNodeToPage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "safari": {
               "version_added": true,
               "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromNodeToPage"
             }
           },
           "status": {
@@ -1369,89 +1382,56 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromPageToNode",
           "support": {
-            "chrome": [
-              {
-                "version_added": "50",
-                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
-              },
-              {
-                "version_added": "7",
-                "version_removed": "50",
-                "notes": "Provided absolute values, not relative."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "50",
-                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "50",
-                "notes": "Provided absolute values, not relative."
-              }
-            ],
-            "edge": {
-              "version_added": "≤18"
+            "chrome": {
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
             },
-            "firefox": [
-              {
-                "version_added": "6"
-              },
-              {
-                "version_added": "3.6",
-                "version_removed": "6",
-                "alternative_name": "onmozorientation"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "6"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "6",
-                "alternative_name": "onmozorientation"
-              }
-            ],
+            "chrome_android": {
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "safari": {
               "version_added": true,
               "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "5.0",
-                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "5.0",
-                "notes": "Provided absolute values, not relative."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "50",
-                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "50",
-                "notes": "Provided absolute values, not relative."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": true,
+              "alternative_name": "webkitConvertPointFromPageToNode"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
While I was going through the Window API to update the Firefox data from mdn-bcd-collector results, I noticed something really weird with the data for the `convertPointFromPageToNode` feature.  The notes were referring to `ondeviceorientationabsolute`, doesn't make sense for this feature.  I traced this back to #2021, which was the initial addition for this data, and I believe that it was meant to be added to `ondeviceorientation` instead.

This corrects the data for both this feature (`convertPointFromPageToNode`), and the sister feature (`convertPointFromNodeToPage`), based upon manual testing in a number of browsers.  The data currently in `ondeviceorientation` seems to be more up to date than this misplaced data.  (Note: this adds "true" without version numbers.  I plan to go through and add version numbers at a later time.)