### PR TITLE
CSSImportRule supported in Opera ≤12.1

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": "≤15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "≤14"
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -70,10 +70,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -118,10 +118,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -166,10 +166,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"


### PR DESCRIPTION
Based upon results from the mdn-bcd-collector project, I've determined that the `CSSImportRule` API was supported in Opera Presto.  This PR corrects the data accordingly, switching the range from `≤15` to `≤12.1`.