### PR TITLE
Add specurl for incumbent settings object tracking in Promises

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -377,6 +377,7 @@
         "incumbent_settings_object_tracking": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise#Incumbent_settings_object_tracking",
+            "spec_url": "https://html.spec.whatwg.org/multipage/#incumbent-settings-object-tracking-in-promises",
             "description": "Incumbent settings object tracking",
             "support": {
               "chrome": {


### PR DESCRIPTION
This is needed for Wattsi to generate an MDN compatibility box for the
HTML specification.

HTML PR: https://github.com/whatwg/html/pull/5722

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
