### PR TITLE
Update IE/Edge data for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -807,7 +807,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -816,7 +816,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -996,7 +996,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for IE for the HTMLImageElement API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
