### PR TITLE
Add Safari versions for TimeRanges API

### DIFF
--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -76,10 +76,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `TimeRanges` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TimeRanges
