### PR TITLE
Add Chromium implementation note for loading script

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -558,13 +558,16 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "61"
+                  "version_added": "61",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "chrome_android": {
-                  "version_added": "61"
+                  "version_added": "61",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": "16",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "firefox": [
                   {
@@ -602,10 +605,12 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "opera_android": {
-                  "version_added": "45"
+                  "version_added": "45",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "safari": {
                   "version_added": "10.1"
@@ -614,10 +619,12 @@
                   "version_added": "10.3"
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.0"
+                  "version_added": "8.0",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 },
                 "webview_android": {
-                  "version_added": "61"
+                  "version_added": "61",
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
                 }
               },
               "status": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -567,7 +567,7 @@
                 },
                 "edge": {
                   "version_added": "16",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "firefox": [
                   {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -559,11 +559,11 @@
               "support": {
                 "chrome": {
                   "version_added": "61",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "chrome_android": {
                   "version_added": "61",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "edge": {
                   "version_added": "16",
@@ -606,11 +606,11 @@
                 },
                 "opera": {
                   "version_added": "48",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "opera_android": {
                   "version_added": "45",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "safari": {
                   "version_added": "10.1"
@@ -620,11 +620,11 @@
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "webview_android": {
                   "version_added": "61",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 }
               },
               "status": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -565,10 +565,16 @@
                   "version_added": "61",
                   "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
-                "edge": {
-                  "version_added": "16",
+                "edge": [
+                  {
+                    "version_added": "16",
+                    "version_removed": "79"
+                  },
+                  {
+                  "version_added": "79",
                   "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
-                },
+                  }
+                ],
                 "firefox": [
                   {
                     "version_added": "60"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -567,12 +567,12 @@
                 },
                 "edge": [
                   {
-                    "version_added": "16",
-                    "version_removed": "79"
-                  },
-                  {
                     "version_added": "79",
                     "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
+                  },
+                  {
+                    "version_added": "16",
+                    "version_removed": "79"
                   }
                 ],
                 "firefox": [

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -559,7 +559,7 @@
               "support": {
                 "chrome": {
                   "version_added": "61",
-                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/717643'>Chromium Issue #717643</a>"
+                  "notes": "Chrome does not load module scripts without the <code>async</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "chrome_android": {
                   "version_added": "61",

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -571,8 +571,8 @@
                     "version_removed": "79"
                   },
                   {
-                  "version_added": "79",
-                  "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
+                    "version_added": "79",
+                    "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                   }
                 ],
                 "firefox": [
@@ -619,10 +619,12 @@
                   "notes": "Module scripts without the <code>async</code> attribute do not load when the page is served as XHTML (<code>application/xhtml+xml</code>). See <a href='https://crbug.com/717643'>bug 717643</a>."
                 },
                 "safari": {
-                  "version_added": "10.1"
+                  "version_added": "10.1",
+                  "notes": "Module scripts do not load when the page is served as XHTML (<code>application/xhtml+xml</code>)."
                 },
                 "safari_ios": {
-                  "version_added": "10.3"
+                  "version_added": "10.3",
+                  "notes": "Module scripts do not load when the page is served as XHTML (<code>application/xhtml+xml</code>)."
                 },
                 "samsunginternet_android": {
                   "version_added": "8.0",


### PR DESCRIPTION
Adds an implementation note warning developers about module script loading (`<script type="module">`) for XHTML documents in Chromium-based browsers.

There is a Chromium bug report about this, revealing that ESM loading is not supposed to work at all in XHTML, but it also reveals that a workaround was found and that the `nomodule` attribute does not help for feature detecting this in XHTML.
https://crbug.com/717643

They had never implemented this, so it should be safe to assume that this applies to all Chromium-based browsers, across all versions.

Can anyone check the current browsers for insurance and non Chromium browsers, i.e. Safari, Firefox?

I had tested this on a recent version of Chrome and Edge by opening an XHTML document that had contained a module script, and observed the effects.
(I had also run a few specific tests, ex: global scope `this === undefined`, and checked if the code was executed in strict mode)

I have no first-hand information regarding any other browser.

Closes https://github.com/mdn/browser-compat-data/issues/7886

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
