### PR TITLE
Drop stray &lt;/&gt; in CSS function descriptions

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -3,7 +3,7 @@
     "types": {
       "calc": {
         "__compat": {
-          "description": "<code>&lt;calc()&gt;</code>",
+          "description": "<code>calc()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
           "support": {
             "chrome": [

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -3,7 +3,7 @@
     "types": {
       "clamp": {
         "__compat": {
-          "description": "<code>&lt;clamp()&gt;</code>",
+          "description": "<code>clamp()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
           "support": {
             "chrome": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -3,7 +3,7 @@
     "types": {
       "max": {
         "__compat": {
-          "description": "<code>&lt;max()&gt;</code>",
+          "description": "<code>max()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "support": {
             "chrome": {

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -3,7 +3,7 @@
     "types": {
       "min": {
         "__compat": {
-          "description": "<code>&lt;min()&gt;</code>",
+          "description": "<code>min()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
           "support": {
             "chrome": {


### PR DESCRIPTION
This change updates the `description` fields for several CSS functions, to remove some stray `&lt;`/`&gt;` character references.

---

Or alternatively, I can update the patch in this branch to just remove the `description` fields completely — because for these cases, that `description` field doesn’t seem to be serving much purpose.