### PR TITLE
Add Firefox versions for Request API

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1199,7 +1199,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "≤83"
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -749,7 +749,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -938,7 +938,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -1006,10 +1006,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "ie": {
               "version_added": false
@@ -1054,10 +1054,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1128,7 +1128,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -1199,7 +1199,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤83"
             },
             "ie": {
               "version_added": false
@@ -1292,10 +1292,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "ie": {
               "version_added": false
@@ -1469,10 +1469,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "57"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "57"
             },
             "ie": {
               "version_added": false
@@ -1533,7 +1533,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `Request` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Request
