### PR TITLE
Correct Safari data for PerformanceTiming API

### DIFF
--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -32,7 +32,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "8"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -172,10 +172,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -220,10 +220,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -268,10 +268,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -319,7 +319,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -364,10 +364,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -412,10 +412,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -460,10 +460,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -508,10 +508,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -556,10 +556,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -604,10 +604,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -652,10 +652,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -700,10 +700,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -748,10 +748,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -796,10 +796,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -844,10 +844,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -892,10 +892,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -940,10 +940,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -988,10 +988,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1036,10 +1036,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1084,10 +1084,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR corrects the Safari data for the PerformanceTiming API based upon results from the mdn-bcd-collector project.
