### PR TITLE
Add Firefox versions for SVGFont* APIs

### DIFF
--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -14,10 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGFont* APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
