### PR TITLE
Add spec_url data in html/global_attributes.json

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -606,7 +606,7 @@
         "__compat": {
           "description": "<code>data-*</code> attributes",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/data-*",
-          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-data-*",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -53,7 +53,7 @@
       "autocapitalize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-autocapitalize",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -116,7 +116,7 @@
       "autocomplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/autocomplete",
-          "spec_url": "https://html.spec.whatwg.org/multipage/#autofill",
+          "spec_url": "https://html.spec.whatwg.org/multipage/#attr-fe-autocomplete",
           "support": {
             "chrome": [
               {
@@ -1033,7 +1033,7 @@
       "inputmode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1463,7 +1463,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang",
-          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-lang",
           "support": {
             "chrome": {
               "version_added": true
@@ -1681,7 +1681,7 @@
       "spellcheck": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/spellcheck",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#spelling-and-grammar-checking",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-spellcheck",
           "support": {
             "chrome": {
               "version_added": "9"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -919,10 +919,7 @@
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/hidden",
-          "spec_url": [
-            "https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute",
-            "https://html.spec.whatwg.org/multipage/rendering.html#hiddenCSS"
-          ],
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -4,6 +4,7 @@
       "accesskey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/accesskey",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -52,6 +53,7 @@
       "autocapitalize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -114,6 +116,7 @@
       "autocomplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/autocomplete",
+          "spec_url": "https://html.spec.whatwg.org/multipage/#autofill",
           "support": {
             "chrome": [
               {
@@ -262,6 +265,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class",
+          "spec_url": "https://html.spec.whatwg.org/multipage/elements.html#classes",
           "support": {
             "chrome": {
               "version_added": true
@@ -310,6 +314,7 @@
       "contenteditable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contenteditable",
+          "spec_url": "https://html.spec.whatwg.org/multipage/editing.html#attr-contenteditable",
           "support": {
             "chrome": {
               "version_added": true
@@ -601,6 +606,7 @@
         "__compat": {
           "description": "<code>data-*</code> attributes",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/data-*",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes",
           "support": {
             "chrome": {
               "version_added": true
@@ -649,6 +655,7 @@
       "dir": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/dir",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -697,6 +704,7 @@
       "draggable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/draggable",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-draggable-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -911,6 +919,10 @@
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/hidden",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute",
+            "https://html.spec.whatwg.org/multipage/rendering.html#hiddenCSS"
+          ],
           "support": {
             "chrome": {
               "version_added": true
@@ -959,6 +971,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/id",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1023,6 +1036,7 @@
       "inputmode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1100,6 +1114,7 @@
       "is": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -1206,6 +1221,7 @@
       "itemid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemid",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid",
           "support": {
             "chrome": {
               "version_added": true
@@ -1254,6 +1270,7 @@
       "itemprop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemprop",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1302,6 +1319,7 @@
       "itemref": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemref",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemref",
           "support": {
             "chrome": {
               "version_added": true
@@ -1350,6 +1368,7 @@
       "itemscope": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemscope",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemscope",
           "support": {
             "chrome": {
               "version_added": true
@@ -1398,6 +1417,7 @@
       "itemtype": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/itemtype",
+          "spec_url": "https://html.spec.whatwg.org/multipage/microdata.html#attr-itemtype",
           "support": {
             "chrome": {
               "version_added": true
@@ -1446,6 +1466,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes",
           "support": {
             "chrome": {
               "version_added": true
@@ -1494,6 +1515,7 @@
       "part": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/part",
+          "spec_url": "https://drafts.csswg.org/css-shadow-parts-1/#part-attr",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -1552,6 +1574,10 @@
       "slot": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/slot",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/dom.html#attr-slot",
+            "https://dom.spec.whatwg.org/#dom-element-slot"
+          ],
           "support": {
             "chrome": {
               "version_added": "53"
@@ -1658,6 +1684,7 @@
       "spellcheck": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/spellcheck",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#spelling-and-grammar-checking",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1706,6 +1733,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/style",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1754,6 +1782,7 @@
       "tabindex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/tabindex",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex",
           "support": {
             "chrome": {
               "version_added": true
@@ -1802,6 +1831,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/title",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute",
           "support": {
             "chrome": {
               "version_added": true
@@ -1898,6 +1928,7 @@
       "translate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/translate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-translate",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
This change adds spec URLs in `html/global_attributes.json` for all global attributes that have an `mdn_url` for an MDN article with a Specification(s) table — with the exception that no spec data is added for any cases where a URL found in an MDN Specification(s) table has no fragment-ID part. Relates to https://github.com/mdn/browser-compat-data/issues/6765.