### PR TITLE
Add IE versions for SVGRect API

### DIFF
--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -66,7 +66,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -113,7 +113,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -160,7 +160,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -207,7 +207,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for IE for the SVGRect API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).