### PR TITLE
Add Safari versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1798,7 +1798,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -2323,7 +2326,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -2510,7 +2516,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3473,7 +3482,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari for the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMediaElement
