### PR TITLE
Add Safari versions for RTCCertificate API

### DIFF
--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari for the `RTCCertificate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCCertificate
