### PR TITLE
Add Safari versions for ImageData API

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -32,7 +32,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "3.2"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -128,7 +128,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -176,7 +176,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -224,7 +224,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ImageData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageData
