### PR TITLE
Add Chromium versions for SVGStylable API

### DIFF
--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStylable",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
             "version_added": "≤18"
@@ -25,10 +25,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": null
@@ -37,7 +37,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGStylable` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStylable
