### PR TITLE
[HOTFIX] Remove duplicate "width" feature from HTMLInputElement API

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2699,53 +2699,6 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/width",
           "support": {
             "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "≤18"
-            },
-            "firefox": {
-              "version_added": "16"
-            },
-            "firefox_android": {
-              "version_added": "16"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "width": {
-        "__compat": {
-          "support": {
-            "chrome": {
               "version_added": "21"
             },
             "chrome_android": {


### PR DESCRIPTION
Two PRs that were recently merged had both added a "width" feature to the HTMLInputElement API, causing a failure of the linter.  This PR is a quick fix to remove the duplicate feature and combine the two entries.
