### PR TITLE
Add Safari versions for HTMLOptionsCollection API

### DIFF
--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari for the `HTMLOptionsCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLOptionsCollection
