### PR TITLE
Remove media members of HTMLAnchorElement/HTMLAreaElement

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -239,54 +239,6 @@
           }
         }
       },
-      "media": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/media",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/name",

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -191,54 +191,6 @@
           }
         }
       },
-      "media": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/media",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "noHref": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/noHref",


### PR DESCRIPTION
These entries both come from wiki migration:
https://github.com/mdn/browser-compat-data/pull/1116
https://github.com/mdn/browser-compat-data/pull/1119

These do not exist in the spec, a media IDL attribute exists only on
these three interfaces:
https://html.spec.whatwg.org/#htmllinkelement
https://html.spec.whatwg.org/#htmlsourceelement
https://html.spec.whatwg.org/#htmlstyleelement

BCD already has entries for those.

The existing data suggesting media is supported on a/area seems
mistaken, and can be confirmed with these tests:
http://mdn-bcd-collector.appspot.com/tests/api/HTMLAnchorElement/media
http://mdn-bcd-collector.appspot.com/tests/api/HTMLAreaElement/media

Both return false on Chrome 86, Edge 18, Firefox 82 and Safari 14.
