### PR TITLE
Add IE versions for CharacterData API

### DIFF
--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -117,7 +117,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -165,7 +165,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -213,7 +213,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -261,7 +261,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -309,7 +309,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -357,7 +357,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -405,7 +405,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for IE for the CharacterData API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).