### PR TITLE
Add Chromium versions for GamepadButton API

### DIFF
--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -201,7 +201,7 @@
               "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "73"
+              "version_added": false
             }
           },
           "status": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -168,10 +168,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton/touched",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "73"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "73"
             },
             "edge": {
               "version_added": "15"
@@ -186,10 +186,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "52"
             },
             "safari": {
               "version_added": "10.1"
@@ -198,10 +198,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "73"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `GamepadButton` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GamepadButton
