### PR TITLE
Add Safari versions for XPathExpression API

### DIFF
--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `XPathExpression` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XPathExpression
