### PR TITLE
Update all versions for NavigatorOnLine API

### DIFF
--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -14,13 +14,13 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "3.5"
+            "version_added": "1.5"
           },
           "firefox_android": {
             "version_added": "4"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "3"
@@ -29,10 +29,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4.2"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -62,14 +62,14 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5",
+              "version_added": "1.5",
               "notes": "Since Firefox 4 the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity. Since Firefox 41, on OS X and Windows, the returned values follow the actual network connectivity, unless 'Work offline' mode is selected (where it will always return <code>false</code>)."
             },
             "firefox_android": {
               "version_added": "4"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "≤6",
               "notes": "in Internet Explorer 8 'online' and 'offline' events are raised on the <code>document.body</code>; under IE 9 they are raised on both <code>document.body</code> and <code>window</code>."
             },
             "opera": {
@@ -81,10 +81,10 @@
               "notes": "From Opera 11.1 until Opera 12.1, the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `NavigatorOnLine` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigatorOnLine
