### PR TITLE
Edge 87 adds support for text-[decoration-thickness,underline-offset]

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -12,7 +12,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": [
               {

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -12,7 +12,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": [
               {

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -163,7 +163,7 @@
                 "version_added": "87"
               },
               "edge": {
-                "version_added": false
+                "version_added": "87"
               },
               "firefox": {
                 "version_added": "74"


### PR DESCRIPTION
Also add support for `from-font` in `text-underline-position`.

The same changes that were made for Chrome 87 in 116a3bd (#7395) also apply to Edge 87.

Verified by testing in Edge 86 and 87 on BrowserStack, with the CSS:

```
a {
  text-decoration-color: red;
  text-decoration-thickness: 3px;
  text-underline-offset: 3px;
}
```

In Edge 86, the underline is red but only the default user agent thickness, and not offset. Developer tools also flags the `text-decoration-thickness` and `text-underline-offset` properties as invalid.

![Edge 86 with text-decoration-thickness and text-underline-offset not having any effect](https://user-images.githubusercontent.com/121939/101518915-7106da80-397a-11eb-9baf-d2319e3abd5e.png)

In Edge 87, it has 3px thickness and is offset, and has the same appearance that it does in Chrome 87)

![Edge 86 with text-decoration-thickness and text-underline-offset working as expected](https://user-images.githubusercontent.com/121939/101518929-7401cb00-397a-11eb-9454-e971c0818bfc.png)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any