### PR TITLE
Add api.HTMLVideoElement.playsInline

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -541,6 +541,53 @@
           }
         }
       },
+      "playsInline": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": {
+              "version_added": "75"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "75"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "poster": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/poster",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the HTMLVideoElement API.

Spec: https://html.spec.whatwg.org/multipage/semantics.html#htmlvideoelement
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
