### PR TITLE
Remove prefix claims for Web Speech API member subfeatures

### DIFF
--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -119,17 +119,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammarList/addFromString",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -155,12 +152,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -177,17 +172,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammarList/addFromURI",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -213,12 +205,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -235,15 +225,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammarList/item",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33"
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79"
             },
             "firefox": {
@@ -268,11 +255,9 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -289,17 +274,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammarList/length",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -325,12 +307,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -121,17 +121,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/abort",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -157,12 +154,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -277,17 +272,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/continuous",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -313,12 +305,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -433,17 +423,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/grammars",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -469,12 +456,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -491,17 +476,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/interimResults",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -527,12 +509,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -549,17 +529,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/lang",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -585,12 +562,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -607,17 +582,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/maxAlternatives",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -643,12 +615,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -714,17 +684,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onaudioend",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -750,12 +717,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -772,17 +737,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onaudiostart",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -808,12 +770,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -830,17 +790,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onend",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -866,12 +823,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -888,17 +843,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onerror",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -924,12 +876,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -946,17 +896,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onnomatch",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -982,12 +929,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1004,17 +949,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onresult",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1040,12 +982,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1062,17 +1002,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onsoundend",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1098,12 +1035,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1120,17 +1055,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onsoundstart",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1156,12 +1088,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1178,17 +1108,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onspeechend",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1214,12 +1141,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1236,17 +1161,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onspeechstart",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1272,12 +1194,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1294,17 +1214,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/onstart",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1330,12 +1247,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1401,17 +1316,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/serviceURI",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1437,12 +1349,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1655,17 +1565,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/start",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1691,12 +1598,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -1762,17 +1667,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/stop",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -1798,12 +1700,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -62,17 +62,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/confidence",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -98,12 +95,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -120,17 +115,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative/transcript",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -156,12 +148,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -62,17 +62,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -98,12 +95,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -120,17 +115,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/interpretation",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -156,12 +148,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -178,17 +168,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/resultIndex",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -214,12 +201,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -236,17 +221,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/results",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -272,12 +254,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -62,17 +62,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/isFinal",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -98,12 +95,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -120,17 +115,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/item",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -156,12 +148,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -178,17 +168,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/length",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -214,12 +201,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -62,17 +62,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/item",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -98,12 +95,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }
@@ -120,17 +115,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList/length",
           "support": {
             "chrome": {
-              "prefix": "webkit",
               "version_added": "33",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "chrome_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "edge": {
-              "prefix": "webkit",
               "version_added": "≤79",
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
@@ -156,12 +148,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
-              "prefix": "webkit",
               "version_added": true,
               "notes": "You'll need to serve your code through a web server for recognition to work."
             }


### PR DESCRIPTION
The members (attributes and methods) of the Web Speech API interfaces
are not themselves prefixes, the usage is

> new webkitSpeechRecognition().start()

not the doubly prefixed

> new webkitSpeechRecognition().webkitStart()

There are also issues with prefixes on some of the interfaces
themselves, and a lot of repetetive notes, but this commit is only about
the member subfeatures.
