### PR TITLE
Add Safari versions for PaymentAddress API

### DIFF
--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -280,10 +280,12 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1",
+              "version_removed": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3",
+              "version_removed": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PaymentAddress` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PaymentAddress
