### PR TITLE
Add missing features for HTMLMarqueeElement API

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -331,6 +331,150 @@
           }
         }
       },
+      "onbounce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "onfinish": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "onstart": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "scrollAmount": {
         "__compat": {
           "support": {
@@ -382,6 +526,53 @@
         "__compat": {
           "support": {
             "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "≤6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "start": {
+        "__compat": {
+          "support": {
+            "chrome": {
               "version_added": "1"
             },
             "chrome_android": {
@@ -397,25 +588,72 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": "2"
+              "version_added": "≤6"
             },
             "opera": {
-              "version_added": "7.2"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "10.1"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "stop": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤13.0"
+            },
+            "webview_android": {
+              "version_added": "≤86"
             }
           },
           "status": {

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -553,7 +553,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -650,10 +650,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "≤13.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤86"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the HTMLMarqueeElement API.

Spec: https://html.spec.whatwg.org/multipage/semantics.html#htmlmarqueeelement
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
