### PR TITLE
Add Safari versions for IntersectionObserverEntry API

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -38,6 +38,9 @@
           "safari": {
             "version_added": "12.1"
           },
+          "safari_ios": {
+            "version_added": "12.2"
+          },
           "samsunginternet_android": {
             "version_added": "5.0"
           },
@@ -87,7 +90,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -139,7 +145,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -191,7 +200,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -245,6 +257,9 @@
             "safari": {
               "version_added": "12.1"
             },
+            "safari_ios": {
+              "version_added": "12.2"
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
@@ -295,7 +310,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -347,7 +365,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -399,7 +420,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `IntersectionObserverEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IntersectionObserverEntry
