### PR TITLE
Add Firefox versions for RTCDTMFSender API

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -61,10 +61,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the RTCDTMFSender API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDTMFSender
