### PR TITLE
Add VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE to ANGLE_instanced_arrays API

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "32"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "47"
+            },
+            "firefox_android": {
+              "version_added": "47"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "19"
+            },
+            "opera_android": {
+              "version_added": "19"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
+            "webview_android": {
+              "version_added": "4.4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawArraysInstancedANGLE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features for the ANGLE_instanced_arrays API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Spec: https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/