### PR TITLE
Add Firefox versions for MessagePort API

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "41"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "ie": {
             "version_added": "10"
@@ -65,10 +65,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "ie": {
               "version_added": "10"
@@ -224,10 +224,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "ie": {
               "version_added": "10"
@@ -326,10 +326,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "ie": {
               "version_added": "10"
@@ -377,10 +377,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MessagePort` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessagePort
