### PR TITLE
Add Firefox versions for MediaQueryList API

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -17,7 +17,7 @@
             "version_added": "6"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "6"
           },
           "ie": {
             "version_added": "10"
@@ -163,7 +163,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
@@ -213,7 +213,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
@@ -261,7 +261,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
@@ -358,7 +358,7 @@
               "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaQueryList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaQueryList
