### PR TITLE
Set <menuitem> HTML element and contextmenu global attribute as non-standard

### DIFF
--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -52,7 +52,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         },
@@ -98,7 +98,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -145,7 +145,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -192,7 +192,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -239,7 +239,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -286,7 +286,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -333,7 +333,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -380,7 +380,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -578,48 +578,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contextmenu",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--enable-blink-features",
-                    "value_to_set": "ContextMenu"
-                  }
-                ],
-                "notes": "This was removed from the <i>Enable Experimental Web Platform Features</i> due to a <a href='https://crbug.com/412945'>Web compatibility issue</a>. In June 2017, it was removed entirely from the browsers. This is documented in <a href='https://crbug.com/87553'>Chromium bug 87553</a>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
             "chrome_android": {
-              "version_added": true,
-              "version_removed": "52",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
+              "version_added": false
             },
             "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--enable-blink-features",
-                  "value_to_set": "ContextMenu"
-                }
-              ]
+              "version_added": false
             },
             "firefox": {
               "version_added": "9"
@@ -632,29 +598,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--enable-blink-features",
-                    "value_to_set": "ContextMenu"
-                  }
-                ],
-                "notes": "This was removed from the <i>Enable Experimental Web Platform Features</i> due to a <a href='https://crbug.com/412945'>Web compatibility issue</a>. In June 2017, it was removed entirely from the browsers. This is documented in <a href='https://crbug.com/87553'>Chromium bug 87553</a>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
             "opera_android": {
               "version_added": false
             },
@@ -665,8 +611,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -674,7 +674,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
These were [dropped from the spec due to a lack of vendor interest](https://github.com/whatwg/html/commit/e7e8c88ecdd7cdc96171f05ab6fe23b56dd48d8a).

I also tidied up or confirmed some data that followed from this discovery:

- For Chrome (and derivatives), this was [implemented behind a flag, then moved to a different flag, then completely removed circa Chrome 61](https://bugs.chromium.org/p/chromium/issues/detail?id=87553). Rather than sort out the history of the flags, I opted to remove them under our irrelevant flags guideline.
- I saw no evidence that IE or Edge implemented this.
- Safari [implemented `<menuitem>` but never shipped it](https://trac.webkit.org/changeset/224457/webkit). I couldn't find evidence that the `contextmenu` attribute was ever supported by Safari.
- The Firefox data looks plausible, despite [an attempt at removal](https://bugzilla.mozilla.org/show_bug.cgi?id=1372276).

I have no idea what prompted me to look at this stuff in the first place.