### PR TITLE
Correct data for "loading" attr in img/iframe

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -539,7 +539,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "60"
+                "version_added": "64"
               },
               "opera_android": {
                 "version_added": "55"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -565,10 +565,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/Performance/Lazy_loading",
             "support": {
               "chrome": {
-                "version_added": "76"
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": "76"
+                "version_added": "77"
               },
               "edge": {
                 "version_added": "79"
@@ -584,10 +584,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "63"
+                "version_added": "64"
               },
               "opera_android": {
-                "version_added": "54"
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false,
@@ -598,10 +598,10 @@
                 "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "12.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "77"
               }
             },
             "status": {


### PR DESCRIPTION
This PR is a follow-up to #5442.  In that PR, the data was based upon information from ChromeStatus, which stated 76.  However, @foolip looked into it further and had confirmed that it was actually implemented in Chrome 77.  This PR fixes the data within the `img` element accordingly, as well as resolves a typo in the Opera version number for the attribute on the `iframe` element.
