### PR TITLE
Add Firefox versions for Notification API

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -243,10 +243,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
@@ -339,10 +339,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "ie": {
               "version_added": false
@@ -387,10 +387,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
@@ -549,10 +549,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
@@ -1129,10 +1129,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
@@ -1225,10 +1225,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "26"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `Notification` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Notification
