### PR TITLE
Add Chromium versions for SVGGraphicsElement API

### DIFF
--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -26,7 +26,7 @@
             "version_added": "17"
           },
           "opera_android": {
-            "version_added": "17"
+            "version_added": "18"
           },
           "safari": {
             "version_added": "6.1"
@@ -80,7 +80,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "6.1"
@@ -127,7 +127,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "6.1"
@@ -174,7 +174,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "6.1"
@@ -203,7 +203,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "≤87"
+              "version_added": "43"
             },
             "edge": {
               "version_added": "15"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "17"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "6.1"
@@ -230,10 +230,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -200,10 +200,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "15"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
               "version_added": "6.1"
@@ -230,10 +230,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "17"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "17"
           },
           "safari": {
             "version_added": "6.1"
@@ -35,10 +35,10 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -51,10 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "safari": {
               "version_added": "6.1"
@@ -89,10 +89,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -106,10 +106,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "safari": {
               "version_added": "6.1"
@@ -136,10 +136,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "15"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "safari": {
               "version_added": "6.1"
@@ -183,10 +183,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -200,10 +200,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "≤87"
             },
             "edge": {
               "version_added": "15"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "safari": {
               "version_added": "6.1"
@@ -230,10 +230,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGGraphicsElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGGraphicsElement
