### PR TITLE
Add Firefox versions for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -810,10 +810,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "≤6"
@@ -1439,7 +1439,7 @@
                 "version_added": "14"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "7"
               }
             ],
@@ -1448,7 +1448,7 @@
                 "version_added": "14"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "7"
               }
             ],
@@ -1499,7 +1499,7 @@
                 "version_added": "14"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "7"
               }
             ],
@@ -1508,7 +1508,7 @@
                 "version_added": "14"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "7"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `HTMLImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement
