### PR TITLE
Add Firefox versions for MutationRecord API

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "14"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "ie": {
             "version_added": null
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -109,10 +109,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -157,10 +157,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -205,10 +205,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -253,10 +253,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -301,10 +301,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -349,10 +349,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -397,10 +397,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null
@@ -445,10 +445,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MutationRecord` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationRecord
