### PR TITLE
Add IE/Edge versions for NamedNodeMap API

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -42,7 +42,7 @@
             }
           ],
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -89,7 +89,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -137,7 +137,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -185,7 +185,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -233,7 +233,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -281,7 +281,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -329,7 +329,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -377,7 +377,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -425,7 +425,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `NamedNodeMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NamedNodeMap
