### PR TITLE
Add Firefox versions for DataTransfer API

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -64,10 +64,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "62"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -160,10 +160,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -208,10 +208,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -256,10 +256,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -304,10 +304,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -352,10 +352,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -448,11 +448,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3.5",
               "version_removed": "71"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -497,10 +498,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -545,11 +546,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3.5",
               "version_removed": "71"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -594,11 +596,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3.5",
               "version_removed": "71"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -643,11 +646,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3.5",
               "version_removed": "71"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -692,10 +696,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -740,11 +744,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3.5",
               "version_removed": "71"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -789,10 +794,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -885,10 +890,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -933,10 +938,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10",


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DataTransfer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransfer
