### PR TITLE
Add Chromium versions for SVGSVGElement API

### DIFF
--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -223,7 +223,7 @@
             },
             "opera_android": {
               "version_added": "≤12.1",
-              "version_removed": "23"
+              "version_removed": "24"
             },
             "safari": {
               "version_added": "≤4",
@@ -280,7 +280,7 @@
             },
             "opera_android": {
               "version_added": "≤12.1",
-              "version_removed": "23"
+              "version_removed": "24"
             },
             "safari": {
               "version_added": "≤4",

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -196,10 +196,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "36"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "36"
             },
             "edge": {
               "version_added": "12"
@@ -216,10 +218,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "23"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "23"
             },
             "safari": {
               "version_added": "≤4",
@@ -230,10 +234,12 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -247,10 +253,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "36"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "36"
             },
             "edge": {
               "version_added": "12"
@@ -267,10 +275,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "23"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "23"
             },
             "safari": {
               "version_added": "≤4",
@@ -281,10 +291,12 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -768,11 +780,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "21",
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "25",
               "version_removed": "56"
             },
             "edge": {
@@ -790,11 +802,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "43"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "43"
             },
             "safari": {
@@ -804,11 +816,11 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "56"
             }
           },
@@ -1199,11 +1211,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "47"
             },
             "edge": {
@@ -1222,11 +1234,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "safari": {
@@ -1238,11 +1250,11 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             }
           },
@@ -1257,11 +1269,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "47"
             },
             "edge": {
@@ -1280,11 +1292,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "safari": {
@@ -1296,11 +1308,11 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             }
           },
@@ -1315,11 +1327,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "47"
             },
             "edge": {
@@ -1338,11 +1350,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "safari": {
@@ -1354,11 +1366,11 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             }
           },
@@ -1373,11 +1385,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "47"
             },
             "edge": {
@@ -1396,11 +1408,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "34"
             },
             "safari": {
@@ -1412,11 +1424,11 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "47"
             }
           },
@@ -1666,11 +1678,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "56"
             },
             "edge": {
@@ -1686,11 +1698,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "43"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "43"
             },
             "safari": {
@@ -1700,11 +1712,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "56"
             }
           },
@@ -1719,10 +1731,12 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "55"
             },
             "edge": {
               "version_added": "12"
@@ -1739,10 +1753,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "version_removed": "42"
             },
             "safari": {
               "version_added": "≤4",
@@ -1753,10 +1769,12 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "55"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGSVGElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGSVGElement
