### PR TITLE
Add Chromium versions for PluginArray API

### DIFF
--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PluginArray",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "14"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,15 +52,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PluginArray/item",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "18",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Since Edge 79, method parameters are required instead of optional."
             },
             "firefox": {
               "version_added": "1"
@@ -72,10 +73,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14",
+              "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
               "version_added": true
@@ -84,12 +87,12 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
+              "version_added": "1.0",
+              "notes": "Since Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since WebView 59, method parameters are required instead of optional."
             }
           },
           "status": {
@@ -152,15 +155,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PluginArray/namedItem",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "18",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Since Edge 79, method parameters are required instead of optional."
             },
             "firefox": {
               "version_added": "1"
@@ -172,10 +176,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14",
+              "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
               "version_added": true
@@ -184,12 +190,12 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
+              "version_added": "1.0",
+              "notes": "Since Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since WebView 59, method parameters are required instead of optional."
             }
           },
           "status": {
@@ -204,15 +210,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PluginArray/refresh",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "18",
+              "notes": "Since Chrome 59, method parameters are required instead of optional."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Since Edge 79, method parameters are required instead of optional."
             },
             "firefox": {
               "version_added": "1"
@@ -224,10 +231,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14",
+              "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
               "version_added": true
@@ -236,12 +245,12 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
+              "version_added": "1.0",
+              "notes": "Since Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting with version 59, method parameters are required instead of optional."
+              "version_added": "1",
+              "notes": "Since WebView 59, method parameters are required instead of optional."
             }
           },
           "status": {

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": true
@@ -73,11 +73,11 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15",
+              "version_added": "≤12.1",
               "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": "14",
+              "version_added": "≤12.1",
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
@@ -176,11 +176,11 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15",
+              "version_added": "≤12.1",
               "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": "14",
+              "version_added": "≤12.1",
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
@@ -231,11 +231,11 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15",
+              "version_added": "≤12.1",
               "notes": "Since Opera 46, method parameters are required instead of optional."
             },
             "opera_android": {
-              "version_added": "14",
+              "version_added": "≤12.1",
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PluginArray` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Additionally, this adjusts a note on a few methods to match our typical wording, and copies it to all of the Chrome-based browsers.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PluginArray
