### PR TITLE
Add Chromium versions for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -26,7 +26,7 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.1"
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -558,24 +558,34 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxAscent",
           "support": {
-            "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
@@ -617,7 +627,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {
@@ -631,24 +641,34 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxDescent",
           "support": {
-            "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "79",
               "flags": [
@@ -690,7 +710,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TextMetrics` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextMetrics
