### PR TITLE
Add Firefox versions for SVGFilterPrimitiveStandardAttributes API

### DIFF
--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -14,10 +14,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "3",
+            "version_removed": "22"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "22"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGFilterPrimitiveStandardAttributes API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFilterPrimitiveStandardAttributes
