### PR TITLE
Add Safari versions for OverconstrainedError API

### DIFF
--- a/api/OverconstrainedError.json
+++ b/api/OverconstrainedError.json
@@ -29,10 +29,10 @@
             "version_added": "46"
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "8.0"
@@ -77,10 +77,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -125,10 +125,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `OverconstrainedError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OverconstrainedError
