### PR TITLE
Add Firefox versions for SVGMatrix API

### DIFF
--- a/api/SVGMatrix.json
+++ b/api/SVGMatrix.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGMatrix API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGMatrix
