### PR TITLE
Seed 103 Early Hints support

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -49,6 +49,78 @@
           }
         }
       },
+      "103": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/103",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "chrome_android": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "edge": {
+              "version_added": "12",
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "firefox": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "firefox_android": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "ie": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "opera": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "opera_android": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "safari": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "safari_ios": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            },
+            "webview_android": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Early Hints are ignored."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "200": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/200",


### PR DESCRIPTION
I'm trying to help https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103 go a bit forward, and I think MDB compatibility data could go a long way.

I only have a few browsers around to test myself, but since at this stage no browser actually implement it, but most of them simply ignore 1xx responses, I think it would be fair to assume the support list is the same than for `100 Continue`.

Fastly did put a test page online: https://early-hints.fastlylabs.com/
They do say they found a few browsers with early HTT2 support that did break https://www.fastly.com/blog/beyond-server-push-experimenting-with-the-103-early-hints-status-code


cc @mnot maybe you have some data to share?