### PR TITLE
Add missing features for ClipboardItem API

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -144,6 +144,53 @@
           }
         }
       },
+      "presentationStyle": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.4"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "types": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/types",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6), for the `ClipboardItem` API.

Spec: https://w3c.github.io/clipboard-apis/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/clipboard-apis.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ClipboardItem

**Depends on #8043.**