### PR TITLE
Add Safari versions for MimeTypeArray API

### DIFF
--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "7.0",
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "7.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MimeTypeArray` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MimeTypeArray
