### PR TITLE
Correct Chromium data for TextTrack API; add versions for TextTrackList API

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -84,7 +84,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -227,7 +227,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack",
         "support": {
           "chrome": {
-            "version_added": "18"
+            "version_added": "23"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "6"
@@ -36,7 +36,7 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/activeCues",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/addCue",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -120,10 +120,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -132,7 +132,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/cues",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -215,10 +215,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/id",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "33"
             },
             "edge": {
               "version_added": "12"
@@ -263,10 +263,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "20"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "20"
             },
             "safari": {
               "version_added": "6"
@@ -275,10 +275,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -293,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/inBandMetadataTrackDispatchType",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -311,7 +311,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -323,10 +323,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": false
             }
           },
           "status": {
@@ -341,10 +341,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/kind",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -359,10 +359,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -371,7 +371,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -389,10 +389,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/label",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -407,10 +407,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -419,7 +419,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -437,10 +437,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/language",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -455,10 +455,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -467,7 +467,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -485,10 +485,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/mode",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -504,10 +504,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -516,7 +516,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -534,10 +534,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/oncuechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -552,10 +552,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -564,10 +564,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -582,10 +582,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/removeCue",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -600,10 +600,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -612,7 +612,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -648,7 +648,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "23"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "6"
@@ -35,10 +35,10 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/getTrackById",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "18"
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "20"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "20"
             },
             "safari": {
               "version_added": "7"
@@ -180,10 +180,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
This PR corrects the data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TextTrack` API, and adds `TextTrackList` API real values, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackList
