### PR TITLE
Add IE/Edge versions for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -354,7 +354,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1787,7 +1787,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "2",
@@ -1797,7 +1797,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "≤12.1",


### PR DESCRIPTION
This PR adds real values for IE/Edge for the Navigator API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).