### PR TITLE
Add Trusted* APIs

### DIFF
--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "TrustedHTML": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "83"
+          },
+          "chrome_android": {
+            "version_added": "83"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "69"
+          },
+          "opera_android": {
+            "version_added": "59"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "83"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "TrustedScript": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "83"
+          },
+          "chrome_android": {
+            "version_added": "83"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "69"
+          },
+          "opera_android": {
+            "version_added": "59"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "83"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "TrustedScriptURL": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "83"
+          },
+          "chrome_android": {
+            "version_added": "83"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "69"
+          },
+          "opera_android": {
+            "version_added": "59"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "83"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "TrustedTypePolicy": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "83"
+          },
+          "chrome_android": {
+            "version_added": "83"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "69"
+          },
+          "opera_android": {
+            "version_added": "59"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "83"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "createHTML": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createScript": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createScriptURL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -1,0 +1,474 @@
+{
+  "api": {
+    "TrustedTypePolicyFactory": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "83"
+          },
+          "chrome_android": {
+            "version_added": "83"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "69"
+          },
+          "opera_android": {
+            "version_added": "59"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "83"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "createPolicy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "defaultPolicy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptyHTML": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptyScript": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAttributeType": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getPropertyType": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isHTML": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isScript": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isScriptURL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for various trusted type APIs.

Spec: https://w3c.github.io/webappsec-trusted-types/dist/spec/
IDL: https://github.com/w3c/webref/blob/master/ed/idl/trusted-types.idl
