### PR TITLE
Document 'text/html' support in Clipboard API for Chrome

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -53,6 +53,11 @@
           "support": {
             "chrome": [
               {
+                "version_added": "86",
+                "partial_implementation": true,
+                "notes": "From version 86, the <code>text/html</code> MIME type is supported."
+              },
+              {
                 "version_added": "76",
                 "partial_implementation": true,
                 "notes": "From version 76, the <code>image/png</code> MIME type is supported."
@@ -64,6 +69,11 @@
               }
             ],
             "chrome_android": [
+              {
+                "version_added": "86",
+                "partial_implementation": true,
+                "notes": "From version 86, the <code>text/html</code> MIME type is supported."
+              },
               {
                 "version_added": "84",
                 "partial_implementation": true,


### PR DESCRIPTION
Chrome added support for 'text/html' MIME type in Chrome 86.

Source: https://www.chromestatus.com/feature/5357049665814528