### PR TITLE
Note support for window.home() in Opera 12.16 (Presto)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3148,7 +3148,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
               "version_added": null


### PR DESCRIPTION
Based on manually testing http://mdn-bcd-collector.appspot.com/tests/api/Window/home
in Opera 12.16 and Opera 15 in Windows 7 on BrowserStack.
