### PR TITLE
Update data for NavigatorConcurrentHardware mixin API

### DIFF
--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "48"
@@ -20,7 +20,7 @@
             "version_added": "48"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "24"
@@ -29,10 +29,12 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": false
+            "version_added": "10.1",
+            "version_removed": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3",
+            "version_removed": "11"
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -67,7 +69,7 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "24"
@@ -76,10 +78,12 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1",
+              "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3",
+              "version_removed": "11"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -115,7 +119,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "24"


### PR DESCRIPTION
This PR uses results from the mdn-bcd-collector project (v1.1.7) to set real values for the NavigatorConcurrentHardware mixin for all browsers. Results were manually confirmed for accuracy.  The collector confirmed the existing results, as well as indicated that IE has no support (expected, since it was supported since Edge 15), and Safari _briefly_ supported it in 10.1.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/hardwareConcurrency
