### PR TITLE
Remove the api.CharacterData.ChildNode entry

### DIFF
--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -47,56 +47,6 @@
           "deprecated": false
         }
       },
-      "ChildNode": {
-        "__compat": {
-          "description": "Implements the <code>ChildNode</code> interface",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "≤18"
-            },
-            "firefox": {
-              "version_added": "25",
-              "notes": "Two properties, <code>nextElementSibling</code> and <code>previousElementSibling</code>, have been moved to the <a href='https://developer.mozilla.org/docs/Web/API/NonDocumentTypeChildNode'><code>NonDocumentTypeChildNode</code></a> interface, also implemented by <code>CharacterData</code>."
-            },
-            "firefox_android": {
-              "version_added": "25",
-              "notes": "Two properties, <code>nextElementSibling</code> and <code>previousElementSibling</code>, have been moved to the <a href='https://developer.mozilla.org/docs/Web/API/NonDocumentTypeChildNode'><code>NonDocumentTypeChildNode</code></a> interface, also implemented by <code>CharacterData</code>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "appendData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/appendData",


### PR DESCRIPTION
ChildNode is a mixin, not an interface as described, and mixins are
completely invisible to web developers; they're a spec author
convenience.

This is a bit of cleanup that makes sense regardless of the outcome of
https://github.com/mdn/browser-compat-data/issues/472 more broadly.