### PR TITLE
Mark RTCRtpSynchronizationSource: voiceActivityFlag non-standard and deprecated

### DIFF
--- a/api/RTCRtpSynchronizationSource.json
+++ b/api/RTCRtpSynchronizationSource.json
@@ -118,8 +118,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This change marks the `voiceActivityFlag` member of the `RTCRtpSynchronizationSource` dictionary as `standard_track:false` and `deprecated:true`, due to it having been dropped from the spec in https://github.com/w3c/webrtc-pc/commit/09ca64e (https://github.com/w3c/webrtc-pc/pull/2610).