### PR TITLE
Mark deprecated HTMLHRElement API features

### DIFF
--- a/api/HTMLHRElement.json
+++ b/api/HTMLHRElement.json
@@ -137,7 +137,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -184,7 +184,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -231,7 +231,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -278,7 +278,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
This marks various features for the HTMLHRElement API as deprecated, based upon the listing on the spec's "obsolete" page: https://html.spec.whatwg.org/multipage/obsolete.html#HTMLHRElement-partial
