### PR TITLE
Add Firefox versions for SVGUseElement API

### DIFF
--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -63,10 +63,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": "9"
@@ -166,10 +166,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGUseElement API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGUseElement
