### PR TITLE
Add spec_url data for html subdirectory

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -4,6 +4,10 @@
       "a": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/a",
+          "spec_url": [
+            "https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery-referrer-attribute",
+            "https://html.spec.whatwg.org/multipage/textlevel-semantics.html#the-a-element"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -603,6 +607,7 @@
           "noopener": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noopener",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-noopener",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -653,6 +658,7 @@
           "noreferrer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noreferrer",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-noreferrer",
               "support": {
                 "chrome": {
                   "version_added": "16"

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -4,6 +4,7 @@
       "abbr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/abbr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-abbr-element",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -4,6 +4,7 @@
       "address": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/address",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-address-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -4,6 +4,10 @@
       "area": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/area",
+          "spec_url": [
+            "https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery-referrer-attribute",
+            "https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -615,6 +619,7 @@
           "noopener": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noopener",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-noopener",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -665,6 +670,7 @@
           "noreferrer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noreferrer",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-noreferrer",
               "support": {
                 "chrome": {
                   "version_added": "16"

--- a/html/elements/article.json
+++ b/html/elements/article.json
@@ -4,6 +4,7 @@
       "article": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/article",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-article-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/aside.json
+++ b/html/elements/aside.json
@@ -4,6 +4,7 @@
       "aside": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/aside",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-aside-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -4,6 +4,7 @@
       "audio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/audio",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-audio-element",
           "support": {
             "chrome": {
               "version_added": "3"

--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -4,6 +4,7 @@
       "b": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/b",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-b-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -4,6 +4,7 @@
       "base": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/base",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-base-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -4,6 +4,7 @@
       "bdi": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdi",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-bdi-element",
           "support": {
             "chrome": {
               "version_added": "16"

--- a/html/elements/bdo.json
+++ b/html/elements/bdo.json
@@ -4,6 +4,7 @@
       "bdo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdo",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-bdo-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/blockquote.json
+++ b/html/elements/blockquote.json
@@ -4,6 +4,7 @@
       "blockquote": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/blockquote",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-blockquote-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -4,6 +4,7 @@
       "body": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/body",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-body-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -4,6 +4,7 @@
       "br": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/br",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-br-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -4,6 +4,7 @@
       "button": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/button",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -4,6 +4,7 @@
       "canvas": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/canvas",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/caption.json
+++ b/html/elements/caption.json
@@ -4,6 +4,7 @@
       "caption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/caption",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-caption-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/cite.json
+++ b/html/elements/cite.json
@@ -4,6 +4,7 @@
       "cite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/cite",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-cite-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/code.json
+++ b/html/elements/code.json
@@ -4,6 +4,7 @@
       "code": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/code",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-code-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -4,6 +4,7 @@
       "col": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/col",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-col-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -4,6 +4,7 @@
       "colgroup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/colgroup",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -4,6 +4,7 @@
       "data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/data",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-data-element",
           "support": {
             "chrome": {
               "version_added": "62"

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -4,6 +4,7 @@
       "datalist": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/datalist",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-datalist-element",
           "support": {
             "chrome": {
               "version_added": "20"

--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -4,6 +4,7 @@
       "dd": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dd",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-dd-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -4,6 +4,7 @@
       "del": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/del",
+          "spec_url": "https://html.spec.whatwg.org/multipage/edits.html#the-del-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -4,6 +4,7 @@
       "details": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/details",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element",
           "support": {
             "chrome": {
               "version_added": "12"

--- a/html/elements/dfn.json
+++ b/html/elements/dfn.json
@@ -4,6 +4,7 @@
       "dfn": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dfn",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-dfn-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -4,6 +4,7 @@
       "dialog": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dialog",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-dialog-element",
           "support": {
             "chrome": {
               "version_added": "37"

--- a/html/elements/div.json
+++ b/html/elements/div.json
@@ -4,6 +4,7 @@
       "div": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/div",
+          "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/dl.json
+++ b/html/elements/dl.json
@@ -4,6 +4,7 @@
       "dl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dl",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-dl-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/dt.json
+++ b/html/elements/dt.json
@@ -4,6 +4,7 @@
       "dt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dt",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-dt-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/em.json
+++ b/html/elements/em.json
@@ -4,6 +4,7 @@
       "em": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/em",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -4,6 +4,7 @@
       "embed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/embed",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -4,6 +4,7 @@
       "fieldset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/fieldset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-fieldset-element",
           "support": {
             "chrome": {
               "version_added": true,

--- a/html/elements/figcaption.json
+++ b/html/elements/figcaption.json
@@ -4,6 +4,7 @@
       "figcaption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/figcaption",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-figcaption-element",
           "support": {
             "chrome": {
               "version_added": "8"

--- a/html/elements/figure.json
+++ b/html/elements/figure.json
@@ -4,6 +4,7 @@
       "figure": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/figure",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-figure-element",
           "support": {
             "chrome": {
               "version_added": "8"

--- a/html/elements/footer.json
+++ b/html/elements/footer.json
@@ -4,6 +4,7 @@
       "footer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/footer",
+          "spec_url": "https://html.spec.whatwg.org/multipage/#the-footer-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -4,6 +4,7 @@
       "form": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-form-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -4,6 +4,7 @@
       "h1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h2.json
+++ b/html/elements/h2.json
@@ -4,6 +4,7 @@
       "h2": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h3.json
+++ b/html/elements/h3.json
@@ -4,6 +4,7 @@
       "h3": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h4.json
+++ b/html/elements/h4.json
@@ -4,6 +4,7 @@
       "h4": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h5.json
+++ b/html/elements/h5.json
@@ -4,6 +4,7 @@
       "h5": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/h6.json
+++ b/html/elements/h6.json
@@ -4,6 +4,7 @@
       "h6": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -4,6 +4,7 @@
       "head": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/head",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-head-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/header.json
+++ b/html/elements/header.json
@@ -4,6 +4,7 @@
       "header": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/header",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-header-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -4,6 +4,7 @@
       "hgroup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/hgroup",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-hgroup-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -4,6 +4,7 @@
       "hr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/hr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-hr-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -4,6 +4,7 @@
       "html": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/html",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-html-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/i.json
+++ b/html/elements/i.json
@@ -4,6 +4,7 @@
       "i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/i",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -4,6 +4,10 @@
       "iframe": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/iframe",
+          "spec_url": [
+            "https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery-referrer-attribute",
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -4,6 +4,10 @@
       "img": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/img",
+          "spec_url": [
+            "https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery-referrer-attribute",
+            "https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -563,6 +567,7 @@
         "loading": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/Performance/Lazy_loading",
+            "spec_url": "https://html.spec.whatwg.org/multipage/#lazy-loading-attributes",
             "support": {
               "chrome": {
                 "version_added": "77"

--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -5,6 +5,7 @@
         "input-button": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/button",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#button-state-(type=button)",
             "description": "<code>type=\"button\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -5,6 +5,7 @@
         "input-checkbox": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/checkbox",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox)",
             "description": "<code>type=\"checkbox\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -5,6 +5,7 @@
         "input-color": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/color",
+            "spec_url": "https://html.spec.whatwg.org/multipage/#color-state-(type=color)",
             "description": "<code>type=\"color\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -5,6 +5,7 @@
         "input-date": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/date",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#date-state-(type=date)",
             "description": "<code>type=\"date\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -5,6 +5,7 @@
         "input-datetime-local": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/datetime-local",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#local-date-and-time-state-(type=datetime-local)",
             "description": "<code>type=\"datetime-local\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -5,6 +5,7 @@
         "input-email": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/email",
+            "spec_url": "https://html.spec.whatwg.org/multipage/#email-state-(type=email)",
             "description": "<code>type=\"email\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -6,6 +6,10 @@
           "__compat": {
             "description": "<code>type=\"file\"</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/file",
+            "spec_url": [
+              "https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)",
+              "https://w3c.github.io/html-media-capture/#the-capture-attribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -5,6 +5,7 @@
         "input-hidden": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/hidden",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#hidden-state-(type=hidden)",
             "description": "<code>type=\"hidden\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -5,6 +5,7 @@
         "input-image": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/image",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#image-button-state-(type=image)",
             "description": "<code>type=\"image\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -4,6 +4,10 @@
       "input": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/forms.html#the-input-element",
+            "https://w3c.github.io/html-media-capture/#the-capture-attribute"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -5,6 +5,7 @@
         "input-month": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/month",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#month-state-(type=month)",
             "description": "<code>type=\"month\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -5,6 +5,7 @@
         "input-number": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/number",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#number-state-(type=number)",
             "description": "<code>type=\"number\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -5,6 +5,7 @@
         "input-password": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/password",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#password-state-(type=password)",
             "description": "<code>type=\"password\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -5,6 +5,7 @@
         "input-radio": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/radio",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-(type=radio)",
             "description": "<code>type=\"radio\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -5,6 +5,7 @@
         "input-range": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/range",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range)",
             "description": "<code>type=\"range\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -5,6 +5,7 @@
         "input-reset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/reset",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#reset-button-state-(type=reset)",
             "description": "<code>type=\"reset\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -5,6 +5,7 @@
         "input-search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/search",
+            "spec_url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)",
             "description": "<code>type=\"search\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -5,6 +5,7 @@
         "input-submit": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/submit",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#submit-button-state-(type=submit)",
             "description": "<code>type=\"submit\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -5,6 +5,7 @@
         "input-tel": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/tel",
+            "spec_url": "https://html.spec.whatwg.org/multipage/#telephone-state-(type=tel)",
             "description": "<code>type=\"tel\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -5,6 +5,7 @@
         "input-text": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/text",
+            "spec_url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)",
             "description": "<code>type=\"text\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -5,6 +5,7 @@
         "input-time": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/time",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#time-state-(type=time)",
             "description": "<code>type=\"time\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -5,6 +5,10 @@
         "input-url": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/url",
+            "spec_url": [
+              "https://html.spec.whatwg.org/multipage/forms.html#url-state-(type=url)",
+              "https://url.spec.whatwg.org/#urls"
+            ],
             "description": "<code>type=\"url\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -5,6 +5,7 @@
         "input-week": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/week",
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#week-state-(type=week)",
             "description": "<code>type=\"week\"</code>",
             "support": {
               "chrome": {

--- a/html/elements/ins.json
+++ b/html/elements/ins.json
@@ -4,6 +4,7 @@
       "ins": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/ins",
+          "spec_url": "https://html.spec.whatwg.org/multipage/edits.html#the-ins-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/kbd.json
+++ b/html/elements/kbd.json
@@ -4,6 +4,7 @@
       "kbd": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/kbd",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/label.json
+++ b/html/elements/label.json
@@ -4,6 +4,7 @@
       "label": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/label",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-label-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -4,6 +4,7 @@
       "legend": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/legend",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-legend-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -4,6 +4,7 @@
       "li": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/li",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-li-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -4,6 +4,7 @@
       "link": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/link",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-link-element",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -624,6 +625,13 @@
             "__compat": {
               "description": "Alternative stylesheets.",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
+              "spec_url": [
+                "https://html.spec.whatwg.org/multipage/#rel-alternate",
+                "https://html.spec.whatwg.org/multipage/#the-link-is-an-alternative-stylesheet",
+                "https://html.spec.whatwg.org/multipage/#attr-style-title",
+                "https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-default-style",
+                "https://drafts.csswg.org/cssom/#css-style-sheet-collections"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "1",
@@ -673,6 +681,7 @@
           "dns-prefetch": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/dns-prefetch",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-dns-prefetch",
               "support": {
                 "chrome": {
                   "version_added": "46"
@@ -774,6 +783,7 @@
           "manifest": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/manifest",
+              "spec_url": "https://w3c.github.io/manifest/#linking",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -822,6 +832,7 @@
           "modulepreload": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/modulepreload",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-modulepreload",
               "support": {
                 "chrome": {
                   "version_added": "66"
@@ -870,6 +881,7 @@
           "preconnect": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/preconnect",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-preconnect",
               "support": {
                 "chrome": {
                   "version_added": "46"
@@ -920,6 +932,7 @@
           "prefetch": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/prefetch",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-prefetch",
               "support": {
                 "chrome": {
                   "version_added": "8"
@@ -968,6 +981,7 @@
           "preload": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/preload",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-preload",
               "support": {
                 "chrome": {
                   "version_added": "50"
@@ -1020,6 +1034,7 @@
           "prerender": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/prerender",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#link-type-prerender",
               "support": {
                 "chrome": {
                   "version_added": "13"

--- a/html/elements/main.json
+++ b/html/elements/main.json
@@ -4,6 +4,7 @@
       "main": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/main",
+          "spec_url": "https://html.spec.whatwg.org/multipage/#the-main-element",
           "support": {
             "chrome": {
               "version_added": "26"

--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -4,6 +4,7 @@
       "map": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/map",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-map-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/mark.json
+++ b/html/elements/mark.json
@@ -4,6 +4,7 @@
       "mark": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/mark",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -4,6 +4,7 @@
       "marquee": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/marquee",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#the-marquee-element-2",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -4,6 +4,7 @@
       "menu": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/menu",
+          "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -4,6 +4,7 @@
       "meta": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/meta",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element",
           "support": {
             "chrome": {
               "version_added": true
@@ -434,6 +435,11 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/meta/name",
+            "spec_url": [
+              "https://html.spec.whatwg.org/multipage/#standard-metadata-names",
+              "https://drafts.csswg.org/css-device-adapt/#viewport-meta",
+              "https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery-meta"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -629,6 +635,7 @@
           "theme-color": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/meta/name/theme-color",
+              "spec_url": "https://html.spec.whatwg.org/multipage/#meta-theme-color",
               "support": {
                 "chrome": [
                   {

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -4,6 +4,7 @@
       "meter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/meter",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-meter-element",
           "support": {
             "chrome": {
               "version_added": "6"

--- a/html/elements/nav.json
+++ b/html/elements/nav.json
@@ -4,6 +4,7 @@
       "nav": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/nav",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-nav-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/noscript.json
+++ b/html/elements/noscript.json
@@ -4,6 +4,7 @@
       "noscript": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/noscript",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -4,6 +4,7 @@
       "object": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/object",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -4,6 +4,7 @@
       "ol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/ol",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-ol-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -4,6 +4,7 @@
       "optgroup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/optgroup",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-optgroup-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -4,6 +4,7 @@
       "option": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/option",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -4,6 +4,7 @@
       "output": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/output",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-output-element",
           "support": {
             "chrome": {
               "version_added": "10"

--- a/html/elements/p.json
+++ b/html/elements/p.json
@@ -4,6 +4,7 @@
       "p": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/p",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-p-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/param.json
+++ b/html/elements/param.json
@@ -4,6 +4,7 @@
       "param": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/param",
+          "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-param-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/picture.json
+++ b/html/elements/picture.json
@@ -4,6 +4,7 @@
       "picture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/picture",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element",
           "support": {
             "chrome": {
               "version_added": "38"

--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -4,6 +4,7 @@
       "pre": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/pre",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-pre-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -4,6 +4,7 @@
       "progress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/progress",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-progress-element",
           "support": {
             "chrome": {
               "version_added": "6"

--- a/html/elements/q.json
+++ b/html/elements/q.json
@@ -4,6 +4,7 @@
       "q": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/q",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-q-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/rp.json
+++ b/html/elements/rp.json
@@ -4,6 +4,7 @@
       "rp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/rp",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/rt.json
+++ b/html/elements/rt.json
@@ -4,6 +4,7 @@
       "rt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/rt",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/ruby.json
+++ b/html/elements/ruby.json
@@ -4,6 +4,7 @@
       "ruby": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/ruby",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-ruby-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/s.json
+++ b/html/elements/s.json
@@ -4,6 +4,7 @@
       "s": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/s",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-s-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/samp.json
+++ b/html/elements/samp.json
@@ -4,6 +4,7 @@
       "samp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/samp",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-samp-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -4,6 +4,7 @@
       "script": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/script",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#the-script-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/section.json
+++ b/html/elements/section.json
@@ -4,6 +4,7 @@
       "section": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/section",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-section-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -4,6 +4,7 @@
       "select": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/select",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-select-element",
           "support": {
             "chrome": {
               "version_added": true,

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -4,6 +4,10 @@
       "slot": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/slot",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element",
+            "https://dom.spec.whatwg.org/#shadow-tree-slots"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"

--- a/html/elements/small.json
+++ b/html/elements/small.json
@@ -4,6 +4,7 @@
       "small": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/small",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-small-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -4,6 +4,7 @@
       "source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/source",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/span.json
+++ b/html/elements/span.json
@@ -4,6 +4,7 @@
       "span": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/span",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/strong.json
+++ b/html/elements/strong.json
@@ -4,6 +4,7 @@
       "strong": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/strong",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-strong-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -4,6 +4,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/style",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-style-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/sub.json
+++ b/html/elements/sub.json
@@ -4,6 +4,7 @@
       "sub": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/sub",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -4,6 +4,7 @@
       "summary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/summary",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element",
           "support": {
             "chrome": {
               "version_added": "12"

--- a/html/elements/sup.json
+++ b/html/elements/sup.json
@@ -4,6 +4,7 @@
       "sup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/sup",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -4,6 +4,7 @@
       "table": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/table",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-table-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -4,6 +4,7 @@
       "tbody": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/tbody",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-tbody-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -4,6 +4,7 @@
       "td": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/td",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-td-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -4,6 +4,7 @@
       "template": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/template",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#the-template-element",
           "support": {
             "chrome": {
               "version_added": "26"

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -4,6 +4,7 @@
       "textarea": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/textarea",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -4,6 +4,7 @@
       "tfoot": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/tfoot",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-tfoot-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -4,6 +4,7 @@
       "th": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/th",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-th-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -4,6 +4,7 @@
       "thead": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/thead",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-thead-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/time.json
+++ b/html/elements/time.json
@@ -4,6 +4,7 @@
       "time": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/time",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element",
           "support": {
             "chrome": {
               "version_added": "62"

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -4,6 +4,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/title",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-title-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -4,6 +4,7 @@
       "tr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/tr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-tr-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -4,6 +4,7 @@
       "track": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/track",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-track-element",
           "support": {
             "chrome": {
               "version_added": "23"

--- a/html/elements/u.json
+++ b/html/elements/u.json
@@ -4,6 +4,7 @@
       "u": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/u",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/ul.json
+++ b/html/elements/ul.json
@@ -4,6 +4,7 @@
       "ul": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/ul",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-ul-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/var.json
+++ b/html/elements/var.json
@@ -4,6 +4,7 @@
       "var": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/var",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -4,6 +4,7 @@
       "video": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/video",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#the-video-element",
           "support": {
             "chrome": {
               "version_added": "3"

--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -4,6 +4,7 @@
       "wbr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/wbr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-wbr-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -4,6 +4,7 @@
       "accesskey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/accesskey",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -52,6 +53,7 @@
       "autocapitalize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -114,6 +116,7 @@
       "autocomplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/autocomplete",
+          "spec_url": "https://html.spec.whatwg.org/multipage/#autofill",
           "support": {
             "chrome": [
               {
@@ -262,6 +265,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class",
+          "spec_url": "https://html.spec.whatwg.org/multipage/elements.html#classes",
           "support": {
             "chrome": {
               "version_added": true
@@ -310,6 +314,7 @@
       "contenteditable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contenteditable",
+          "spec_url": "https://html.spec.whatwg.org/multipage/editing.html#attr-contenteditable",
           "support": {
             "chrome": {
               "version_added": true
@@ -601,6 +606,7 @@
         "__compat": {
           "description": "<code>data-*</code> attributes",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/data-*",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes",
           "support": {
             "chrome": {
               "version_added": true
@@ -649,6 +655,7 @@
       "dir": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/dir",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -697,6 +704,7 @@
       "draggable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/draggable",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-draggable-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -865,7 +873,6 @@
       },
       "exportparts": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/exportparts",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -911,6 +918,10 @@
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/hidden",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute",
+            "https://html.spec.whatwg.org/multipage/rendering.html#hiddenCSS"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -959,6 +970,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/id",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1023,6 +1035,7 @@
       "inputmode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1100,6 +1113,7 @@
       "is": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -1206,6 +1220,7 @@
       "itemid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemid",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid",
           "support": {
             "chrome": {
               "version_added": true
@@ -1254,6 +1269,7 @@
       "itemprop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemprop",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1302,6 +1318,7 @@
       "itemref": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemref",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemref",
           "support": {
             "chrome": {
               "version_added": true
@@ -1350,6 +1367,7 @@
       "itemscope": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemscope",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemscope",
           "support": {
             "chrome": {
               "version_added": true
@@ -1398,6 +1416,7 @@
       "itemtype": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemtype",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemtype",
           "support": {
             "chrome": {
               "version_added": true
@@ -1446,6 +1465,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes",
           "support": {
             "chrome": {
               "version_added": true
@@ -1494,6 +1514,7 @@
       "part": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/part",
+          "spec_url": "https://drafts.csswg.org/css-shadow-parts-1/#part-attr",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -1552,6 +1573,10 @@
       "slot": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/slot",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/dom.html#attr-slot",
+            "https://dom.spec.whatwg.org/#dom-element-slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"
@@ -1658,6 +1683,7 @@
       "spellcheck": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/spellcheck",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#spelling-and-grammar-checking",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1706,6 +1732,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/style",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1754,6 +1781,7 @@
       "tabindex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/tabindex",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex",
           "support": {
             "chrome": {
               "version_added": true
@@ -1802,6 +1830,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/title",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1898,6 +1927,7 @@
       "translate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/translate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-translate",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -4,6 +4,7 @@
       "background_color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/background_color",
+          "spec_url": "https://w3c.github.io/manifest/#background_color-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -4,6 +4,7 @@
       "categories": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/categories",
+          "spec_url": "https://w3c.github.io/manifest/#categories-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -4,6 +4,7 @@
       "description": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/description",
+          "spec_url": "https://w3c.github.io/manifest/#description-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -4,6 +4,7 @@
       "dir": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/dir",
+          "spec_url": "https://w3c.github.io/manifest/#dir-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -4,6 +4,7 @@
       "display": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display",
+          "spec_url": "https://w3c.github.io/manifest/#display-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -4,6 +4,7 @@
       "iarc_rating_id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/iarc_rating_id",
+          "spec_url": "https://w3c.github.io/manifest/#iarc_rating_id-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -4,6 +4,7 @@
       "icons": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/icons",
+          "spec_url": "https://w3c.github.io/manifest/#icons-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/lang.json
+++ b/html/manifest/lang.json
@@ -4,6 +4,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/lang",
+          "spec_url": "https://w3c.github.io/manifest/#lang-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -4,6 +4,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/name",
+          "spec_url": "https://w3c.github.io/manifest/#name-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -4,6 +4,7 @@
       "orientation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/orientation",
+          "spec_url": "https://w3c.github.io/manifest/#orientation-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -4,6 +4,7 @@
       "prefer_related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/prefer_related_applications",
+          "spec_url": "https://w3c.github.io/manifest/#prefer_related_applications-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -4,6 +4,7 @@
       "related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/related_applications",
+          "spec_url": "https://w3c.github.io/manifest/#related_applications-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -4,6 +4,7 @@
       "scope": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/scope",
+          "spec_url": "https://w3c.github.io/manifest/#scope-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -4,6 +4,7 @@
       "screenshots": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/screenshots",
+          "spec_url": "https://w3c.github.io/manifest/#screenshots-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -4,6 +4,7 @@
       "short_name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/short_name",
+          "spec_url": "https://w3c.github.io/manifest/#short_name-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -4,6 +4,7 @@
       "start_url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/start_url",
+          "spec_url": "https://w3c.github.io/manifest/#start_url-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -4,6 +4,7 @@
       "theme_color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/theme_color",
+          "spec_url": "https://w3c.github.io/manifest/#theme_color-member",
           "support": {
             "chrome": {
               "version_added": null


### PR DESCRIPTION
This change adds spec URLs in the sources for all features in the html subdirectory that have an `mdn_url` for an MDN article with a Specification(s) table — with the exception that no spec data is added for any cases where a URL found in an MDN Specification(s) table has no fragment-ID part.