### PR TITLE
Update nodejs features based on v8/chrome support

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -282,7 +282,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.9.0"
                 },
                 "opera": {
                   "version_added": false
@@ -332,7 +332,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.9.0"
                 },
                 "opera": {
                   "version_added": false

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -230,7 +230,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "60"

--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -26,7 +26,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "11.0.0"
               },
               "opera": {
                 "version_added": false
@@ -78,7 +78,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "11.0.0"
                 },
                 "opera": {
                   "version_added": false
@@ -129,7 +129,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "11.0.0"
                 },
                 "opera": {
                   "version_added": false
@@ -180,7 +180,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "11.0.0"
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
I wondered what the difference between our data for Chrome and nodejs is given they both use v8.
Here's some updates that fix the discrepancies.

A few discrepancies left, but I think nodejs doesn't support these (unlike Chrome): 
javascript.builtins.WebAssembly.compileStreaming
javascript.builtins.WebAssembly.instantiateStreaming
javascript.statements.import.worker_support