### PR TITLE
Undeprecate DOMPointReadOnly.p.matrixTransform

### DIFF
--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -190,7 +190,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This change marks `DOMPointReadOnly.prototype.matrixTransform` as `deprecated:false`. Per https://drafts.fxtf.org/geometry/#dom-dompointreadonly-matrixtransform it’s not currently deprecated (and it’s not clear it should ever have been marked `deprecated:true` to begin with).

Related: https://github.com/mdn/browser-compat-data/issues/7709