### PR TITLE
Add Safari versions for MutationRecord API

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -268,10 +268,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -316,10 +316,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -364,10 +364,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -412,10 +412,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -460,10 +460,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -29,7 +29,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "6.1"
           },
           "safari_ios": {
             "version_added": "7"
@@ -76,7 +76,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -124,7 +124,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -220,7 +220,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -268,7 +268,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -316,7 +316,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -364,7 +364,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -412,7 +412,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"
@@ -460,7 +460,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": "7"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MutationRecord` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationRecord
