### PR TITLE
Add/update Chromium data for CanvasRenderingContext2D

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1248,20 +1248,9 @@
             "chrome_android": {
               "version_added": "77"
             },
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "≤79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2439,11 +2439,11 @@
             ],
             "opera_android": [
               {
-                "version_added": "17"
+                "version_added": "18"
               },
               {
                 "version_added": true,
-                "version_removed": "17",
+                "version_removed": "18",
                 "prefix": "webkit"
               }
             ],

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2379,16 +2379,9 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "30"
-              },
-              {
-                "version_added": true,
-                "version_removed": "30",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": {
               "version_added": "15"
             },
@@ -2416,52 +2409,24 @@
               "version_added": true,
               "prefix": "ms"
             },
-            "opera": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": true,
-                "version_removed": "17",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "version_added": true,
-                "version_removed": "18",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": {
               "version_added": "9.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "2.0"
-              },
-              {
-                "version_added": true,
-                "version_removed": "2.0",
-                "prefix": "webkit"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "version_added": true,
-                "version_removed": "4.4",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "4.4"
+            }
           },
           "status": {
             "experimental": true,

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1236,7 +1236,7 @@
                 "version_added": "77"
               },
               {
-                "version_added": true,
+                "version_added": "39",
                 "flags": [
                   {
                     "type": "preference",
@@ -1276,7 +1276,7 @@
                 "version_added": "64"
               },
               {
-                "version_added": true,
+                "version_added": "26",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2468,7 +2468,7 @@
                 "version_added": "4.4"
               },
               {
-                "version_added": "≤37",
+                "version_added": true,
                 "version_removed": "4.4",
                 "prefix": "webkit"
               }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1231,27 +1231,37 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/direction",
           "support": {
-            "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "77"
             },
-            "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "≤79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -1261,11 +1271,22 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": "9"
@@ -1274,10 +1295,10 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "77"
             }
           },
           "status": {
@@ -2040,10 +2061,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -2369,9 +2390,16 @@
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": true,
+                "version_removed": "30",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": "15"
             },
@@ -2399,24 +2427,52 @@
               "version_added": true,
               "prefix": "ms"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": true,
+                "version_removed": "17",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": true,
+                "version_removed": "17",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": {
               "version_added": "9.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "version_added": true,
+                "version_removed": "2.0",
+                "prefix": "webkit"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "4.4",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -3272,10 +3328,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "safari": {
               "version_added": true
@@ -3320,10 +3388,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari": {
               "version_added": "10.1"
@@ -3551,7 +3619,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": "≤79",
@@ -3572,7 +3646,13 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
               "version_added": false
@@ -3584,10 +3664,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds and updates the Chromium data for the CanvasRenderingContext2D API based upon results from the mdn-bcd-collector project.  Many of the updates include mirroring data to Opera, Opera Android, Samsung Internet, and WebView (which all have been confirmed with collector results).