### PR TITLE
Add Bluetooth.getDevices

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -269,14 +269,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "85",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -203,6 +203,89 @@
           }
         }
       },
+      "getDevices": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getDevices",
+          "support": {
+            "chrome": {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "onavailabilitychanged": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/onavailabilitychanged",

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -218,7 +218,14 @@
               ]
             },
             "chrome_android": {
-              "version_added": "85"
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": "85",
@@ -250,14 +257,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -240,7 +240,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "85",
+              "version_added": "71",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

This adds documentation for the new Bluetooth.getDevices() which was recently added to chromium (build 85) under a flag. Some docs on this here:
- https://docs.google.com/document/d/1RF4D-60cQJWR1LoQeLBxxigrxJwYS8nLOE0qWmBF1eo/edit
- https://googlechrome.github.io/samples/web-bluetooth/get-devices.html
- https://www.chromestatus.com/feature/4797798639730688

I tested this for Chrome, Edge, Opera for desktop on Windows. I rolled out to equivalent versions for some of the others. There are a couple of questions inline too.

FYI, this is one of the missing entries listed in https://github.com/mdn/browser-compat-data/issues/7585

PS When this is done will need to add compatibility table to https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/getDevices