### PR TITLE
Add Firefox versions for SVGRect API

### DIFF
--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -60,10 +60,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -107,10 +107,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -154,10 +154,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -201,10 +201,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGRect API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGRect
