### PR TITLE
Add Safari versions for SVGTransformList API

### DIFF
--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -29,10 +29,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -75,10 +75,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -75,10 +75,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGTransformList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTransformList
