### PR TITLE
Add Chromium versions for SVGAnimated* APIs

### DIFF
--- a/api/SVGAnimateColorElement.json
+++ b/api/SVGAnimateColorElement.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimateColorElement",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "34"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18",
+            "version_removed": "34"
           },
           "edge": {
             "version_added": false
@@ -23,10 +25,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "≤12.1",
+            "version_removed": "21"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "≤12.1",
+            "version_removed": "21"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +39,12 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0",
+            "version_removed": "2.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "37"
           }
         },
         "status": {

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "10"
@@ -35,10 +35,10 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedBoolean",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedEnumeration",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedInteger",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumber",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumberList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/animVal",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤87"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15> ≤72"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤60"
             },
             "safari": {
               "version_added": true
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "≤13.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤86"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/baseVal",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤87"
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15> ≤72"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤60"
             },
             "safari": {
               "version_added": true
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "≤13.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤86"
             }
           },
           "status": {

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/animVal",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "≤87"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15> ≤72"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "≤60"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "≤13.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "≤86"
+              "version_added": true
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/baseVal",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "≤87"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15> ≤72"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "≤60"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "≤13.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "≤86"
+              "version_added": true
             }
           },
           "status": {

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedTransformList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium for various SVGAnimated* APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).
