### PR TITLE
Mark OverconstrainedErrorEvent non-standard

### DIFF
--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "error": {
@@ -90,8 +90,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This change marks `OverconstrainedErrorEvent` as `standard_track:false` and `deprecated:true`.

It was implemented only on WebKit, and is no longer part of any spec; https://github.com/w3c/mediacapture-main/issues/573 removed it.