### PR TITLE
Add missing Navigator APIs

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2365,6 +2365,112 @@
           }
         }
       },
+      "unregisterProtocolHandler": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "usb": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "≤87"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15> ≤73"
+            },
+            "opera_android": {
+              "version_added": "≤61"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤13.0"
+            },
+            "webview_android": {
+              "version_added": "≤87"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "vendor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/vendor",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2395,15 +2395,9 @@
                 "version_removed": "15"
               }
             ],
-            "opera_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2418,7 +2418,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2465,8 +2465,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2431,7 +2431,7 @@
               "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "≤87"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -2446,10 +2446,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15> ≤73"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "≤61"
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -2458,10 +2458,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "≤13.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "≤87"
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for `Navigator.usb`.

Spec: https://wicg.github.io/webusb/
IDL: https://github.com/w3c/webref/blob/master/ed/idl/webusb.idl
Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/usb
