### PR TITLE
Add Safari versions for SVGExternalResourcesRequired API

### DIFF
--- a/api/SVGExternalResourcesRequired.json
+++ b/api/SVGExternalResourcesRequired.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": true
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGExternalResourcesRequired` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGExternalResourcesRequired
