### PR TITLE
Add all versions for NavigatorStorage API

### DIFF
--- a/api/NavigatorStorage.json
+++ b/api/NavigatorStorage.json
@@ -5,59 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorStorage",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "55"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "55"
           },
           "edge": {
-            "version_added": null
+            "version_added": "79"
           },
-          "firefox": [
-            {
-              "version_added": "57"
-            },
-            {
-              "version_added": "51",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storageManager.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "57"
+          },
           "firefox_android": {
-            "version_added": "51",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.storageManager.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "57"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "42"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "42"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "55"
           }
         },
         "status": {
@@ -71,59 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorStorage/storage",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "55"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.storageManager.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "57"
+            },
             "firefox_android": {
-              "version_added": "51",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storageManager.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "55"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `NavigatorStorage` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigatorStorage
