### PR TITLE
Add missing features for AuthenticatorAttestationResponse API

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -125,6 +125,147 @@
           }
         }
       },
+      "getAuthenticatorData": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getPublicKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getPublicKeyAlgorithm": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getTransports": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the `AuthenticatorAttestationResponse` API.

Spec: https://w3c.github.io/webauthn/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/webauthn.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorAttestationResponse
