### PR TITLE
Add Chromium versions for SVGFontElement API

### DIFF
--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFontElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "5",
+            "version_removed": "40"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18",
+            "version_removed": "40"
           },
           "edge": {
             "version_added": null
@@ -23,10 +25,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "≤12.1",
+            "version_removed": "27"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤12.1",
+            "version_removed": "27"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +39,12 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "version_removed": "4.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "≤37",
+            "version_removed": "40"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGFontElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFontElement
