### PR TITLE
 Update anchor and area support of target=_blank imply rel=noopener 

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -383,7 +383,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "12.1"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -356,10 +356,10 @@
             "description": "<code>target=\"_blank\"</code> implies <code>rel=\"noopener\"</code> behavior",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false
@@ -383,7 +383,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "12.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -395,7 +395,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -362,7 +362,7 @@
                 "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
                 "version_added": "79"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -341,7 +341,7 @@
                 "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
                 "version_added": "79"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -362,7 +362,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "12.1"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -335,10 +335,10 @@
             "description": "<code>target=\"_blank\"</code> implies <code>rel=\"noopener\"</code> behavior",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false
@@ -362,7 +362,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "12.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -374,7 +374,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
- [Chrome 88 supports it](https://bugs.chromium.org/p/chromium/issues/detail?id=898942)
- [Safari 12.1 support it](https://developer.apple.com/documentation/safari-release-notes/safari-12_1-release-notes) (see also [Revision 237144 – WebKit](https://trac.webkit.org/changeset/237144/webkit/))

Fix mdn#7324

Change depreciated flag to false, [it's now a recommendation](https://github.com/whatwg/html/pull/4330).