### PR TITLE
Add Chromium versions for HTMLDialogElement API

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -8,7 +8,7 @@
             "version_added": "37"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "37"
           },
           "edge": {
             "version_added": "79"
@@ -42,7 +42,7 @@
             "version_added": "24"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "24"
           },
           "safari": {
             "version_added": false
@@ -51,10 +51,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "37"
           }
         },
         "status": {
@@ -120,7 +120,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
               "version_added": "79"
@@ -154,7 +154,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -163,10 +163,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -233,7 +233,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
               "version_added": "79"
@@ -267,7 +267,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -276,10 +276,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -297,7 +297,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
               "version_added": "79"
@@ -331,7 +331,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -340,10 +340,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -361,7 +361,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
               "version_added": "79"
@@ -395,7 +395,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -404,10 +404,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -425,7 +425,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "edge": {
               "version_added": "79"
@@ -459,7 +459,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -468,10 +468,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLDialogElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLDialogElement
