### PR TITLE
firefox dropped support for HTMLCanvasElement.getContext powerPrefere…

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -314,10 +314,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "63"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "63"
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1496459


Edit 12/20:
This was broken ~~either never supported on Windows, or dropped~~ around version ~71

Copied from bugzilla:

Steps to reproduce:

1. Start Firefox on a Windows system that has an Nvidia optimus configuration containing an integrated and discrete GPU.  (Make sure that the NVIDIA control panel has _not_ been set to force use of the discrete GPU for Firefox)

2. Go to https://bug1349799.bmoattachments.org/attachment.cgi?id=8941348

3. Hit the '2' key to select the high performance option

Actual results:

Note that the integrated GPU is used

Expected results:

The discrete (Nvidia) GPU should be used for WebGL contexts that are created setting "powerPreference" to "high-performance".