### PR TITLE
Mark the DPR HTTP header non-standard & deprecated

### DIFF
--- a/http/headers/dpr.json
+++ b/http/headers/dpr.json
@@ -44,8 +44,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The DPR header is no longer part of any specification. It was specified in the “HTTP Client Hints” Internet Draft up to version 06: https://tools.ietf.org/html/draft-ietf-httpbis-client-hints-06#section-6.4, but https://tools.ietf.org/html/draft-ietf-httpbis-client-hints-07 and later versions of that dropped the DPR header completely. https://github.com/mdn/content/pull/415 is the related MDN change.