### PR TITLE
Add Chromium versions for SVGAnimationElement API

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +35,10 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onbegin",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
               "version_added": false
@@ -180,10 +180,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -198,10 +198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onend",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
@@ -216,10 +216,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
               "version_added": false
@@ -228,10 +228,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -246,10 +246,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onrepeat",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
@@ -264,10 +264,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
               "version_added": false
@@ -276,10 +276,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -343,10 +343,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/targetElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -361,10 +361,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -373,10 +373,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAnimationElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimationElement
