### PR TITLE
Add Firefox versions for RTCCertificate API

### DIFF
--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "42"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "42"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "42"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "ie": {
               "version_added": false
@@ -109,10 +109,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -157,10 +157,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the RTCCertificate API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCCertificate
