### PR TITLE
Add missing features for CSSStyleValue API

### DIFF
--- a/api/CSSStyleValue.json
+++ b/api/CSSStyleValue.json
@@ -142,6 +142,53 @@
             "deprecated": false
           }
         }
+      },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the `CSSStyleValue` API.

Spec: https://drafts.css-houdini.org/css-typed-om-1/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/css-typed-om.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSStyleValue
