### PR TITLE
Add Opera versions for RTCIceCandidate API

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -128,10 +128,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -224,10 +224,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -272,10 +272,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -320,10 +320,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -368,10 +368,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -416,10 +416,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -464,10 +464,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -512,10 +512,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -656,10 +656,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -752,10 +752,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -800,10 +800,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": false

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -128,7 +128,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -224,7 +224,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -272,7 +272,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -320,7 +320,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -368,7 +368,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -416,7 +416,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -464,7 +464,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -512,7 +512,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -656,7 +656,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -752,7 +752,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"
@@ -800,7 +800,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `RTCIceCandidate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidate
