### PR TITLE
Add Safari versions for VRDisplayCapabilities API

### DIFF
--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -46,7 +46,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "6.0",
@@ -108,7 +111,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -171,7 +177,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -234,7 +243,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -297,7 +309,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -360,7 +375,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `VRDisplayCapabilities` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VRDisplayCapabilities
