### PR TITLE
Add IE/Edge versions for MediaList API

### DIFF
--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -106,7 +106,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -154,7 +154,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -202,7 +202,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -211,7 +211,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -250,7 +250,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MediaList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaList
