### PR TITLE
Undeprecate HTMLMapElement "areas" & "name" attributes

### DIFF
--- a/api/HTMLMapElement.json
+++ b/api/HTMLMapElement.json
@@ -91,7 +91,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -139,7 +139,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This change marks the `areas` and `name` attributes of the `HTMLMapElement` interface as `deprecated:false`, because the spec does not deprecate them.

Related: https://github.com/mdn/browser-compat-data/issues/7709