### PR TITLE
Add/update data for dir HTML element

### DIFF
--- a/api/HTMLDirectoryElement.json
+++ b/api/HTMLDirectoryElement.json
@@ -19,7 +19,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤9"
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/HTMLDirectoryElement.json
+++ b/api/HTMLDirectoryElement.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "HTMLDirectoryElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "≤9"
+          },
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
+          },
+          "safari": {
+            "version_added": "≤4"
+          },
+          "safari_ios": {
+            "version_added": "≤3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "1"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "compact": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLDirectoryElement.json
+++ b/api/HTMLDirectoryElement.json
@@ -43,7 +43,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "compact": {
@@ -89,7 +89,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/html/elements/dir.json
+++ b/html/elements/dir.json
@@ -6,40 +6,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dir",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "≤6"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -52,40 +52,40 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "18"
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "4"
               },
               "ie": {
-                "version_added": false
+                "version_added": "≤6"
               },
               "opera": {
-                "version_added": false
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": false
+                "version_added": "≤4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "≤3"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds the missing HTMLDirectoryElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Spec: https://html.spec.whatwg.org/multipage/obsolete.html#htmldirectoryelement

Edit: this also updates the data for the HTML element itself.