### PR TITLE
Update MDN URLs for various CSS functions

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -199,7 +199,7 @@
         "calc": {
           "__compat": {
             "description": "<code>calc()</code> expressions",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc()",
             "support": {
               "chrome": {
                 "version_added": "66"

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -52,7 +52,7 @@
         },
         "element": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element()",
             "description": "<code>element()</code>",
             "support": {
               "chrome": {
@@ -213,7 +213,7 @@
         },
         "image-set": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set()",
             "description": "<code>image-set()</code>",
             "support": {
               "chrome": {

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -146,7 +146,7 @@
         },
         "url": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url()",
             "description": "<code>url()</code>",
             "support": {
               "chrome": {

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -166,7 +166,7 @@
         },
         "var": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/var",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/var()",
             "description": "<code>var()</code>",
             "support": {
               "chrome": [

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -226,7 +226,7 @@
         },
         "minmax": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax()",
             "description": "<code>minmax()</code>",
             "support": {
               "chrome": [
@@ -345,7 +345,7 @@
         },
         "repeat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat()",
             "description": "<code>repeat()</code>",
             "support": {
               "chrome": [

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -226,7 +226,7 @@
         },
         "minmax": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax()",
             "description": "<code>minmax()</code>",
             "support": {
               "chrome": [
@@ -345,7 +345,7 @@
         },
         "repeat": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeat()",
             "description": "<code>repeat()</code>",
             "support": {
               "chrome": [

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -4206,7 +4206,7 @@
         },
         "symbols": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols()",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -50,7 +50,7 @@
         },
         "symbols": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/symbols()",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -3,7 +3,7 @@
     "types": {
       "attr": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr()",
           "description": "<code>attr()</code>",
           "support": {
             "chrome": {

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -4,7 +4,7 @@
       "calc": {
         "__compat": {
           "description": "<code>calc()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc()",
           "support": {
             "chrome": [
               {

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -4,7 +4,7 @@
       "clamp": {
         "__compat": {
           "description": "<code>clamp()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp()",
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -3,7 +3,7 @@
     "types": {
       "counter": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter()",
           "description": "<code>counter()</code>",
           "support": {
             "chrome": {

--- a/css/types/counters.json
+++ b/css/types/counters.json
@@ -3,7 +3,7 @@
     "types": {
       "counters": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counters",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counters()",
           "description": "<code>counters()</code>",
           "support": {
             "chrome": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -51,7 +51,7 @@
         },
         "cross-fade": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade()",
             "description": "<code>cross-fade()</code>",
             "support": {
               "chrome": {
@@ -130,7 +130,7 @@
         },
         "element": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element()",
             "description": "<code>element()</code>",
             "support": {
               "chrome": {
@@ -323,7 +323,7 @@
           "conic-gradient": {
             "__compat": {
               "description": "<code>conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient()",
               "support": {
                 "chrome": [
                   {
@@ -486,7 +486,7 @@
           "linear-gradient": {
             "__compat": {
               "description": "<code>linear-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/linear-gradient",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/linear-gradient()",
               "support": {
                 "chrome": [
                   {
@@ -864,7 +864,7 @@
           "radial-gradient": {
             "__compat": {
               "description": "<code>radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/radial-gradient",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/radial-gradient()",
               "support": {
                 "chrome": [
                   {
@@ -1207,7 +1207,7 @@
           "repeating-conic-gradient": {
             "__compat": {
               "description": "<code>repeating-conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient()",
               "support": {
                 "chrome": [
                   {
@@ -1488,7 +1488,7 @@
                 "standard_track": true,
                 "deprecated": false
               },
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient"
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient()"
             },
             "doubleposition": {
               "__compat": {
@@ -1700,7 +1700,7 @@
           "repeating-radial-gradient": {
             "__compat": {
               "description": "<code>repeating-radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-radial-gradient",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-radial-gradient()",
               "support": {
                 "chrome": [
                   {
@@ -2059,7 +2059,7 @@
         },
         "image": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/imagefunction",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image()",
             "description": "<code>image()</code>",
             "support": {
               "chrome": {
@@ -2110,7 +2110,7 @@
         },
         "image-set": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set()",
             "description": "<code>image-set()</code>",
             "support": {
               "chrome": {
@@ -2174,7 +2174,7 @@
         },
         "paint": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/paint",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/paint()",
             "description": "<code>paint()</code>",
             "support": {
               "chrome": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -4,7 +4,7 @@
       "max": {
         "__compat": {
           "description": "<code>max()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max()",
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -4,7 +4,7 @@
       "min": {
         "__compat": {
           "description": "<code>min()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min()",
           "support": {
             "chrome": {
               "version_added": "79"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -4,7 +4,7 @@
       "url": {
         "__compat": {
           "description": "<code>&lt;url&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url()",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This change updates the MDN URLs for various CSS functions (e.g., `attr()`, `calc()`, `var()`…)

