### PR TITLE
Add Chromium versions for KeyframeEffect API

### DIFF
--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "84"
             },
             "edge": {
               "version_added": null
@@ -140,10 +140,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -152,10 +152,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "84"
             }
           },
           "status": {
@@ -170,10 +170,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/getKeyframes",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "84"
             },
             "edge": {
               "version_added": null
@@ -188,10 +188,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -200,10 +200,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "84"
             }
           },
           "status": {
@@ -218,10 +218,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/iterationComposite",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -286,24 +286,34 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/pseudoElement",
           "support": {
-            "chrome": {
-              "version_added": "81",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "81",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "81",
               "flags": [
@@ -322,17 +332,22 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -344,7 +359,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -359,10 +374,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "84"
             },
             "edge": {
               "version_added": false
@@ -377,10 +392,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -392,7 +407,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `KeyframeEffect` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyframeEffect
