### PR TITLE
Add TextTrackCueList

### DIFF
--- a/api/TextTrackCueList.json
+++ b/api/TextTrackCueList.json
@@ -109,7 +109,7 @@
               "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "32"
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -118,7 +118,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10"

--- a/api/TextTrackCueList.json
+++ b/api/TextTrackCueList.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "TextTrackCueList": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "23"
+          },
+          "chrome_android": {
+            "version_added": "25"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "31"
+          },
+          "firefox_android": {
+            "version_added": "31"
+          },
+          "ie": {
+            "version_added": "10"
+          },
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
+          },
+          "safari": {
+            "version_added": "6"
+          },
+          "safari_ios": {
+            "version_added": "6"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.5"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getCueById": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "23"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "length": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "44"
+            },
+            "chrome_android": {
+              "version_added": "44"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "31"
+            },
+            "opera_android": {
+              "version_added": "31"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "44"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TextTrackCueList.json
+++ b/api/TextTrackCueList.json
@@ -53,7 +53,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "23"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -109,7 +109,7 @@
               "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "ie": {
               "version_added": "10"

--- a/api/TextTrackCueList.json
+++ b/api/TextTrackCueList.json
@@ -97,10 +97,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -115,22 +115,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the TextTrackCueList API.

Spec: https://html.spec.whatwg.org/multipage/media.html#texttrackcuelist
IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl
