### PR TITLE
Update Chrome + Opera data for api.Range.detach

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -633,11 +633,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Range/detach",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Since April 2014 this method is a <a href='https://src.chromium.org/viewvc/blink?revision=173010&view=revision'>no-op in Chrome</a>."
+              "version_added": "1",
+              "notes": "Starting in Chrome 37, this method is a no-op and has no effect."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "notes": "Starting in Chrome 37, this method is a no-op and has no effect."
             },
             "edge": {
               "version_added": "12"
@@ -656,10 +657,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Starting in Opera 24, this method is a no-op and has no effect."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1",
+              "notes": "Starting in Opera 24, this method is a no-op and has no effect."
             },
             "safari": {
               "version_added": true,
@@ -670,10 +673,12 @@
               "notes": "Since August 2015 this method is a no-op in <a href='https://webkit.org/b/148454'>WebKit-based browsers</a>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Starting in Samsung Internet 3.0, this method is a no-op and has no effect."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Starting in WebView 37, this method is a no-op and has no effect."
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Opera for the `detach` method of the Range API, as well as updates the notes for consistency (and to add version numbers for them).
