### PR TITLE
Canvas getContextAttributes is supported later

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2127,10 +2127,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "73"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "73"
             },
             "edge": {
               "version_added": "79"
@@ -2145,10 +2145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "19"
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": "19"
+              "version_added": "52"
             },
             "safari": {
               "version_added": false
@@ -2157,10 +2157,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "73"
             }
           },
           "status": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2125,13 +2125,26 @@
       },
       "getContextAttributes": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getContextAttributes",
           "support": {
-            "chrome": {
-              "version_added": "73"
-            },
-            "chrome_android": {
-              "version_added": "73"
-            },
+            "chrome": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "32",
+                "version_removed": "60"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "32",
+                "version_removed": "60"
+              }
+            ],
             "edge": {
               "version_added": "79"
             },
@@ -2144,24 +2157,48 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "60"
-            },
-            "opera_android": {
-              "version_added": "52"
-            },
+            "opera": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "19",
+                "version_removed": "47"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "19",
+                "version_removed": "44"
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": "11.0"
-            },
-            "webview_android": {
-              "version_added": "73"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "11.0"
+              },
+              {
+                "version_added": "2.0",
+                "version_removed": "8.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "4.4.3",
+                "version_removed": "60"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
In https://github.com/mdn/browser-compat-data/pull/7845 `getContextAttributes` for canvas was added.

I was very suspicious to see so early support for such a new feature. So, I thought the data is wrong.

Chrome had this as an origin trial according to: https://chromestatus.com/feature/6545516187877376 and then there was an intent to ship: https://groups.google.com/a/chromium.org/g/blink-dev/c/IcxDgEnEEIs/m/eWc-OXUGDQAJ

https://bugs.chromium.org/p/chromium/issues/detail?id=919118#c5 confirms shipping in 73 and not in 32.

fyi @foolip and @vinyldarkscratch. Not sure what part of your machinery failed here.