### PR TITLE
Add Firefox versions for MediaKeys API

### DIFF
--- a/api/MediaKeys.json
+++ b/api/MediaKeys.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "38"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -109,10 +109,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the MediaKeys API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaKeys
