### PR TITLE
Add an issue template for reporting data problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.md
+++ b/.github/ISSUE_TEMPLATE/data-problem.md
@@ -1,0 +1,15 @@
+---
+name: Data problem
+about: Report incorrect, incomplete, or missing data
+title: "<NAME THE FEATURE> - <SUMMARIZE THE PROBLEM>"
+labels: ''
+assignees: ''
+
+---
+
+<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->
+
+#### What information was incorrect, unhelpful, or incomplete?
+#### What did you expect to see?
+#### Did you test this? If so, how?
+#### Do you know of any release notes, bugs, or issues related to this?

--- a/.github/ISSUE_TEMPLATE/data-problem.md
+++ b/.github/ISSUE_TEMPLATE/data-problem.md
@@ -12,4 +12,4 @@ assignees: ''
 #### What information was incorrect, unhelpful, or incomplete?
 #### What did you expect to see?
 #### Did you test this? If so, how?
-#### Do you know of any release notes, bugs, or issues related to this?
+#### Can you link to any release notes, bugs, pull requests, or MDN pages related to this?


### PR DESCRIPTION
This is inspired by the issue template from Yari, which has been working pretty well so far:

https://github.com/mdn/yari/blob/6a2e6cd78e853305e382067a08bf8c9584a90e9c/client/src/document/ingredients/browser-compatibility-table/index.tsx#L16