### PR TITLE
PaymentRequest.p.paymentAddress → shippingAddress

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -503,56 +503,6 @@
           }
         }
       },
-      "paymentAddress": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/paymentAddress",
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": {
-              "version_added": "53"
-            },
-            "edge": {
-              "version_added": "15"
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
-            },
-            "firefox_android": {
-              "version_added": false,
-              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "paymentmethodchange_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/paymentmethodchange_event",
@@ -643,6 +593,56 @@
             },
             "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingAddress": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingAddress",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -620,11 +620,15 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.payments.request.enabled"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Available only in nightly builds as <code>shippingAddress</code>."
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This change renames the BCD `paymentAddress` subfeature of the `PaymentRequest` feature to `shippingAddress`.

As noted in https://github.com/mdn/browser-compat-data/issues/7668, it’s been `PaymentRequest.prototype.shippingAddress` “for years, probably from the start”.

---

cc @marcoscaceres for confirmation