### PR TITLE
Remove service_workers_support from api/FileReaderSync

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -251,57 +251,56 @@
       },
       "worker_support": {
         "__compat": {
-          "description": "Available in workers (except for service workers)",
+          "description": "Available in workers",
           "support": {
             "chrome": {
               "version_added": true,
-              "notes": "Not supported in service workers from Chrome 59"
+              "notes": "From Chrome 59, not supported in service workers."
             },
             "chrome_android": {
               "version_added": true,
-              "notes": "Not supported in service workers from Chrome 59"
+              "notes": "From Chrome 59, not supported in service workers."
             },
             "edge": {
               "version_added": "12",
-              "notes": "Not supported in service workers"
+              "notes": "Not supported in service workers."
             },
             "firefox": {
               "version_added": "8",
-              "notes": "Not supported in service workers from FF61"
+              "notes": "From Firefox 61, not supported in service workers."
             },
             "firefox_android": {
               "version_added": "8",
-              "notes": "Not supported in service workers from FF61"
+              "notes": "Form Firefox 61, not supported in service workers."
             },
             "ie": {
-              "version_added": true,
-              "notes": "Not supported in service workers"
+              "version_added": true
             },
             "opera": {
               "version_added": true,
-              "notes": "Not supported in service workers from Opera 46"
+              "notes": "From Opera 46, not supported in service workers."
             },
             "opera_android": {
               "version_added": true,
-              "notes": "Not supported in service workers from Opera 43"
+              "notes": "From Opera 43, not supported in service workers."
             },
             "safari": {
               "version_added": true,
               "version_removed": "6.1",
-              "notes": "Service workers not supported"
+              "notes": "Not supported in service workers."
             },
             "safari_ios": {
               "version_added": true,
               "version_removed": "7",
-              "notes": "Service workers not supported"
+              "notes": "Not supported in service workers."
             },
             "samsunginternet_android": {
               "version_added": true,
-              "notes": "Not supported in service workers from version 7.0"
+              "notes": "From version 7.0, not supported in service workers."
             },
             "webview_android": {
               "version_added": true,
-              "notes": "Not supported in service workers from version 59"
+              "notes": "From version 59, not supported in service workers."
             }
           },
           "status": {

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -251,7 +251,7 @@
       },
       "worker_support": {
         "__compat": {
-          "description": "Available in workers",
+          "description": "Available in workers (except for service workers)",
           "support": {
             "chrome": {
               "version_added": true,

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -271,7 +271,7 @@
             },
             "firefox_android": {
               "version_added": "8",
-              "notes": "Form Firefox 61, not supported in service workers."
+              "notes": "From Firefox 61, not supported in service workers."
             },
             "ie": {
               "version_added": true

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -249,103 +249,59 @@
           }
         }
       },
-      "service_workers_support": {
-        "__compat": {
-          "description": "Service workers support",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "59"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "59"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "46"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "7.0"
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "59"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from Chrome 59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from Chrome 59"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Service workers not supported"
             },
             "firefox": {
-              "version_added": "8"
+              "version_added": "8",
+              "notes": "Service workers not supported from FF61"
             },
             "firefox_android": {
-              "version_added": "8"
+              "version_added": "8",
+              "notes": "Service workers not supported from FF61"
             },
             "ie": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported"
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from Opera 46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from Opera 43"
             },
             "safari": {
               "version_added": true,
-              "version_removed": "6.1"
+              "version_removed": "6.1",
+              "notes": "Service workers not supported"
             },
             "safari_ios": {
               "version_added": true,
-              "version_removed": "7"
+              "version_removed": "7",
+              "notes": "Service workers not supported"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from version 7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Service workers not supported from version 59"
             }
           },
           "status": {

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -255,35 +255,35 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "notes": "Service workers not supported from Chrome 59"
+              "notes": "Not supported in service workers from Chrome 59"
             },
             "chrome_android": {
               "version_added": true,
-              "notes": "Service workers not supported from Chrome 59"
+              "notes": "Not supported in service workers from Chrome 59"
             },
             "edge": {
               "version_added": "12",
-              "notes": "Service workers not supported"
+              "notes": "Not supported in service workers"
             },
             "firefox": {
               "version_added": "8",
-              "notes": "Service workers not supported from FF61"
+              "notes": "Not supported in service workers from FF61"
             },
             "firefox_android": {
               "version_added": "8",
-              "notes": "Service workers not supported from FF61"
+              "notes": "Not supported in service workers from FF61"
             },
             "ie": {
               "version_added": true,
-              "notes": "Service workers not supported"
+              "notes": "Not supported in service workers"
             },
             "opera": {
               "version_added": true,
-              "notes": "Service workers not supported from Opera 46"
+              "notes": "Not supported in service workers from Opera 46"
             },
             "opera_android": {
               "version_added": true,
-              "notes": "Service workers not supported from Opera 43"
+              "notes": "Not supported in service workers from Opera 43"
             },
             "safari": {
               "version_added": true,
@@ -297,11 +297,11 @@
             },
             "samsunginternet_android": {
               "version_added": true,
-              "notes": "Service workers not supported from version 7.0"
+              "notes": "Not supported in service workers from version 7.0"
             },
             "webview_android": {
               "version_added": true,
-              "notes": "Service workers not supported from version 59"
+              "notes": "Not supported in service workers from version 59"
             }
           },
           "status": {


### PR DESCRIPTION
There is a [Worker support guideline](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#web-workers-worker_support) so `service_workers_support` is incorrect. This follows on from this discussion:  https://github.com/mdn/browser-compat-data/issues/7849#issuecomment-745445095

@ddbeck The way I have done this  is to just add a note indicating that service workers are not supported (with the version, if known). 

Are there other alternatives? i.e. should/can I do multiple worker supports like this?:
```
 "worker_support": {
        "__compat": {
          "description": "Available in workers",
...

 "worker_support": {
        "__compat": {
          "description": "Available in service workers",
...
````

Or something like this (feels confusing).
```json
 "worker_support": {
        "__compat": {
          "description": "Available in workers",
          "support": {
            "chrome": [
              {
                "version_added": true,
              },
              {
                "version_added": true,
                "version_removed": "59",
                "notes": "Service workers not supported from Chrome 59"
              },
            ],
```
