### PR TITLE
Add Safari versions for IntersectionObserver API

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -198,7 +198,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -418,7 +421,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `IntersectionObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IntersectionObserver
