### PR TITLE
Nodejs support values: bump <0.10.0 to 0.10.0

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -24,7 +24,7 @@
             "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open. This behavior was fixed in Internet Explorer 10."
           },
           "nodejs": {
-            "version_added": "0.1.100"
+            "version_added": "0.10.0"
           },
           "opera": {
             "version_added": "10.5"
@@ -78,7 +78,7 @@
                 "version_added": "10.0.0"
               },
               {
-                "version_added": "0.1.101",
+                "version_added": "0.10.0",
                 "partial_implementation": true,
                 "notes": "Throws error when assertion fails."
               }
@@ -405,7 +405,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": "0.1.101"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11"
@@ -514,7 +514,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "10.5"
@@ -572,7 +572,7 @@
                 ]
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"
@@ -877,7 +877,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100",
+              "version_added": "0.10.0",
               "notes": "Alias for <code>console.log</code>"
             },
             "opera": {
@@ -988,7 +988,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "10.5"
@@ -1048,7 +1048,7 @@
                 ]
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"
@@ -1267,7 +1267,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "0.1.104"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11"
@@ -1318,7 +1318,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "0.1.104"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11"
@@ -1477,7 +1477,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "0.1.104"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "11"
@@ -1528,7 +1528,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100",
+              "version_added": "0.10.0",
               "notes": "Alias for <code>console.error</code>"
             },
             "opera": {
@@ -1587,7 +1587,7 @@
                 ]
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1133,7 +1133,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.9.1",
+              "version_added": "0.10.0",
               "partial_implementation": true,
               "notes": "Takes an <code>Immediate</code> object instead of the <code>immediateID</code>."
             },
@@ -8885,7 +8885,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": "0.9.1",
+              "version_added": "0.10.0",
               "partial_implementation": true,
               "notes": "Returns an <code>Immediate</code> object instead of the <code>immediateID</code>."
             },

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,41 +3,6 @@
     "nodejs": {
       "name": "Node.js",
       "releases": {
-        "0.1.100": {
-          "release_date": "2010-07-03",
-          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.100/ChangeLog",
-          "status": "retired",
-          "engine": "V8",
-          "engine_version": "2.2"
-        },
-        "0.1.101": {
-          "release_date": "2010-07-16",
-          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.101/ChangeLog",
-          "status": "retired",
-          "engine": "V8",
-          "engine_version": "2.2"
-        },
-        "0.1.104": {
-          "release_date": "2010-08-13",
-          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.104/ChangeLog",
-          "status": "retired",
-          "engine": "V8",
-          "engine_version": "2.2"
-        },
-        "0.8.0": {
-          "release_date": "2012-06-25",
-          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.8.0/ChangeLog",
-          "status": "retired",
-          "engine": "V8",
-          "engine_version": "3.11"
-        },
-        "0.9.1": {
-          "release_date": "2012-08-28",
-          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.9.1/ChangeLog",
-          "status": "retired",
-          "engine": "V8",
-          "engine_version": "3.11"
-        },
         "0.10.0": {
           "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -77,7 +77,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -129,7 +129,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -285,7 +285,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -400,7 +400,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -682,7 +682,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -849,7 +849,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -901,7 +901,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -953,7 +953,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1057,7 +1057,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1109,7 +1109,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1161,7 +1161,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1265,7 +1265,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1317,7 +1317,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1369,7 +1369,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1421,7 +1421,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1473,7 +1473,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1525,7 +1525,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1577,7 +1577,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1629,7 +1629,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1681,7 +1681,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1785,7 +1785,7 @@
                 "notes": "From Internet Explorer 5.5 through 8, all elements of the array will not be deleted if <code>deleteCount</code> is omitted. This behavior was fixed in Internet Explorer 9."
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1840,7 +1840,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2054,7 +2054,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2106,7 +2106,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -77,7 +77,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -234,7 +234,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -26,7 +26,7 @@
               "notes": "The <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO8601 Date Format</a> is not supported in Internet Explorer 8 or earlier."
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -442,7 +442,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -494,7 +494,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -546,7 +546,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -598,7 +598,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -650,7 +650,7 @@
                 "version_added": "5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -702,7 +702,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -754,7 +754,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -806,7 +806,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -858,7 +858,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -910,7 +910,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -962,7 +962,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1014,7 +1014,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1066,7 +1066,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1118,7 +1118,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1170,7 +1170,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1222,7 +1222,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1325,7 +1325,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1377,7 +1377,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1429,7 +1429,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1481,7 +1481,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1533,7 +1533,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1585,7 +1585,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1637,7 +1637,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1689,7 +1689,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1741,7 +1741,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1793,7 +1793,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1845,7 +1845,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1897,7 +1897,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1949,7 +1949,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2001,7 +2001,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2053,7 +2053,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2105,7 +2105,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2157,7 +2157,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -2209,7 +2209,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2261,7 +2261,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -2313,7 +2313,7 @@
                 "version_added": "8"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -2368,7 +2368,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -2581,7 +2581,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2794,7 +2794,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -3057,7 +3057,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -3109,7 +3109,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -3161,7 +3161,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -3213,7 +3213,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -25,7 +25,7 @@
               "version_added": "6"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -77,7 +77,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -282,7 +282,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -334,7 +334,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -385,7 +385,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -490,7 +490,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -25,7 +25,7 @@
               "version_added": "8"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "10.5"
@@ -128,7 +128,7 @@
                 "version_added": "8"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -180,7 +180,7 @@
                 "version_added": "8"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -442,7 +442,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -494,7 +494,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -598,7 +598,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -702,7 +702,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -754,7 +754,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -910,7 +910,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1014,7 +1014,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1118,7 +1118,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1222,7 +1222,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1430,7 +1430,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1638,7 +1638,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1690,7 +1690,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1742,7 +1742,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1794,7 +1794,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1846,7 +1846,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1950,7 +1950,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2054,7 +2054,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2106,7 +2106,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -180,7 +180,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -284,7 +284,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -336,7 +336,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -388,7 +388,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -441,7 +441,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -493,7 +493,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -857,7 +857,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "7"
@@ -909,7 +909,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "7"
@@ -966,7 +966,7 @@
                 "notes": "In Internet Explorer 11, numbers are rounded to 15 decimal digits. For example, <code>(1000000000000005).toLocaleString('en-US')</code> returns <code>\"1,000,000,000,000,010\"</code>."
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1125,7 +1125,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "7"
@@ -1230,7 +1230,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1282,7 +1282,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "6"
@@ -243,7 +243,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -347,7 +347,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -450,7 +450,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -553,7 +553,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"
@@ -605,7 +605,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -657,7 +657,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -709,7 +709,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -761,7 +761,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "8"
@@ -865,7 +865,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -968,7 +968,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -1145,7 +1145,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "8"
@@ -1197,7 +1197,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -1247,7 +1247,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "0.8.0"
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -1556,7 +1556,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"
@@ -1661,7 +1661,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -77,7 +77,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -505,7 +505,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -620,7 +620,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -672,7 +672,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -724,7 +724,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -776,7 +776,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -957,7 +957,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1009,7 +1009,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1061,7 +1061,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1113,7 +1113,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1165,7 +1165,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -1220,7 +1220,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "7"
@@ -1379,7 +1379,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1776,7 +1776,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1880,7 +1880,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -1984,7 +1984,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2036,7 +2036,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2088,7 +2088,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2203,7 +2203,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2255,7 +2255,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2307,7 +2307,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2359,7 +2359,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2411,7 +2411,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2466,7 +2466,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2578,7 +2578,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -2687,7 +2687,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2792,7 +2792,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2844,7 +2844,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -2896,7 +2896,7 @@
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -3161,7 +3161,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -3213,7 +3213,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -77,7 +77,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "5"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -77,7 +77,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -129,7 +129,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "7"
@@ -181,7 +181,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "7"
@@ -233,7 +233,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "7"
@@ -285,7 +285,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "7"
@@ -337,7 +337,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -389,7 +389,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -493,7 +493,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -545,7 +545,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -597,7 +597,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -649,7 +649,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -701,7 +701,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -804,7 +804,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -856,7 +856,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -140,7 +140,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -192,7 +192,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -244,7 +244,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "62"
@@ -296,7 +296,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -348,7 +348,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -400,7 +400,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -578,7 +578,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "5"
@@ -630,7 +630,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -682,7 +682,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -952,7 +952,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "9.5"
@@ -1053,7 +1053,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.5"

--- a/javascript/operators/addition.json
+++ b/javascript/operators/addition.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/addition_assignment.json
+++ b/javascript/operators/addition_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_and.json
+++ b/javascript/operators/bitwise_and.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_and_assignment.json
+++ b/javascript/operators/bitwise_and_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_not.json
+++ b/javascript/operators/bitwise_not.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_or.json
+++ b/javascript/operators/bitwise_or.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_or_assignment.json
+++ b/javascript/operators/bitwise_or_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_xor.json
+++ b/javascript/operators/bitwise_xor.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/bitwise_xor_assignment.json
+++ b/javascript/operators/bitwise_xor_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/decrement.json
+++ b/javascript/operators/decrement.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "9"

--- a/javascript/operators/division.json
+++ b/javascript/operators/division.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/division_assignment.json
+++ b/javascript/operators/division_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/equality.json
+++ b/javascript/operators/equality.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/greater_than.json
+++ b/javascript/operators/greater_than.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/greater_than_or_equal.json
+++ b/javascript/operators/greater_than_or_equal.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/increment.json
+++ b/javascript/operators/increment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/inequality.json
+++ b/javascript/operators/inequality.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -25,7 +25,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/left_shift.json
+++ b/javascript/operators/left_shift.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/left_shift_assignment.json
+++ b/javascript/operators/left_shift_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/less_than.json
+++ b/javascript/operators/less_than.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/less_than_or_equal.json
+++ b/javascript/operators/less_than_or_equal.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/logical_and.json
+++ b/javascript/operators/logical_and.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/logical_not.json
+++ b/javascript/operators/logical_not.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/logical_or.json
+++ b/javascript/operators/logical_or.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/multiplication.json
+++ b/javascript/operators/multiplication.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/multiplication_assignment.json
+++ b/javascript/operators/multiplication_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -26,7 +26,7 @@
               "version_added": "1"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/remainder.json
+++ b/javascript/operators/remainder.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/remainder_assignment.json
+++ b/javascript/operators/remainder_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/right_shift.json
+++ b/javascript/operators/right_shift.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/right_shift_assignment.json
+++ b/javascript/operators/right_shift_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/strict_equality.json
+++ b/javascript/operators/strict_equality.json
@@ -26,7 +26,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/strict_inequality.json
+++ b/javascript/operators/strict_inequality.json
@@ -26,7 +26,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/subtraction.json
+++ b/javascript/operators/subtraction.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/subtraction_assignment.json
+++ b/javascript/operators/subtraction_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "9.5"

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/unary_negation.json
+++ b/javascript/operators/unary_negation.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/unary_plus.json
+++ b/javascript/operators/unary_plus.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/unsigned_right_shift.json
+++ b/javascript/operators/unsigned_right_shift.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/unsigned_right_shift_assignment.json
+++ b/javascript/operators/unsigned_right_shift_assignment.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -25,7 +25,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -89,7 +89,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -141,7 +141,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -391,7 +391,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -443,7 +443,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "10"
@@ -496,7 +496,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -549,7 +549,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -875,7 +875,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -993,7 +993,7 @@
               "version_added": "6"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "2"
@@ -1202,7 +1202,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -1523,7 +1523,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -1918,7 +1918,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -2096,7 +2096,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -2148,7 +2148,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -2200,7 +2200,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -2253,7 +2253,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"
@@ -2356,7 +2356,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -2408,7 +2408,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -2460,7 +2460,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": "0.1.100"
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "4"


### PR DESCRIPTION
As discussed in https://github.com/mdn/browser-compat-data/issues/6861, this bumps values <0.10.0 to 0.10.0.

``` 
0.1.100 -> 0.10.0
0.1.101 -> 0.10.0
0.1.104 -> 0.10.0
0.8.0   -> 0.10.0
0.9.1   -> 0.10.0
``` 