### PR TITLE
Add missing WebGL extensions

### DIFF
--- a/api/EXT_disjoint_timer_query_webgl2.json
+++ b/api/EXT_disjoint_timer_query_webgl2.json
@@ -1,0 +1,110 @@
+{
+  "api": {
+    "EXT_disjoint_timer_query_webgl2": {
+      "__compat": {
+        "support": {
+          "chrome": [
+            {
+              "version_added": "70"
+            },
+            {
+              "version_added": "56",
+              "version_removed": "62"
+            }
+          ],
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "queryCounterEXT": {
+        "__compat": {
+          "support": {
+            "chrome": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "62"
+              }
+            ],
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -2,6 +2,7 @@
   "api": {
     "EXT_texture_norm16": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_norm16",
         "support": {
           "chrome": {
             "version_added": "87"

--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "EXT_texture_norm16": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "87"
+          },
+          "chrome_android": {
+            "version_added": "87"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "87"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "WEBGL_multi_draw": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "86"
+          },
+          "chrome_android": {
+            "version_added": "86"
+          },
+          "edge": {
+            "version_added": "86"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "72"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "86"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "multiDrawArraysInstancedWEBGL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "multiDrawArraysWEBGL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "multiDrawElementsInstancedWEBGL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "multiDrawElementsWEBGL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -2,6 +2,7 @@
   "api": {
     "WEBGL_multi_draw": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -48,6 +49,7 @@
       },
       "multiDrawArraysInstancedWEBGL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -95,6 +97,7 @@
       },
       "multiDrawArraysWEBGL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -142,6 +145,7 @@
       },
       "multiDrawElementsInstancedWEBGL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -189,6 +193,7 @@
       },
       "multiDrawElementsWEBGL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL",
           "support": {
             "chrome": {
               "version_added": "86"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds three missing WebGL extensions, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Specs:
https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/
https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/
https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/

Note: the results for EXT_disjoint_timer_query_webgl2 seem a little bit odd.  I've confirmed these results manually however.