### PR TITLE
Add Firefox versions for DOMRect API

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -20,10 +20,10 @@
             }
           ],
           "firefox": {
-            "version_added": true
+            "version_added": "27"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "ie": [
             {


### PR DESCRIPTION
This PR adds real values for Firefox for the DOMRect API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy
