### PR TITLE
Fix discrepancies between Firefox & Firefox Android for JS data

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -71,7 +71,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1884,7 +1884,7 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": false
@@ -1942,7 +1942,7 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -18,7 +18,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "ie": {
               "version_added": false
@@ -783,7 +783,7 @@
                 "version_added": "57"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -276,7 +276,7 @@
                   "version_added": "70"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -326,7 +326,7 @@
                   "version_added": "70"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2412,7 +2412,7 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": false
@@ -2625,7 +2625,7 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": false
@@ -2838,7 +2838,7 @@
                   "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -182,7 +182,7 @@
                 "version_added": "71"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -174,7 +174,7 @@
                 "version_added": "78"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -806,8 +806,7 @@
                 "version_added": "78"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -1014,7 +1013,7 @@
                 "version_added": "78"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -1076,7 +1075,7 @@
                 "version_added": "78"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1263,7 +1263,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"
@@ -1320,7 +1320,7 @@
                   "version_added": "29"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "56"
                 },
                 "ie": {
                   "version_added": "11"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -122,7 +122,7 @@
                 "version_added": "57"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "57"
               },
               "ie": {
                 "version_added": false
@@ -1053,7 +1053,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -20,7 +20,7 @@
                 "version_added": "78"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -73,7 +73,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -132,7 +132,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -185,7 +185,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -238,7 +238,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -291,7 +291,7 @@
                   "version_added": "78"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -20,7 +20,7 @@
                 "version_added": "75"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -72,7 +72,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -124,7 +124,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -176,7 +176,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -228,7 +228,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -280,7 +280,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -332,7 +332,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -384,7 +384,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -436,7 +436,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -488,7 +488,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -540,7 +540,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -592,7 +592,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -644,7 +644,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -696,7 +696,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -748,7 +748,7 @@
                   "version_added": "75"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -130,7 +130,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false
@@ -181,7 +181,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false
@@ -232,7 +232,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false
@@ -283,7 +283,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false
@@ -334,7 +334,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false
@@ -385,7 +385,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false

--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -185,7 +185,7 @@
                   "version_added": "70"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -288,7 +288,7 @@
                     "version_added": "70"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -127,7 +127,7 @@
                     "version_added": "78"
                   },
                   "firefox_android": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "ie": {
                     "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -569,7 +569,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -784,7 +784,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -446,7 +446,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -20,7 +20,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -56,7 +56,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -816,7 +816,7 @@
                 "version_added": "80"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "80"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
When Mozilla resumed releases for Firefox Android with version 79, many features became available. I've taken a look at the discrepancies between `firefox` and `firefox_android` in our data (for `javascript/` at least). 
This PR fixes these issues. Let me know if this is reviewable as is.

Fixes https://github.com/mdn/browser-compat-data/issues/7430 (which inspired me to do this, thanks!)