### PR TITLE
Add IE/Edge versions for StyleSheetList API

### DIFF
--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -20,7 +20,7 @@
             "version_added": "31"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "8"
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "8"
             },
             "opera": {
               "version_added": true

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -20,7 +20,7 @@
             "version_added": "31"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -20,7 +20,7 @@
             "version_added": "31"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `StyleSheetList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StyleSheetList
