### PR TITLE
Add/update IE+Edge versions for HTMLAllCollection API

### DIFF
--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": "44"
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "31"
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the HTMLAllCollection API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Additionally, this updates the Edge data based upon the IE data.
