### PR TITLE
Update Intl.ListFormat for Safari 14.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -173,6 +173,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"
+        },
+        "14.1": {
+          "release_notes": "https://developer.apple.com/safari/technology-preview/release-notes/"
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -175,7 +175,7 @@
           "engine_version": "610.1.28"
         },
         "14.1": {
-          "release_notes": "https://developer.apple.com/safari/technology-preview/release-notes/"
+          "release_notes": "https://developer.apple.com/safari/technology-preview/release-notes/",
           "status": "beta",
           "engine": "WebKit"
         }

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -36,7 +36,7 @@
                 "version_added": "51"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -95,7 +95,7 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -148,7 +148,7 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -201,7 +201,7 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -254,7 +254,7 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -313,7 +313,7 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
                   "version_added": false


### PR DESCRIPTION
Safari 14.1 adds support for these operations. 14.1 is still in testing with Safari Technology Preview. I've added 14.1 as the version added for Safari on Desktop.

I tested this by running the MDN code examples for each section with Safari Technology Preview 117.

Webkit Release Notes: https://webkit.org/blog/11364/release-notes-for-safari-technology-preview-117/

I've never made a PR here before so I hope this is all good.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
