### PR TITLE
Add Safari versions for Notification API

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -258,7 +258,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -306,7 +306,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -402,7 +402,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -564,7 +564,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false
@@ -660,7 +660,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -708,7 +708,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -756,7 +756,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -804,7 +804,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -852,7 +852,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -952,7 +952,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -1144,7 +1144,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -1240,7 +1240,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Notification` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Notification
