### PR TITLE
Remove ghost feature: api.HTMLAreaElement.hreflang

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -191,54 +191,6 @@
           }
         }
       },
-      "hreflang": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/hreflang",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/media",


### PR DESCRIPTION
This PR removes the ghost feature: api.HTMLAreaElement.hreflang.  This feature is not supported in any browsers (despite what the current data indicates).
