### PR TITLE
Add Safari versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -26,7 +26,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -68,7 +71,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -110,7 +116,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
