### PR TITLE
Add const variables from CSSPrimitiveValue API

### DIFF
--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -55,6 +55,1436 @@
           "deprecated": true
         }
       },
+      "CSS_ATTR": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_CM": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_COUNTER": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_DEG": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_DIMENSION": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_EMS": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_EXS": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_GRAD": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_HZ": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_IDENT": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_IN": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_KHZ": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_MM": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_MS": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_NUMBER": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_PC": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_PERCENTAGE": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_PT": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_PX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_RAD": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_RECT": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_RGBCOLOR": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_S": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_STRING": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_UNKNOWN": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "CSS_URI": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "getCounterValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getCounterValue",


### PR DESCRIPTION
This PR is a part of a project to add missing features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features for the CSSPrimitiveValue API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Spec: https://www.w3.org/TR/DOM-Level-2-Style/css.html

The features that are added in this PR are all `const` variables.  I've seen a mix of whether BCD records `const` variables for APIs, but I'm assuming that we do.  If not, we should probably document as such in the data guidelines.