### PR TITLE
Mark Application Cache features non-standard

### DIFF
--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -90,8 +90,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -100,7 +100,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           },


### PR DESCRIPTION
Per https://github.com/whatwg/html/pull/6153 and https://github.com/whatwg/html/commit/e4330d5, the Application Cache feature is no longer part of the HTML standard. So this change marks both the `applicationCache` member of `SharedWorkerGlobalScope` and the `manifest` attribute of the `html` element as `standard_track:false`.

---

I’ve also already updated the following MDN articles:

* https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html/manifest