### PR TITLE
Add Safari versions for CountQueuingStrategy API

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -125,10 +125,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -53,10 +53,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": null
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -125,10 +125,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -244,10 +244,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CountQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CountQueuingStrategy
