### PR TITLE
Add Safari versions for RTCRtpTransceiver API

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -414,10 +414,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR adds real values for Safari for the `RTCRtpTransceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpTransceiver
