### PR TITLE
Add Firefox versions for SVGPoint API

### DIFF
--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": null
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGPoint API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGPoint
