### PR TITLE
Add Safari versions for HTMLCollection API

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -32,7 +32,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3.2"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -29,7 +29,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "4"
+            "version_added": "≤4"
           },
           "safari_ios": {
             "version_added": "≤3"
@@ -76,7 +76,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "≤4"
             },
             "safari_ios": {
               "version_added": "≤3"
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "≤4"
             },
             "safari_ios": {
               "version_added": "≤3"

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -76,7 +76,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "≤3"

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari for the `HTMLCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLCollection
