### PR TITLE
Add Chromium versions for SVGRenderingIntent API

### DIFF
--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRenderingIntent",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "1",
+            "version_removed": "45"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18",
+            "version_removed": "45"
           },
           "edge": {
             "version_added": null
@@ -23,10 +25,12 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "15",
+            "version_removed": "32"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "14",
+            "version_removed": "32"
           },
           "safari": {
             "version_added": null
@@ -35,10 +39,12 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "version_removed": "5.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "1",
+            "version_removed": "45"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGRenderingIntent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGRenderingIntent
