### PR TITLE
Add CSSTransformComponent.toString method

### DIFF
--- a/api/CSSTransformComponent.json
+++ b/api/CSSTransformComponent.json
@@ -142,6 +142,54 @@
             "deprecated": false
           }
         }
+      },
+      "toString": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformComponent/toString",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The `toString()` method of `CSSTransformComponent` was missing and is causing a scripting error here: https://wiki.developer.mozilla.org/en-US/docs/Web/API/CSSTransformComponent/toString

This PR adds the method.