### PR TITLE
Add touch-action: pinch-zoom support for Firefox 85

### DIFF
--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -385,12 +385,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1285685'>bug 1285685</a>."
+                "version_added": "85",
+                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1285685'>bug 1285685</a>."
+                "version_added": "85",
+                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
               },
               "ie": [
                 {


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/295

Adding BCD for fx85 for `touch-action: pinch-zoom`

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1329241
