### PR TITLE
Update Safari versions for MediaList API

### DIFF
--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "≤5"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "≤4"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "≤5"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "≤4"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "≤4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "≤4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `MediaList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaList
