### PR TITLE
Update link for private class fields

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -476,7 +476,7 @@
       "private_class_fields": {
         "__compat": {
           "description": "Private class fields",
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Private_class_fields",
           "spec_url": "https://tc39.es/proposal-class-fields/#prod-PrivateIdentifier",
           "support": {
             "chrome": {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -476,7 +476,7 @@
       "private_class_fields": {
         "__compat": {
           "description": "Private class fields",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_fields",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields",
           "spec_url": "https://tc39.es/proposal-class-fields/#prod-PrivateIdentifier",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR addresses issue #7962, updating the `private_class_fields` link.
