### PR TITLE
Add Safari versions for Audio() constructor (HTMLAudioElement API)

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari for the Audio() constructor of the HTMLAudioElement API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).

Test Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAudioElement/Audio
