### PR TITLE
Update Safari versions for TextTrack API

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -657,7 +657,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -317,7 +317,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -558,7 +558,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -657,7 +657,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `TextTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrack
