### PR TITLE
Add Safari versions for Notation API

### DIFF
--- a/api/Notation.json
+++ b/api/Notation.json
@@ -29,10 +29,12 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "≤4",
+            "version_removed": "9"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "≤3",
+            "version_removed": "9"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -76,10 +78,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7",
+              "version_removed": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7",
+              "version_removed": "9"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -124,10 +128,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7",
+              "version_removed": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7",
+              "version_removed": "9"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Notation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Notation
