### PR TITLE
Add missing Option constructor of HTMLOptionElement

### DIFF
--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "Option": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "≤6"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "defaultSelected": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/defaultSelected",

--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -49,6 +49,8 @@
       },
       "Option": {
         "__compat": {
+          "description": "<code>Option()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/Option",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the HTMLOptionElement API.

Spec: https://html.spec.whatwg.org/multipage/semantics.html#htmloptionelement
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
