### PR TITLE
Update CSS text-combine-upright

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -211,26 +211,10 @@
                 }
               ],
               "firefox": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-combine-upright-digits.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-combine-upright-digits.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
+                "version_added": false
               },
               "ie": {
                 "version_added": "11",

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -27,10 +27,16 @@
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "alternative_name": "-ms-text-combine-horizontal"
-            },
+            "edge": [
+              {
+                "version_added": "15",
+                "version_removed": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-text-combine-horizontal"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "81",
@@ -194,10 +200,16 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "15",
+                  "version_removed": "79"
+                },
+                {
+                  "version_added": "12",
+                  "alternative_name": "-ms-text-combine-horizontal"
+                }
+              ],
               "firefox": {
                 "version_added": "48",
                 "flags": [

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -233,7 +233,8 @@
                 "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
               },
               "ie": {
-                "version_added": "11"
+                "version_added": "11",
+                "alternative_name": "-ms-text-combine-horizontal"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
This updates support chart for the CSS `text-combine-upright` property for Edge, IE, and Firefox.
