### PR TITLE
Update Safari versions for MediaStreamAudioSourceNode API

### DIFF
--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -29,10 +29,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -129,10 +129,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `MediaStreamAudioSourceNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamAudioSourceNode
