### PR TITLE
Add Firefox versions for HTMLDocument API

### DIFF
--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox for the HTMLDocument API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLDocument
