### PR TITLE
Add Chromium versions for PannerNode API

### DIFF
--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -138,7 +138,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -234,7 +234,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -282,7 +282,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -330,7 +330,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -345,10 +345,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/orientationX",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -363,10 +363,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -375,10 +375,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -393,10 +393,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/orientationY",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -411,10 +411,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -423,10 +423,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -441,10 +441,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/orientationZ",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -459,10 +459,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -471,10 +471,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -522,7 +522,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -537,10 +537,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/positionX",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -555,10 +555,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -567,10 +567,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -585,10 +585,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/positionY",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -603,10 +603,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -615,10 +615,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -633,10 +633,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PannerNode/positionZ",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "edge": {
               "version_added": "≤18"
@@ -651,10 +651,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "safari": {
               "version_added": false
@@ -663,10 +663,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "52"
             }
           },
           "status": {
@@ -714,7 +714,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -762,7 +762,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -810,7 +810,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -858,7 +858,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -366,7 +366,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -414,7 +414,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -462,7 +462,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -558,7 +558,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -606,7 +606,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -654,7 +654,7 @@
               "version_added": "39"
             },
             "opera_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PannerNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PannerNode
