### PR TITLE
Fix name of j.o.subtraction_assignment

### DIFF
--- a/javascript/operators/subtraction_assignment.json
+++ b/javascript/operators/subtraction_assignment.json
@@ -1,7 +1,7 @@
 {
   "javascript": {
     "operators": {
-      "substraction_assignment": {
+      "subtraction_assignment": {
         "__compat": {
           "description": "Subtraction assignment (<code>x -= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment",


### PR DESCRIPTION
`javascript.operators.substraction_assignment` should be `javascript.operators.subtraction_assignment`. Found while trying to match `mdn/content` articles to `mdn/browser-compat-data`.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
