### PR TITLE
Add ApplicationCache API

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -48,7 +48,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "abort": {
@@ -99,7 +99,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -151,7 +151,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -203,7 +203,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -255,7 +255,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -307,7 +307,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -359,7 +359,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -411,7 +411,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -463,7 +463,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -515,7 +515,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -567,7 +567,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -619,7 +619,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -671,7 +671,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -47,7 +47,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -98,7 +98,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -150,7 +150,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -202,7 +202,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -254,7 +254,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -306,7 +306,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -358,7 +358,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -410,7 +410,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -462,7 +462,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -514,7 +514,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -566,7 +566,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -618,7 +618,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -670,7 +670,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -1,0 +1,680 @@
+{
+  "api": {
+    "ApplicationCache": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "5",
+            "version_removed": "85"
+          },
+          "chrome_android": {
+            "version_added": "18",
+            "version_removed": "85"
+          },
+          "edge": {
+            "version_added": "12",
+            "version_removed": "86"
+          },
+          "firefox": {
+            "version_added": "3"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "10"
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "71"
+          },
+          "opera_android": {
+            "version_added": "≤12.1",
+            "version_removed": "60"
+          },
+          "safari": {
+            "version_added": "≤4"
+          },
+          "safari_ios": {
+            "version_added": "≤3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "abort": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "oncached": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onchecking": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ondownloading": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onerror": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onnoupdate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onobsolete": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onprogress": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onupdateready": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "status": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "swapCache": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "update": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the now-deprecated ApplicationCache API.

Spec: http://web.archive.org/web/20201129180031/https://html.spec.whatwg.org/multipage/offline.html
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
