### PR TITLE
Add Chromium versions for RTCRtpSender API

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "64"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "64"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "51"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "safari": {
             "version_added": "11"
@@ -35,10 +35,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "64"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/dtmf",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "66"
             },
             "edge": {
               "version_added": "≤18"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"
@@ -82,10 +82,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "66"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "description": "<code>getCapabilities()</code>",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "69"
             },
             "edge": {
               "version_added": "12"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"
@@ -131,10 +131,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "69"
             }
           },
           "status": {
@@ -150,10 +150,10 @@
           "description": "<code>getParameters()</code>",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "68"
             },
             "edge": {
               "version_added": "≤79"
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -180,10 +180,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "68"
             }
           },
           "status": {
@@ -266,10 +266,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "11"
@@ -296,10 +296,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/rtcpTransport",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "12",
@@ -315,10 +315,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -327,10 +327,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -346,10 +346,10 @@
           "description": "<code>setParameters()</code>",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "68"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "68"
             },
             "edge": {
               "version_added": "≤79"
@@ -376,10 +376,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"
@@ -388,10 +388,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "68"
             }
           },
           "status": {
@@ -406,10 +406,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/track",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "64"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "64"
             },
             "edge": {
               "version_added": "12"
@@ -424,10 +424,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "11"
@@ -436,10 +436,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "64"
             }
           },
           "status": {
@@ -454,10 +454,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/transport",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "12",
@@ -473,10 +473,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -485,10 +485,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCRtpSender` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpSender
