### PR TITLE
Move <menuitem> behind a flag in Firefox 85

### DIFF
--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -23,6 +23,10 @@
                     "name": "dom.menuitem.enabled",
                     "value_to_set": "true"
                   }
+                ],
+                "notes": [
+                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
+                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
                 ]
               },
               {
@@ -43,6 +47,10 @@
                     "name": "dom.menuitem.enabled",
                     "value_to_set": "true"
                   }
+                ],
+                "notes": [
+                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
+                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
                 ]
               },
               {

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -14,20 +14,46 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8",
-              "notes": [
-                "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-              ]
-            },
-            "firefox_android": {
-              "version_added": "8",
-              "notes": [
-                "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_removed": "85",
+                "version_added": "8",
+                "notes": [
+                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
+                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_removed": "85",
+                "version_added": "8",
+                "notes": [
+                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
+                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/294

Moving `<menuitem>` behind a flag. I've set it as removed in 85 then a flag added in 85, let me know if there is a better way to represent this.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1680596