### PR TITLE
Add version for IE for HTMLDocument API

### DIFF
--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the HTMLDocument API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
