### PR TITLE
Mark ShadowRoot.p.delegatesFocus non-standard

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -116,8 +116,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks `ShadowRoot.prototype.delegatesFocus` as `standard_track:false` and `deprecated:true`. https://dom.spec.whatwg.org/#interface-shadowroot doesn’t (yet) actually define any such exposed property — neither for `ShadowRoot` nor for the interfaces it inherits from.

Blink/Chrome does expose such a property, but that’s not due to any actual spec requirements.

Related: https://github.com/mdn/sprints/issues/3917, https://github.com/whatwg/dom/issues/931

---

cc @unarist, @gregwhitworth