### PR TITLE
Add Chromium versions for SVGPathElement API

### DIFF
--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -51,11 +51,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -74,11 +74,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -88,11 +88,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -107,11 +107,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -130,11 +130,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -144,11 +144,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -163,11 +163,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -186,11 +186,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -200,11 +200,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -219,11 +219,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -242,11 +242,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -256,11 +256,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -275,11 +275,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -298,11 +298,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -312,11 +312,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -331,11 +331,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -354,11 +354,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -368,11 +368,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -387,11 +387,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -410,11 +410,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -424,11 +424,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -443,11 +443,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -466,11 +466,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -480,11 +480,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -499,11 +499,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -522,11 +522,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -536,11 +536,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -555,11 +555,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -578,11 +578,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -592,11 +592,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -611,11 +611,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -634,11 +634,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -648,11 +648,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -667,11 +667,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -690,11 +690,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -704,11 +704,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -723,11 +723,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -746,11 +746,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -760,11 +760,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -779,11 +779,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -802,11 +802,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -816,11 +816,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -835,11 +835,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -858,11 +858,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -872,11 +872,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -891,11 +891,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -914,11 +914,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -928,11 +928,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -947,11 +947,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -970,11 +970,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -984,11 +984,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -1003,11 +1003,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -1026,11 +1026,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -1040,11 +1040,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -1059,11 +1059,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "48"
             },
             "edge": {
@@ -1082,11 +1082,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "35"
             },
             "safari": {
@@ -1096,11 +1096,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "48"
             }
           },
@@ -1115,11 +1115,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "62"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "62"
             },
             "edge": {
@@ -1136,11 +1136,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "49"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "46"
             },
             "safari": {
@@ -1150,11 +1150,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "8.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "62"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGPathElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGPathElement
