### PR TITLE
Add IE/Edge versions for Plugin and PluginArray APIs

### DIFF
--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "11"
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "15"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -165,7 +165,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "15"
@@ -215,7 +215,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -265,7 +265,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "15"
@@ -316,7 +316,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": false

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "11"
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -70,7 +70,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -122,7 +122,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -173,7 +173,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -228,7 +228,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1",

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "11"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -70,7 +70,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -122,7 +122,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -173,7 +173,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -228,7 +228,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1",


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Plugin` and `PluginArray` APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PluginArray
