### PR TITLE
Add Chromium versions for HTMLSelectElement API

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -166,12 +166,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "53"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "47"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -197,10 +209,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/autofocus",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -215,10 +227,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -227,10 +239,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -245,10 +257,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/blur",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -263,10 +275,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -275,10 +287,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1"
             }
           },
           "status": {
@@ -362,7 +374,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -389,10 +401,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/focus",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -407,10 +419,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -419,10 +431,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLSelectElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLSelectElement
