### PR TITLE
Add Firefox versions for SVGExternalResourcesRequired API

### DIFF
--- a/api/SVGExternalResourcesRequired.json
+++ b/api/SVGExternalResourcesRequired.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": true
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGExternalResourcesRequired API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGExternalResourcesRequired
