### PR TITLE
Add Chromium versions for URL API

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -212,7 +212,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -287,10 +287,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/hash",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -308,10 +308,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": true
@@ -320,10 +320,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -338,10 +338,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/host",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -359,10 +359,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": true
@@ -371,10 +371,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -389,10 +389,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/hostname",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -410,10 +410,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -422,10 +422,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -440,10 +440,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/href",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -461,10 +461,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -473,10 +473,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -526,10 +526,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -577,10 +577,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -607,10 +607,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/pathname",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -642,10 +642,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -654,10 +654,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -672,10 +672,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/port",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -693,10 +693,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -705,10 +705,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -723,10 +723,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/protocol",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -744,10 +744,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -756,10 +756,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -827,10 +827,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/search",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "13"
@@ -862,10 +862,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"
@@ -874,10 +874,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -964,10 +964,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "safari": {
               "version_added": true
@@ -1012,10 +1012,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -1063,10 +1063,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `URL` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/URL
