### PR TITLE
Add Firefox versions for GamepadButton API

### DIFF
--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -177,10 +177,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `GamepadButton` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GamepadButton
