### PR TITLE
Add missing features for HTMLIFrameElement

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -621,6 +621,53 @@
           }
         }
       },
+      "getSVGDocument": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/height",
@@ -660,6 +707,53 @@
             },
             "webview_android": {
               "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loading": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "55"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "77"
             }
           },
           "status": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -744,10 +744,12 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -521,10 +521,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "76"
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": "76"
+                "version_added": "77"
               },
               "edge": {
                 "version_added": "79"
@@ -539,10 +539,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "63"
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": "54"
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false,
@@ -553,10 +553,10 @@
                 "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "12.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "77"
               }
             },
             "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the HTMLIFrameElement API.

Spec: https://html.spec.whatwg.org/multipage/semantics.html#htmliframeelement
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
