### PR TITLE
Add missing Navigator.bluetooth

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -322,6 +322,53 @@
           }
         }
       },
+      "bluetooth": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "57"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "70"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "buildID": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/buildID",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from a spec in Editor's Draft or more and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for `Navigator.bluetooth`.

Spec: https://webbluetoothcg.github.io/web-bluetooth/
IDL: https://github.com/w3c/webref/blob/master/ed/idl/web-bluetooth.idl
Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/bluetooth