### PR TITLE
Add logical border properties support for Chrome 89

### DIFF
--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "edge": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "edge": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "edge": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "edge": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {


### PR DESCRIPTION
The logical versions of the `border-radius` properties are shipping in Chrome 89, this updates the BCD for the four properties.

- https://groups.google.com/a/chromium.org/g/blink-dev/c/YmWSODSTPS4
- https://bugs.chromium.org/p/chromium/issues/detail?id=1155270
- https://www.chromestatus.com/feature/5631002091192320
