### PR TITLE
Add Safari versions for Text API

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -26,10 +26,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "webview_android": {
             "version_added": true
@@ -224,10 +224,12 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -278,11 +280,11 @@
               "notes": "Before Opera 17, the <code>offset</code> argument was optional."
             },
             "safari": {
-              "version_added": true,
+              "version_added": "≤4",
               "notes": "The <code>offset</code> argument is optional."
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "≤3",
               "notes": "The <code>offset</code> argument is optional."
             },
             "samsunginternet_android": {
@@ -327,10 +329,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Text` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Text
