### PR TITLE
Add Chromium versions for HTMLKeygenElement API

### DIFF
--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -5,12 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLKeygenElement",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "10",
             "version_removed": "57",
             "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "version_removed": "57",
             "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
           },
@@ -31,10 +31,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "≤12.1",
+            "version_removed": "44"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "≤12.1",
+            "version_removed": "43"
           },
           "safari": {
             "version_added": "5.1",
@@ -45,11 +47,11 @@
             "version_removed": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "version_removed": "7.0"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "version_removed": "57",
             "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
           }


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLKeygenElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLKeygenElement
