### PR TITLE
Add Opera versions for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -94,10 +94,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": true
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": true
@@ -238,10 +238,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": true
@@ -310,10 +310,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": true
@@ -383,10 +383,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -456,10 +456,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -529,10 +529,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -602,10 +602,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -675,10 +675,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -748,10 +748,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -821,10 +821,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `TextMetrics` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextMetrics
