### PR TITLE
Add IE/Edge versions for TimeRanges API

### DIFF
--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `TimeRanges` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TimeRanges
