### PR TITLE
Remove api.HTMLInputElement.weight; add api.HTMLInputElement.width

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1594,9 +1594,9 @@
           }
         }
       },
-      "weight": {
+      "width": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/weight",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/width",
           "support": {
             "chrome": {
               "version_added": true
@@ -1611,7 +1611,7 @@
               "version_added": "16"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "16"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
In the original compat tables in the wiki, there was a column that read "height and weight properties".  However, there is no "weight" attribute for HTMLInputElement.  There _is_ a "width" attribute that is not documented in BCD, which makes me assume that this was a mistake and misuse of words.  This removes the "weight" feature from BCD, and adds a "width" feature in its place.