### PR TITLE
Add Chromium versions for SVGFontFaceElement API

### DIFF
--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFontFaceElement",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "40"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "18",
+            "version_removed": "40"
           },
           "edge": {
             "version_added": false
@@ -23,10 +25,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "15",
+            "version_removed": "27"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "14",
+            "version_removed": "27"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +39,12 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.0",
+            "version_removed": "4.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1",
+            "version_removed": "40"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGFontFaceElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFontFaceElement
