### PR TITLE
Add Chromium versions for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/availHeight",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
@@ -71,10 +71,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -83,10 +83,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "1"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/availLeft",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"
@@ -131,10 +131,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/availTop",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"
@@ -179,10 +179,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "1"
             }
           },
           "status": {
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/availWidth",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
@@ -216,10 +216,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -228,10 +228,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -246,11 +246,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/colorDepth",
           "support": {
             "chrome": {
-              "version_added": "40",
+              "version_added": "1",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "chrome_android": {
-              "version_added": "40",
+              "version_added": "18",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "edge": {
@@ -266,10 +266,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -278,11 +278,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0",
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 7.0 this property is no longer required to always return 24."
             },
             "webview_android": {
-              "version_added": "40",
+              "version_added": "1",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             }
           },
@@ -298,10 +298,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/height",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -316,10 +316,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -328,10 +328,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -686,11 +686,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/pixelDepth",
           "support": {
             "chrome": {
-              "version_added": "40",
+              "version_added": "1",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "edge": {
@@ -706,10 +706,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -718,11 +718,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 7.0 this property is no longer required to always return 24."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with version 59 this property is no longer required to always return 24."
             }
           },
@@ -839,10 +839,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/width",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -857,10 +857,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -869,10 +869,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen
