### PR TITLE
Add Safari versions for NamedNodeMap API

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -242,10 +242,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `NamedNodeMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NamedNodeMap
