### PR TITLE
Add Safari versions for SVGMatrix API

### DIFF
--- a/api/SVGMatrix.json
+++ b/api/SVGMatrix.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "4"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGMatrix` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGMatrix
