### PR TITLE
Update data for api.NavigatorID.taintEnabled

### DIFF
--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -296,40 +296,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorID/taintEnabled",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1",
+              "version_removed": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #6709.  This PR updates all of the data for the `taintEnabled` property of the `NavigatorID` mixin.