### PR TITLE
Remove incorrect claims of prefixed Web Speech interfaces

### DIFF
--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -5,17 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionAlternative",
         "support": {
           "chrome": {
-            "prefix": "webkit",
             "version_added": "33",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "chrome_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
-            "prefix": "webkit",
             "version_added": "≤79",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
@@ -41,12 +38,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "webview_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           }

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -5,17 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult",
         "support": {
           "chrome": {
-            "prefix": "webkit",
             "version_added": "33",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "chrome_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
-            "prefix": "webkit",
             "version_added": "≤79",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
@@ -41,12 +38,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "webview_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           }

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -5,17 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResultList",
         "support": {
           "chrome": {
-            "prefix": "webkit",
             "version_added": "33",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "chrome_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
-            "prefix": "webkit",
             "version_added": "≤79",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
@@ -41,12 +38,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "webview_android": {
-            "prefix": "webkit",
             "version_added": true,
             "notes": "You'll need to serve your code through a web server for recognition to work."
           }


### PR DESCRIPTION
The set of webkitSpeech* members on the global object are:
 - webkitSpeechGrammar
 - webkitSpeechGrammarList
 - webkitSpeechRecognition
 - webkitSpeechRecognitionError
 - webkitSpeechRecognitionEvent

These 3 other SpeechRecognition* interfaces are instead decorated with
[LegacyNoInterfaceObject] in Chromium source, which means their
interfaces objects are not exposed at all. They don't have constructors,
as they are accessed from the `SpeechRecognitionResultList` at
`event.results` for a "result" event.

So while use of prefixes is required to get to these APIs, they are
not themselves prefixed.

See also https://github.com/mdn/browser-compat-data/pull/7554.