### PR TITLE
Add missing features for DOMRectReadOnly API

### DIFF
--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -353,6 +353,53 @@
           }
         }
       },
+      "toJSON": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "top": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/top",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `DOMRectReadOnly` API.

Spec: https://drafts.fxtf.org/geometry/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/geometry.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRectReadOnly
