### PR TITLE
Add IE/Edge versions for Text API

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -17,7 +17,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": true
@@ -53,7 +53,7 @@
               "version_added": "28"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "24"
@@ -213,7 +213,7 @@
               "version_removed": "10"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -269,7 +269,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true,
@@ -320,7 +320,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Text` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Text
