### PR TITLE
Add IE/Edge versions for DOMException API

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": true
@@ -116,7 +116,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -164,7 +164,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -212,7 +212,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `DOMException` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.6).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMException
