### PR TITLE
Remove Chrome support from SVGAElement#referrerPolicy

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -194,13 +194,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": false
             },
             "edge": {
-              "version_added": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "52"
@@ -212,10 +212,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -224,10 +224,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "7.2"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "51"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests):
   * https://github.com/chromium/chromium/blob/a973c71e533a3e968b4849d69d730f8f97c17c2d/third_party/blink/renderer/core/svg/svg_a_element.idl
   * https://github.com/chromium/chromium/blob/955d8931c3ad56e998bc3d17e5b23217a8e3a321/third_party/WebKit/Source/core/svg/SVGAElement.idl
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

#2858 added the data, but per the history it hasn't supported the attribute.