### PR TITLE
Deprecate CSP block-all-mixed-content directive

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -167,7 +167,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "deprecated": false
+                "deprecated": true
               }
             }
           },


### PR DESCRIPTION
This change marks the CSP `block-all-mixed-content` directive as `deprecated:true,` per the current version of the CSP spec at https://w3c.github.io/webappsec-mixed-content/#obsolescences:

> This specification renders the Mixed Content §4 Strict Mixed Content Checking mode and the `block-all-mixed-content` CSP directive obsolete, because all mixed content is now blocked if it can’t be autoupgraded.

---

MDN article already updated.