### PR TITLE
Update Storage Access API availability on Chrome

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6303,10 +6303,17 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "71"
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -6318,7 +6325,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "85"
+              "version_added": false
             }
           },
           "status": {
@@ -10322,10 +10329,17 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "71"
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -10337,7 +10351,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "85"
+              "version_added": false
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -6264,10 +6264,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess",
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": "85"
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": "85"
@@ -10269,10 +10283,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess",
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": "85"
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": "85"

--- a/api/Document.json
+++ b/api/Document.json
@@ -6264,7 +6264,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess",
           "support": {
             "chrome": {
-              "version_added": "85",
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",
@@ -6274,7 +6274,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "85",
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",
@@ -10283,7 +10283,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess",
           "support": {
             "chrome": {
-              "version_added": "85",
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",
@@ -10293,7 +10293,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "85",
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This change updates the availability of the Storage Access API in Chrome

+ [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=989663)
+ [Chrome Platform Status](https://www.chromestatus.com/feature/5612590694662144)

The [first commit](https://chromium.googlesource.com/chromium/src.git/+/da12cf8726dc8414f0d61624afebff46b83c8f1a) was in [version 78](https://chromium.googlesource.com/chromium/src/+/da12cf8726dc8414f0d61624afebff46b83c8f1a/chrome/VERSION), not 85, and the flag remains off by default.

I’m not sure how MS Edge’s versions work and when it was turned on by default, so that version hasn’t been altered.

Fixes #7510 