### PR TITLE
Add missing requestMIDIAccess() for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2109,6 +2109,53 @@
           }
         }
       },
+      "requestMIDIAccess": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scheduling": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for `Navigator.requestMIDIAccess`.

Spec: https://webaudio.github.io/web-midi-api/
IDL: https://github.com/w3c/webref/blob/master/ed/idl/webmidi.idl
Test Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/requestMIDIAccess
