### PR TITLE
Add Chromium versions for Plugin API

### DIFF
--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Plugin",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -148,11 +148,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Plugin/item",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
@@ -168,10 +168,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -180,11 +180,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             }
           },
@@ -248,11 +248,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Plugin/namedItem",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "edge": {
@@ -268,10 +268,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -280,11 +280,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with version 59, method parameters are required instead of optional."
             }
           },
@@ -300,10 +300,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Plugin/version",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -318,10 +318,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -330,10 +330,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Plugin` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Plugin
