### PR TITLE
Add spec_url data in html/manifest/*.json sources

### DIFF
--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -4,6 +4,7 @@
       "background_color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/background_color",
+          "spec_url": "https://w3c.github.io/manifest/#background_color-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -4,6 +4,7 @@
       "categories": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/categories",
+          "spec_url": "https://w3c.github.io/manifest/#categories-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -4,6 +4,7 @@
       "description": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/description",
+          "spec_url": "https://w3c.github.io/manifest/#description-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -4,6 +4,7 @@
       "dir": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/dir",
+          "spec_url": "https://w3c.github.io/manifest/#dir-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -4,6 +4,7 @@
       "display": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display",
+          "spec_url": "https://w3c.github.io/manifest/#display-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -4,6 +4,7 @@
       "iarc_rating_id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/iarc_rating_id",
+          "spec_url": "https://w3c.github.io/manifest/#iarc_rating_id-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -4,6 +4,7 @@
       "icons": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/icons",
+          "spec_url": "https://w3c.github.io/manifest/#icons-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/lang.json
+++ b/html/manifest/lang.json
@@ -4,6 +4,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/lang",
+          "spec_url": "https://w3c.github.io/manifest/#lang-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -4,6 +4,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/name",
+          "spec_url": "https://w3c.github.io/manifest/#name-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -4,6 +4,7 @@
       "orientation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/orientation",
+          "spec_url": "https://w3c.github.io/manifest/#orientation-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -4,6 +4,7 @@
       "prefer_related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/prefer_related_applications",
+          "spec_url": "https://w3c.github.io/manifest/#prefer_related_applications-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -4,6 +4,7 @@
       "related_applications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/related_applications",
+          "spec_url": "https://w3c.github.io/manifest/#related_applications-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -4,6 +4,7 @@
       "scope": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/scope",
+          "spec_url": "https://w3c.github.io/manifest/#scope-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -4,6 +4,7 @@
       "screenshots": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/screenshots",
+          "spec_url": "https://w3c.github.io/manifest/#screenshots-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -4,6 +4,7 @@
       "short_name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/short_name",
+          "spec_url": "https://w3c.github.io/manifest/#short_name-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -4,6 +4,7 @@
       "start_url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/start_url",
+          "spec_url": "https://w3c.github.io/manifest/#start_url-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -4,6 +4,7 @@
       "theme_color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/theme_color",
+          "spec_url": "https://w3c.github.io/manifest/#theme_color-member",
           "support": {
             "chrome": {
               "version_added": null


### PR DESCRIPTION
This change adds spec URLs in the `html/manifest/*.json` sources for all features with an `mdn_url` for an article with a Specification(s) table. Relates to https://github.com/mdn/browser-compat-data/issues/6765