### PR TITLE
Add IE/Edge versions for SVGTransform[List] APIs

### DIFF
--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "9"

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for IE and Edge for the SVGTransform and SVGTransformList APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
