### PR TITLE
Update Safari versions for Notification API

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -48,7 +48,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": false
@@ -114,7 +114,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
@@ -468,7 +468,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Notification` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Notification
