### PR TITLE
Add Firefox versions for SVGAltGlyphDefElement API

### DIFF
--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGAltGlyphDefElement API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAltGlyphDefElement
