### PR TITLE
Add Chromium versions for DocumentType API

### DIFF
--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +35,10 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,10 +52,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/entities",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "34"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "34"
             },
             "edge": {
               "version_added": "12",
@@ -73,10 +75,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "21"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "21"
             },
             "safari": {
               "version_added": "≤4",
@@ -87,10 +91,12 @@
               "version_removed": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "2.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -105,10 +111,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/internalSubset",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "37"
             },
             "edge": {
               "version_added": "12",
@@ -124,10 +132,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "24"
             },
             "safari": {
               "version_added": "≤4",
@@ -138,10 +148,12 @@
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -156,10 +168,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -174,10 +186,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -186,10 +198,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -204,10 +216,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/notations",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "34"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18",
+              "version_removed": "34"
             },
             "edge": {
               "version_added": "12",
@@ -225,10 +239,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "21"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1",
+              "version_removed": "21"
             },
             "safari": {
               "version_added": "≤4",
@@ -239,10 +255,12 @@
               "version_removed": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0",
+              "version_removed": "2.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1",
+              "version_removed": "37"
             }
           },
           "status": {
@@ -257,10 +275,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/publicId",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -275,10 +293,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -287,10 +305,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -305,10 +323,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentType/systemId",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -323,10 +341,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -335,10 +353,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DocumentType` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DocumentType
