### PR TITLE
Add CompressionStream + DecompressionStream APIs

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -1,0 +1,193 @@
+{
+  "api": {
+    "CompressionStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "80"
+          },
+          "chrome_android": {
+            "version_added": "80"
+          },
+          "edge": {
+            "version_added": "80"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "67"
+          },
+          "opera_android": {
+            "version_added": "57"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "80"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CompressionStream": {
+        "__compat": {
+          "description": "<code>CompressionStream()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -42,7 +42,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -89,7 +89,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -136,7 +136,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -183,7 +183,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -1,0 +1,193 @@
+{
+  "api": {
+    "DecompressionStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "80"
+          },
+          "chrome_android": {
+            "version_added": "80"
+          },
+          "edge": {
+            "version_added": "80"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "67"
+          },
+          "opera_android": {
+            "version_added": "57"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "80"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "DecompressionStream": {
+        "__compat": {
+          "description": "<code>DecompressionStream()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -42,7 +42,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -89,7 +89,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -136,7 +136,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -183,7 +183,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the CompressionStream and DecompressionStream APIs.

Spec: https://wicg.github.io/compression/
IDL: https://github.com/w3c/webref/blob/master/ed/idl/compression.idl
