### PR TITLE
Add Chromium versions for OES_ WebGL Extensions APIs

### DIFF
--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_element_index_uint",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "24"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_standard_derivatives",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "10"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "10"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float_linear",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "29"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "16"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "16"
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "27"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float_linear",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "29"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "16"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "16"
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "24"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "17"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "8"
@@ -35,10 +35,10 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"
@@ -82,10 +82,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/createVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"
@@ -130,10 +130,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/deleteVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17"
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"
@@ -178,10 +178,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/isVertexArrayOES",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17"
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"
@@ -226,10 +226,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `OES_` WebGL Extensions APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/OES_element_index_uint
https://mdn-bcd-collector.appspot.com/tests/api/OES_standard_derivatives
https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_float
https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_float_linear
https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_half_float
https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_half_float_linear
https://mdn-bcd-collector.appspot.com/tests/api/OES_vertex_array_object
