### PR TITLE
Complete nodejs data for functions

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -77,7 +77,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -129,7 +129,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -179,7 +179,7 @@
                   "version_added": "9"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.10.0"
                 },
                 "opera": {
                   "version_added": "5"
@@ -231,7 +231,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -283,7 +283,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "11.6"
@@ -335,7 +335,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -386,7 +386,7 @@
                 "version_added": "8"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "9.6"
@@ -489,7 +489,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"
@@ -539,7 +539,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "4.0.0"
                 },
                 "opera": {
                   "version_added": "30"
@@ -592,7 +592,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "10.5"
@@ -642,7 +642,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "4.0.0"
                 },
                 "opera": {
                   "version_added": "30"
@@ -694,9 +694,20 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": null
-                },
+                "nodejs": [
+                  {
+                    "version_added": "6.5.0"
+                  },
+                  {
+                    "version_added": "6.0.0",
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--harmony"
+                      }
+                    ]
+                  }
+                ],
                 "opera": {
                   "version_added": "38"
                 },
@@ -801,7 +812,7 @@
                 "version_added": "5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -86,9 +86,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "4.0.0"
+                },
+                {
+                  "version_added": "0.12.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "26"
               },

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -24,9 +24,20 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "26"
             },

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -24,7 +24,7 @@
             "version_added": "3"
           },
           "nodejs": {
-            "version_added": true
+            "version_added": "0.10.0"
           },
           "opera": {
             "version_added": "3"
@@ -75,7 +75,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "3"
@@ -126,7 +126,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -178,7 +178,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "4"
@@ -233,7 +233,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "39"
@@ -294,9 +294,22 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.12.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ],
+                "partial_implementation": true,
+                "notes": "The arrow function syntax is supported, but not the correct lexical binding of the <code>this</code> value."
+              }
+            ],
             "opera": {
               "version_added": "32"
             },
@@ -345,7 +358,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "8.0.0"
               },
               "opera": {
                 "version_added": "45"
@@ -396,9 +409,20 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": {
-              "version_added": null
-            },
+            "nodejs": [
+              {
+                "version_added": "4.0.0"
+              },
+              {
+                "version_added": "0.10.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony"
+                  }
+                ]
+              }
+            ],
             "opera": {
               "version_added": "36"
             },
@@ -500,7 +524,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -551,7 +575,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -604,7 +628,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "9.5"
@@ -654,7 +678,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "47"
@@ -708,7 +732,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "4.0.0"
             },
             "opera": {
               "version_added": "26"
@@ -997,7 +1021,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -1050,7 +1074,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "9.5"
@@ -1100,7 +1124,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "47"


### PR DESCRIPTION
Part of #6249. This fills in all the `true` and `null` values for all function-related entries for Node.js

Thanks to the new minimum version of `0.10.0`, most of the entries get assigned to that version. The rest were checked on [node.green](https://node.green) and cross-referenced against Chrome via the V8 version (plus some manual testing).