### PR TITLE
Add Safari versions for ImageData API

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -77,7 +77,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ImageData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageData
