### PR TITLE
Add missing FragmentDirective API

### DIFF
--- a/api/FragmentDirective.json
+++ b/api/FragmentDirective.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "FragmentDirective": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "81"
+          },
+          "chrome_android": {
+            "version_added": "81"
+          },
+          "edge": {
+            "version_added": "83"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "68"
+          },
+          "opera_android": {
+            "version_added": "58"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "13.0"
+          },
+          "webview_android": {
+            "version_added": "81"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds the missing FragmentDirective API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Spec: https://wicg.github.io/scroll-to-text-fragment/#feature-detectability

IDL: https://github.com/w3c/webref/blob/master/ed/idl/scroll-totext-fragment.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FragmentDirective
