### PR TITLE
Add Chromium versions for HTMLAudioElement API

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -53,10 +53,10 @@
           "description": "<code>Audio()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -71,10 +71,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -83,10 +83,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium for the `HTMLAudioElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAudioElement
