### PR TITLE
Set Chromium real values for api.Navigator.registerContentHandler

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1780,10 +1780,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/registerContentHandler",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "6"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -1799,10 +1800,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -1811,10 +1814,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets real values for Chromium for the `registerContentHandler` feature of the Navigator API based upon results from the mdn-bcd-collector project.