### PR TITLE
Add Firefox versions for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1522,11 +1522,11 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "3",
               "version_removed": "35"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "35"
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator
