### PR TITLE
Add Chromium versions for SVGElement API

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -344,11 +344,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "50"
             },
             "edge": {
@@ -364,11 +364,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "safari": {
@@ -380,11 +380,11 @@
               "version_removed": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             }
           },
@@ -399,11 +399,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "50"
             },
             "edge": {
@@ -419,11 +419,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "safari": {
@@ -435,11 +435,11 @@
               "version_removed": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             }
           },
@@ -454,11 +454,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "50"
             },
             "edge": {
@@ -474,11 +474,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "safari": {
@@ -490,11 +490,11 @@
               "version_removed": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             }
           },
@@ -509,11 +509,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "50"
             },
             "edge": {
@@ -529,11 +529,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "safari": {
@@ -545,11 +545,11 @@
               "version_removed": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             }
           },
@@ -564,11 +564,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "50"
             },
             "edge": {
@@ -584,11 +584,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "37"
             },
             "safari": {
@@ -600,11 +600,11 @@
               "version_removed": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "50"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGElement
