### PR TITLE
Add IE/Edge versions for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -213,7 +213,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -263,7 +263,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -313,7 +313,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -362,7 +362,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -627,11 +627,16 @@
             "chrome_android": {
               "version_added": "39"
             },
-            "edge": {
-              "version_added": "12",
-              "prefix": "ms",
-              "notes": "Edge does not return an <code>Orientation</code> object; instead, it returns the orientation type as a string."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "prefix": "ms",
+                "notes": "Edge does not return an <code>Orientation</code> object; instead, it returns the orientation type as a string."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "43"
@@ -703,7 +708,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -754,7 +759,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -854,7 +859,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen
