### PR TITLE
Add versions for IE for FileReaderSync API

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -20,7 +20,7 @@
             "version_added": "8"
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": true
@@ -69,7 +69,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -119,7 +119,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -169,7 +169,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -219,7 +219,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the FileReaderSync API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
