### PR TITLE
Add Firefox versions for SVGZoomAndPan API

### DIFF
--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -14,10 +14,12 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "1.5",
+            "version_removed": "71"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "4",
+            "version_removed": "79"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox for the SVGZoomAndPan API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGZoomAndPan
