### PR TITLE
Correct data errors in certain CSS interfaces.

### DIFF
--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -47,54 +47,6 @@
           "deprecated": false
         }
       },
-      "CSSNumericValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/CSSNumericValue",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/entries",
@@ -290,54 +242,6 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/values",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "@@iterator": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/@@iterator",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -431,54 +431,6 @@
             "deprecated": false
           }
         }
-      },
-      "@@iterator": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/@@iterator",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -383,54 +383,6 @@
             "deprecated": false
           }
         }
-      },
-      "@@iterator": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/@@iterator",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
The corrects a few errors with some CSS interfaces.

None of them have `@@iterator` which must be [present in the the IDL](https://heycam.github.io/webidl/#es-iterator). They are in neither [the spec](https://drafts.css-houdini.org/css-typed-om/), nor Chrome's implemention of it:

* [CSSNumericArray](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/cssom/css_numeric_array.idl)
* [CSSTransformValue](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/cssom/css_transform_value.idl)
* [CSSUnparsedValue](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/cssom/css_unparsed_value.idl)

The setters and getters listed in the IDL were misinterpreted as functions. For example, instead of there being a method named `CSSNumericArray.CSSNumbericValue` there is actually the ability to treat an instance of the interface as an array. In other words, `CSSNumbericArray[n]` would be a valid programming reference.
