### PR TITLE
Add WebGLTimerQueryEXT API

### DIFF
--- a/api/WebGLTimerQueryEXT.json
+++ b/api/WebGLTimerQueryEXT.json
@@ -1,0 +1,65 @@
+{
+  "api": {
+    "WebGLTimerQueryEXT": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "chrome_android": {
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "51",
+            "version_removed": "59",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "34",
+            "version_removed": "52",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "opera_android": {
+            "version_added": "34",
+            "version_removed": "47",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "5.0",
+            "version_removed": "9.0",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "webview_android": {
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the WebGLTimerQueryEXT API.

Spec: https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/

This API is for the object returned by EXT_disjoint_timer_query.createQueryEXT()
