### PR TITLE
Add missing features for ByteLengthQueuingStrategy API

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -144,6 +144,53 @@
           }
         }
       },
+      "highWaterMark": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "78"
+            },
+            "chrome_android": {
+              "version_added": "78"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "65"
+            },
+            "opera_android": {
+              "version_added": "56"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "78"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/size",

--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -185,7 +185,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the `ByteLengthQueuingStrategy` API.

Spec: https://streams.spec.whatwg.org/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/streams.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ByteLengthQueuingStrategy
