### PR TITLE
Add Firefox versions for MediaKeyStatusMap API

### DIFF
--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "38"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -109,10 +109,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "47"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "ie": {
               "version_added": false
@@ -157,10 +157,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "ie": {
               "version_added": false
@@ -205,10 +205,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "ie": {
               "version_added": false
@@ -253,10 +253,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -301,10 +301,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -349,10 +349,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -396,10 +396,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the MediaKeyStatusMap API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaKeyStatusMap
