### PR TITLE
Add IE/Edge versions for MutationRecord API

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -20,7 +20,7 @@
             "version_added": "14"
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "14"
@@ -115,7 +115,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "14"
@@ -163,7 +163,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "14"
@@ -211,7 +211,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "14"
@@ -259,7 +259,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -307,7 +307,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -355,7 +355,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -403,7 +403,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -451,7 +451,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MutationRecord` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationRecord
