### PR TITLE
Note an issue with text-decoration-thickness in Chrome, Edge

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -6,13 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "87",
+              "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>"
             },
             "chrome_android": {
-              "version_added": "87"
+              "version_added": "87",
+              "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>"
             },
             "edge": {
-              "version_added": "87"
+              "version_added": "87",
+              "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>"
             },
             "firefox": [
               {
@@ -52,7 +55,8 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "87"
+              "version_added": "87",
+              "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>"
             }
           },
           "status": {


### PR DESCRIPTION
Following on from https://github.com/mdn/browser-compat-data/pull/7618#issuecomment-741643427.

The `text-decoration-thickness` property does not work unless either `text-underline-offset` is set to something other than `auto` or `text-decoration-color` is set to something other than `currentColor`.

See https://crbug.com/1154537.

Still seeing this in Chrome 88 / Edge 88 betas, but Chrome Canary 89 does not have this issue. However, I’m not sure exactly how the Chrome / Edge release process works and so am not sure if this fix might end up in Chrome 88 as well, so not able to provide a bounded version range until Chrome 88 is stable.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
