### PR TITLE
Add missing features for CSSStyleSheet API

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "CSSStyleSheet": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "≤87"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "addRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/addRule",
@@ -384,6 +431,100 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "replace": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "52"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "replaceSync": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "52"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       },

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -84,7 +84,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "≤87"
+              "version_added": "66"
             }
           },
           "status": {

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -49,6 +49,7 @@
       },
       "CSSStyleSheet": {
         "__compat": {
+          "description": "<code>CSSStyleSheet()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -67,7 +67,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "53"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `CSSStyleSheet` API.

Spec: https://wicg.github.io/construct-stylesheets/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/construct-stylesheets.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSStyleSheet
