### PR TITLE
Add BarProp API

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "BarProp": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "29"
+          },
+          "chrome_android": {
+            "version_added": "29"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "16"
+          },
+          "opera_android": {
+            "version_added": "16"
+          },
+          "safari": {
+            "version_added": "6.1"
+          },
+          "safari_ios": {
+            "version_added": "7"
+          },
+          "samsunginternet_android": {
+            "version_added": "2.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "visible": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the BarProp API.

Spec: https://html.spec.whatwg.org/multipage/window-object.html#barprop
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
