### PR TITLE
Correct note text for cancelBubble prototype move

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -232,7 +232,7 @@
               },
               {
                 "version_added": "1",
-                "notes": "This property was defined on the <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a> interface."
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a>, not all <code>Event</code> objects."
               }
             ],
             "firefox_android": [
@@ -241,7 +241,7 @@
               },
               {
                 "version_added": "4",
-                "notes": "This property was defined on the <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a> interface."
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a>, not all <code>Event</code> objects."
               }
             ],
             "ie": {

--- a/api/Event.json
+++ b/api/Event.json
@@ -231,7 +231,9 @@
                 "version_added": "53"
               },
               {
+                "version_removed": "53",
                 "version_added": "1",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a>, not all <code>Event</code> objects."
               }
             ],
@@ -240,7 +242,9 @@
                 "version_added": "53"
               },
               {
+                "version_removed": "53",
                 "version_added": "4",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a>, not all <code>Event</code> objects."
               }
             ],


### PR DESCRIPTION
This is a follow up to #7360. It rewrites the notes to use the model text in #7517.