### PR TITLE
Add Firefox versions for SVGStylable API

### DIFF
--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -14,10 +14,12 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "1.5",
+            "version_removed": "20"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "20"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGStylable API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStylable
