### PR TITLE
Add Safari versions for Node API

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -352,7 +352,7 @@
               "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -647,10 +647,12 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1111,10 +1113,12 @@
               "version_removed": "33"
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -1269,10 +1273,12 @@
               "version_removed": "33"
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -1736,10 +1742,12 @@
               "version_removed": "21"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari for the `Node` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Node
