### PR TITLE
Correct data for DocumentOrShadowRoot mixin API

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -14,7 +14,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "firefox_android": {
             "version_added": "4"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot",
         "support": {
           "chrome": {
-            "version_added": "53"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "53"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
-            "version_added": "40"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "53"
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,28 +52,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/activeElement",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "63"
-            },
-            "ie": {
               "version_added": "4"
             },
+            "ie": {
+              "version_added": "≤6"
+            },
             "opera": {
-              "version_added": "40"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -82,10 +82,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "53"
+              "version_added": "1"
             }
           },
           "status": {
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -196,43 +196,45 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/elementFromPoint",
           "support": {
             "chrome": {
-              "version_added": "53",
+              "version_added": "1",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "chrome_android": {
-              "version_added": "53",
+              "version_added": "18",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "≤12.1",
+              "notes": "Before Opera 53, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "≤12.1",
+              "notes": "Before Opera Android 47, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": "1.0",
               "notes": "Before Samsung Internet 9.0, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "webview_android": {
-              "version_added": "53",
+              "version_added": "1",
               "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             }
           },
@@ -248,11 +250,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/elementsFromPoint",
           "support": {
             "chrome": {
-              "version_added": "53",
+              "version_added": "43",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "chrome_android": {
-              "version_added": "53",
+              "version_added": "43",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "edge": {
@@ -261,10 +263,10 @@
               "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "46"
             },
             "ie": {
               "version_added": "10",
@@ -272,23 +274,23 @@
               "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "30"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": "4.0",
               "notes": "Before Samsung Internet 9.0, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "webview_android": {
-              "version_added": "53",
+              "version_added": "43",
               "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             }
           },
@@ -424,40 +426,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/getSelection",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "53"
+              "version_added": "1"
             }
           },
           "status": {
@@ -472,28 +474,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/pointerLockElement",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "50"
             },
             "ie": {
               "version_added": true
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "24"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "24"
             },
             "safari": {
               "version_added": true
@@ -502,10 +504,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "53"
+              "version_added": "37"
             }
           },
           "status": {
@@ -520,40 +522,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/styleSheets",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
-              "version_added": "40"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "53"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
While working on adding missing features of the Document API, the script was attempting to add data for features in this mixin (the mdn-bcd-collector flattens mixins).  However, before undoing those changes, I noticed that the new data mismatched what was in here.  This PR fixes the data accordingly.  All data was confirmed via manual testing.
