### PR TITLE
Add Safari versions for MimeType API

### DIFF
--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -29,10 +29,11 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3",
+            "version_removed": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +77,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +126,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +175,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +224,11 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3",
+              "version_removed": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MimeType` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MimeType
