### PR TITLE
:focus-visible CSS pseudo-class is enabled in Firefox 85

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -46,14 +46,24 @@
                 }
               ]
             },
-            "firefox": {
-              "version_added": "4",
-              "alternative_name": ":-moz-focusring"
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "alternative_name": ":-moz-focusring"
-            },
+            "firefox": [
+              {
+                "version_added": "85"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": ":-moz-focusring"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": ":-moz-focusring"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Working on: https://github.com/mdn/content/issues/292

`:focus-visible` is enabled in Firefox 85, so this PR adds that information to the BCD.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1445482
