### PR TITLE
Add Chromium versions for HTMLCollection API

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/length",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/item",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "safari": {
               "version_added": true
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -166,10 +166,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLCollection
