### PR TITLE
Add IE/Edge versions for Comment API

### DIFF
--- a/api/Comment.json
+++ b/api/Comment.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "24"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Comment` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Comment
