### PR TITLE
Add Safari versions for RTCRtpReceiver API

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -550,10 +550,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari for the `RTCRtpReceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpReceiver
