### PR TITLE
Update Edge support for JavaScript features in Chromium

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -13,7 +13,7 @@
               "version_added": "85"
             },
             "edge": {
-              "version_added": false
+              "version_added": "85"
             },
             "firefox": {
               "version_added": "79"
@@ -65,7 +65,7 @@
                 "version_added": "85"
               },
               "edge": {
-                "version_added": false
+                "version_added": "85"
               },
               "firefox": {
                 "version_added": "79"

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -12,7 +12,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"
@@ -777,7 +777,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "57"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -228,7 +228,7 @@
                 "version_added": "85"
               },
               "edge": {
-                "version_added": false
+                "version_added": "85"
               },
               "firefox": {
                 "version_added": "79"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -123,7 +123,7 @@
                     "version_added": "76"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "79"
@@ -324,7 +324,7 @@
                     "version_added": "76"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "79"
@@ -430,7 +430,7 @@
                   "version_added": "76"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -483,7 +483,7 @@
                   "version_added": "76"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false

--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -14,7 +14,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "62"
@@ -66,7 +66,7 @@
                   "version_added": "69"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "62"
@@ -117,7 +117,7 @@
                   "version_added": "69"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "62"
@@ -168,7 +168,7 @@
                   "version_added": "69"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "62"


### PR DESCRIPTION
This mirrors a few JavaScript features from Chrome to Edge (I think some of this was forgotten when we initially mirrored for Edge 79 as other PRs got merged around the same time then).

Also fixes https://github.com/mdn/browser-compat-data/issues/6711

