### PR TITLE
Add Firefox versions for SVGTransformList API

### DIFF
--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGTransformList API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTransformList
