### PR TITLE
Add Navigator.contacts

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -534,6 +534,54 @@
           }
         }
       },
+      "contacts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/contacts",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "cookieEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/cookieEnabled",


### PR DESCRIPTION
This adds `Navigator.contacts`, as discussed in #7851. This is not complete - it still depends on discussion in #7851.

What I've done for now is matched the [ContactsManager BCD info](https://developer.mozilla.org/en-US/docs/Web/API/Contact_Picker_API#Browser_compatibility), but only included the android chromium builds. This might therefore be incorrect if, for example, Opera on Android did not choose to add this. 
