### PR TITLE
Update Safari versions for Path2D API

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -29,10 +29,10 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -78,10 +78,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -126,10 +126,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Path2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Path2D
