### PR TITLE
Add XPathEvaluator

### DIFF
--- a/api/XPathEvaluator.json
+++ b/api/XPathEvaluator.json
@@ -48,6 +48,7 @@
       },
       "XPathEvaluator": {
         "__compat": {
+          "description": "<code>XPathEvaluator()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/XPathEvaluator.json
+++ b/api/XPathEvaluator.json
@@ -2,7 +2,7 @@
   "api": {
     "XPathEvaluator": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathEvaluator",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -97,7 +97,7 @@
       },
       "createExpression": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/createExpression",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathEvaluator/createExpression",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -145,7 +145,7 @@
       },
       "createNSResolver": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/createNSResolver",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathEvaluator/createNSResolver",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -193,7 +193,7 @@
       },
       "evaluate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/evaluate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathEvaluator/evaluate",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/XPathEvaluator.json
+++ b/api/XPathEvaluator.json
@@ -2,6 +2,7 @@
   "api": {
     "XPathEvaluator": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -96,6 +97,7 @@
       },
       "createExpression": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/createExpression",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -143,6 +145,7 @@
       },
       "createNSResolver": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/createNSResolver",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -190,6 +193,7 @@
       },
       "evaluate": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator/evaluate",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/XPathEvaluator.json
+++ b/api/XPathEvaluator.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "XPathEvaluator": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
+          },
+          "safari": {
+            "version_added": "≤4"
+          },
+          "safari_ios": {
+            "version_added": "≤3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "1"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "XPathEvaluator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createExpression": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createNSResolver": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "evaluate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the XPathEvaluator API.

Spec: https://dom.spec.whatwg.org/#interface-xpathevaluator
IDL: https://github.com/w3c/webref/blob/master/ed/idl/dom.idl
