### PR TITLE
Require real values for nodejs in javascript/

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -33,7 +33,7 @@ const blockList = {
   html: [],
   http: [],
   svg: [],
-  javascript: blockMany,
+  javascript: [...blockMany, 'nodejs'],
   mathml: blockMany,
   webdriver: blockMany,
   webextensions: [],


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/6249

BCD now has complete data for `nodejs` in the `javascript/` folder :tada: :tada: 

This was possible after we fixed the initial version to `0.10.0` in https://github.com/mdn/browser-compat-data/issues/6861 and also because there are a few amazing folks that helped getting version info:

Special thanks to:
- @gilmoreorless 
- @joneskj55 
- @ddbeck 
- @vinyldarkscratch 

for your PRs and reviews with all these issues related to this story.

In order to not allow new "true" or "null" values, this change adds `nodejs` to the blocklist for the `javascript/ `folder.