### PR TITLE
Add Safari versions for XPathResult API

### DIFF
--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `XPathResult` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XPathResult
