### PR TITLE
Add Firefox versions for HTMLAllCollection API

### DIFF
--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "32"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "32"
           },
           "ie": {
             "version_added": null
@@ -61,10 +61,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "32"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "ie": {
               "version_added": null
@@ -109,10 +109,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "32"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "32"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the HTMLAllCollection API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAllCollection
