### PR TITLE
Mark top level await supported behind a flag in Firefox 85

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -80,11 +80,22 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1519100'>bug 1519100</a>"
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.top_level_await"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.top_level_await"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests): https://bugzil.la/1519100
- [x] Data: if you tested something, describe how you tested with details like browser and version

```html
<script type="module">
  console.log("foo");
  await new Promise(resolve => setTimeout(resolve, 5000));
  console.log("bar");
</script>
```

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
