### PR TITLE
Add Safari versions for RTCPeerConnection API

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1137,10 +1137,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1309,10 +1309,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1847,10 +1847,12 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11",
+              "version_removed": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -2803,10 +2805,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2866,10 +2868,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2929,10 +2931,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3054,10 +3056,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari for the `RTCPeerConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection
