### PR TITLE
Add IE/Edge versions for OverconstrainedError API

### DIFF
--- a/api/OverconstrainedError.json
+++ b/api/OverconstrainedError.json
@@ -11,7 +11,7 @@
             "version_added": "63"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -20,7 +20,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "50"
@@ -59,7 +59,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -68,7 +68,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "50"
@@ -107,7 +107,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -116,7 +116,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `OverconstrainedError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OverconstrainedError
