### PR TITLE
Add missing SVGDiscardElement API

### DIFF
--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -1,0 +1,53 @@
+{
+  "api": {
+    "SVGDiscardElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "34",
+            "version_removed": "81"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "79",
+            "version_removed": "81"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -8,7 +8,8 @@
             "version_removed": "81"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "34",
+            "version_removed": "81"
           },
           "edge": {
             "version_added": "79",
@@ -24,10 +25,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "21",
+            "version_removed": "68"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "21",
+            "version_removed": "48"
           },
           "safari": {
             "version_added": false
@@ -36,10 +39,12 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "2.0",
+            "version_removed": "13.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "37",
+            "version_removed": "81"
           }
         },
         "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds the missing SVGDiscardElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Spec: https://svgwg.org/specs/animations/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/svg-animations.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGDiscardElement
