### PR TITLE
Add :playing and :paused pseudo-class selectors

### DIFF
--- a/css/selectors/paused.json
+++ b/css/selectors/paused.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "paused": {
+        "__compat": {
+          "description": "<code>:paused</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:paused",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/playing.json
+++ b/css/selectors/playing.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "playing": {
+        "__compat": {
+          "description": "<code>:playing</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:playing",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I am documenting the missing level 4 pseudo-classes in https://github.com/mdn/sprints/issues/1686 as far as I can tell these have no support at present. However as with the other unsupported pseudos I think it is helpful for authors to be able to see lack of support.
