### PR TITLE
Update Firefox data for Gamepad extensions

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -462,18 +462,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -519,18 +511,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -864,18 +848,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -14,18 +14,10 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": true,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            "version_added": "55"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "55"
           },
           "ie": {
             "version_added": false
@@ -117,18 +109,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -220,18 +204,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -15,18 +15,10 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": true,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.gamepad-extensions.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+            "version_added": "55"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "55"
           },
           "ie": {
             "version_added": false
@@ -71,18 +63,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -128,18 +112,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -185,18 +161,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -242,18 +210,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -299,18 +259,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -356,18 +308,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -413,18 +357,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -470,18 +406,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad-extensions.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The flag is enabled by default in Firefox Nightly and Beta, versions 55 and above."
+              "version_added": "55"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates the data for Gamepad features behind the `dom.gamepad-extensions.enabled` flag in Firefox, using results from the mdn-bcd-collector project (as well as the existing notes).  These features were enabled by default in Firefox 55; as such, this PR replaces the data with `version_added: "55"`, thus removing the now-irrelevant flag data (since it has been enabled by default over two years ago).