### PR TITLE
Add Firefox versions for SVGTransformable API

### DIFF
--- a/api/SVGTransformable.json
+++ b/api/SVGTransformable.json
@@ -14,10 +14,12 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "1.5",
+            "version_removed": "21"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "21"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGTransformable API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTransformable
