### PR TITLE
Update all versions for NavigatorLanguage API

### DIFF
--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -107,27 +107,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage/languages",
           "support": {
             "chrome": {
-              "version_added": "32",
+              "version_added": "37",
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             },
             "chrome_android": {
-              "version_added": "32",
+              "version_added": "37",
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             },
             "edge": {
-              "version_added": "12",
-              "notes": "In Chromium versions of Edge, this returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
+              "version_added": "16",
+              "notes": [
+                "In Chromium versions of Edge, this returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>.",
+                "Before Edge 16, the closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
+              ]
             },
             "firefox": {
               "version_added": "32",
               "notes": "In Firefox, the <code>navigator.languages</code> property's value is taken from the <code>intl.accept_languages</code> preference."
             },
             "firefox_android": {
-              "version_added": "4",
+              "version_added": "32",
               "notes": "In Firefox, the <code>navigator.languages</code> property's value is taken from the <code>intl.accept_languages</code> preference."
             },
             "ie": {
-              "version_added": "11",
+              "version_added": false,
               "notes": "Closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
             },
             "opera": {
@@ -137,17 +140,17 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "2.0",
+              "version_added": "3.0",
               "notes": "In Samsung Internet, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             },
             "webview_android": {
-              "version_added": "4.4.3",
+              "version_added": "37",
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             }
           },

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -116,10 +116,7 @@
             },
             "edge": {
               "version_added": "16",
-              "notes": [
-                "In Chromium versions of Edge, this returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>.",
-                "Before Edge 16, the closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
-              ]
+              "notes": "In Chromium versions of Edge, this returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
             "firefox": {
               "version_added": "32",


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `NavigatorLanguage` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/languages