### PR TITLE
Add IE/Edge versions for DOMError API

### DIFF
--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -72,7 +72,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "12",
@@ -83,7 +83,7 @@
               "version_removed": "79"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `DOMError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMError
