### PR TITLE
Undeprecate the "type" attribute of the script element and HTMLScriptElement interface

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -588,7 +588,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -551,7 +551,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           },
           "module": {


### PR DESCRIPTION
This change marks the `type` content/markup attribute of the `script` element and the `type` IDL/DOM attribute of the `HTMLScriptElement` interface `deprecated:false`. They were mistakenly marked `deprecated:true` in https://github.com/mdn/browser-compat-data/commit/a6f6d39.

Related: https://github.com/mdn/browser-compat-data/issues/7709