### PR TITLE
Add checkValidity/setCustomValidity features of HTMLFieldSetElement API

### DIFF
--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "checkValidity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/disabled",
@@ -326,6 +373,53 @@
             },
             "webview_android": {
               "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setCustomValidity": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the HTMLFieldSetElement API.

Spec: https://html.spec.whatwg.org/multipage/form-elements.html#htmlfieldsetelement
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
