### PR TITLE
Add IE versions for HTMLCollection API

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for IE for the HTMLCollection API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
