### PR TITLE
Undeprecate the usemap/useMap attribute of img/HTMLImageElement

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1322,7 +1322,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -1009,7 +1009,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           },
           "caseless_usemap": {
@@ -1056,7 +1056,7 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
-                "deprecated": true
+                "deprecated": false
               }
             }
           }


### PR DESCRIPTION
This change marks the `usemap` content/markup attribute of the `img` element and the `useMap` IDL/DOM attribute of the `HTMLImageElement` interface `deprecated:false`. They were mistakenly marked `deprecated:true` in https://github.com/mdn/browser-compat-data/commit/b3ea219.

Relates to https://github.com/mdn/browser-compat-data/issues/7709