### PR TITLE
Update Chromium versions for ShadowRoot API

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot",
         "support": {
           "chrome": {
-            "version_added": "57"
+            "version_added": "53"
           },
           "chrome_android": {
-            "version_added": "57"
+            "version_added": "53"
           },
           "edge": {
             "version_added": "79"
@@ -64,7 +64,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "57"
+            "version_added": "53"
           }
         },
         "status": {
@@ -78,10 +78,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -96,10 +96,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "40"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -108,10 +108,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "53"
             }
           },
           "status": {
@@ -126,10 +126,10 @@
           "description": "Features included from the <code>DocumentOrShadowRoot</code> mixin",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -161,7 +161,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "53"
             }
           },
           "status": {
@@ -176,10 +176,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/host",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -235,7 +235,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "53"
             }
           },
           "status": {
@@ -250,10 +250,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/innerHTML",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -309,7 +309,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "53"
             }
           },
           "status": {
@@ -324,10 +324,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/mode",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "79"
@@ -383,7 +383,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "53"
             }
           },
           "status": {


### PR DESCRIPTION
This PR fixes real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ShadowRoot` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot
