### PR TITLE
Add Safari versions for PaymentRequest API

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -337,7 +337,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -387,7 +387,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -534,10 +534,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -636,10 +636,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PaymentRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PaymentRequest
