### PR TITLE
Update nodejs initial version to 0.10.0

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -261,7 +261,7 @@ The following table indicates initial versions for browsers in BCD. These are th
 | Firefox          | 1               |                                                                                                                                                                          |
 | Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                         |
 | IE               | 1               |                                                                                                                                                                          |
-| Node.js          | 0.10.0          | This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied.                                   |
+| Node.js          | 0.10.0          | This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied. See issue #6861.                  |
 | Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                         |
 | Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                       |
 | Safari           | 1               |                                                                                                                                                                          |

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -253,21 +253,21 @@ Examples:
 
 The following table indicates initial versions for browsers in BCD. These are the earliest possible version numbers allowed to be used. When the earliest version is not naturally "1" or "1.0", see the _Notes_ column for an explanation.
 
-| Browser          | Initial version | Notes                                                                                                                                                                                |
-| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Chrome           | 1               |                                                                                                                                                                                      |
-| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                                                                                  |
-| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme.             |
-| Firefox          | 1               |                                                                                                                                                                                      |
-| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                                     |
-| IE               | 1               |                                                                                                                                                                                      |
-| Node.js          | 0.1.100         | Subject to change to 0.10.0. This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied. See issue #6861. |
-| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                                     |
-| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                                   |
-| Safari           | 1               |                                                                                                                                                                                      |
-| iOS Safari       | 1               |                                                                                                                                                                                      |
-| Samsung Internet | 1.0             |                                                                                                                                                                                      |
-| WebView Android  | 1               |                                                                                                                                                                                      |
+| Browser          | Initial version | Notes                                                                                                                                                                    |
+| ---------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Chrome           | 1               |                                                                                                                                                                          |
+| Chrome Android   | 18              | Stable versioning started at 18. No Chrome Android 17 or earlier was ever released.                                                                                      |
+| Edge             | 12              | EdgeHTML versioning started at 12, continuing from Internet Explorer 11. After version 18, Edge jumped to version 79, synchronizing with the Chromium versioning scheme. |
+| Firefox          | 1               |                                                                                                                                                                          |
+| Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                         |
+| IE               | 1               |                                                                                                                                                                          |
+| Node.js          | 0.10.0          | This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied.                                   |
+| Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                         |
+| Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                       |
+| Safari           | 1               |                                                                                                                                                                          |
+| iOS Safari       | 1               |                                                                                                                                                                          |
+| Samsung Internet | 1.0             |                                                                                                                                                                          |
+| WebView Android  | 1               |                                                                                                                                                                          |
 
 ### Ranged versions
 


### PR DESCRIPTION
I believe this is the last step to complete https://github.com/mdn/browser-compat-data/issues/6861

https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#initial-versions-for-browsers looks like it good as is, or do we want to tweak that any further?