### PR TITLE
Add Opera versions for HTMLElement API

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -596,7 +596,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -644,10 +644,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -793,7 +793,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5"
@@ -841,10 +841,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": false
@@ -1051,7 +1053,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -2359,10 +2361,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `HTMLElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement
