### PR TITLE
Add IE versions for HTMLMenuElement API

### DIFF
--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -165,7 +165,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for IE for the HTMLMenuElement API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).