### PR TITLE
Update Safari versions for TextTrackList API

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -225,7 +225,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -174,7 +174,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "8"
@@ -222,10 +222,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `TextTrackList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackList
