### PR TITLE
Add Chromium versions for Path2D API

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -26,7 +26,7 @@
             "version_added": "23"
           },
           "opera_android": {
-            "version_added": "23"
+            "version_added": "24"
           },
           "safari": {
             "version_added": "10"
@@ -75,7 +75,7 @@
               "version_added": "23"
             },
             "opera_android": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "safari": {
               "version_added": "10"

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "36"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "36"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "23"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "23"
           },
           "safari": {
             "version_added": "10"
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "37"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D/Path2D",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "36"
             },
             "edge": {
               "version_added": "≤18",
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "23"
             },
             "safari": {
               "version_added": "10"
@@ -84,10 +84,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Path2D/addPath",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "68"
             },
             "edge": {
               "version_added": "≤79"
@@ -120,10 +120,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": true
@@ -132,10 +132,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "68"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Path2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Path2D
