### PR TITLE
Add Safari versions for SVGLengthList API

### DIFF
--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -29,10 +29,10 @@
             "version_added": "15"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGLengthList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGLengthList
