### PR TITLE
Add Safari versions for AudioContext API

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -374,10 +374,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -425,7 +425,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -712,10 +712,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -760,10 +760,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `AudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioContext
