### PR TITLE
Rename NDEFReader.prototype.onerror to NDEFReader.prototype.onreadingerror

### DIFF
--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -96,9 +96,9 @@
           }
         }
       },
-      "onerror": {
+      "onreadingerror": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onerror",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onreadingerror",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -96,9 +96,9 @@
           }
         }
       },
-      "onreadingerror": {
+      "onread": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onreadingerror",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onread",
           "support": {
             "chrome": {
               "version_added": false
@@ -144,9 +144,9 @@
           }
         }
       },
-      "onread": {
+      "onreadingerror": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onread",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onreadingerror",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This change renames `NDEFReader.prototype.onerror` to `NDEFReader.prototype.onreadingerror,` per the spec change at https://github.com/w3c/web-nfc/commit/a71bff9 (https://github.com/w3c/web-nfc/pull/601).

---

No browsers yet implement this feature, so alternatively, we could just remove it from BCD.

I’ve already also updated MDN for this, to make https://developer.mozilla.org/docs/Web/API/NDEFReader/onerror a redirect to https://developer.mozilla.org//docs/Web/API/NDEFReader/onreadingerror