### PR TITLE
Add IE/Edge versions for SVGNumber[List] APIs

### DIFF
--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for IE and Edge for the SVGNumber and SVGNumberList APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
