### PR TITLE
Add Chromium versions for MediaError API

### DIFF
--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError/code",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "≤87"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "15> ≤73"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "≤61"
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
@@ -82,10 +82,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": "≤13.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤87"
+              "version_added": true
             }
           },
           "status": {

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +35,10 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError/code",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "≤87"
             },
             "edge": {
               "version_added": "12"
@@ -70,10 +70,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15> ≤73"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤61"
             },
             "safari": {
               "version_added": "10"
@@ -82,10 +82,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "≤13.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤87"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaError
