### PR TITLE
Add Chromium versions for XPathExpression API

### DIFF
--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathExpression",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "29"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "edge": {
             "version_added": "12"
@@ -22,12 +22,24 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "16"
+            },
+            {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "16"
+            },
+            {
+              "version_added": "≤12.1",
+              "version_removed": "14"
+            }
+          ],
           "safari": {
             "version_added": null
           },
@@ -35,10 +47,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -52,10 +64,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathExpression/evaluate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "12"
@@ -69,12 +81,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": null
             },
@@ -82,10 +106,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `XPathExpression` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XPathExpression
