### PR TITLE
Add Chromium versions for XSLTProcessor API

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/clearParameters",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -82,10 +82,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -100,11 +100,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/getParameter",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome only supports string values."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Chrome only supports string values."
             },
             "edge": {
@@ -120,11 +120,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera only supports string values."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera only supports string values."
             },
             "safari": {
@@ -134,11 +134,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome only supports string values."
             }
           },
@@ -154,10 +154,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/importStylesheet",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -202,10 +202,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/removeParameter",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -232,10 +232,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -250,10 +250,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/reset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -280,10 +280,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -298,11 +298,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/setParameter",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome only supports string values."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Chrome only supports string values."
             },
             "edge": {
@@ -318,11 +318,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera only supports string values."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera only supports string values."
             },
             "safari": {
@@ -332,11 +332,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome only supports string values."
             }
           },
@@ -352,11 +352,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/transformToDocument",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             },
             "edge": {
@@ -374,11 +374,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera returns <code>null</code>if an error occurs."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera returns <code>null</code>if an error occurs."
             },
             "safari": {
@@ -388,11 +388,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             }
           },
@@ -408,11 +408,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/transformToFragment",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             },
             "edge": {
@@ -430,11 +430,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera returns <code>null</code>if an error occurs."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Opera returns <code>null</code>if an error occurs."
             },
             "safari": {
@@ -444,11 +444,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `XSLTProcessor` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XSLTProcessor
