### PR TITLE
Add IE/Edge versions for SVGAnimatedTransformList API

### DIFF
--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "9"
@@ -20,7 +20,7 @@
             "version_added": "9"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for IE/Edge for the SVGAnimatedTransformList API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).