### PR TITLE
Add/correct Safari versions for HTMLAllCollection API

### DIFF
--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -124,7 +124,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": true

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -124,10 +124,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -127,7 +127,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds and corrects real values for Safari for the HTMLAllCollection API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAllCollection