### PR TITLE
Add missing OTPCredential API

### DIFF
--- a/api/OTPCredential.json
+++ b/api/OTPCredential.json
@@ -7,7 +7,7 @@
             "version_added": false
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "84"
           },
           "edge": {
             "version_added": false
@@ -25,7 +25,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -53,7 +53,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "84"
             },
             "edge": {
               "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/OTPCredential.json
+++ b/api/OTPCredential.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "OTPCredential": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "code": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `OTPCredential` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).

Spec: https://wicg.github.io/web-otp/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/web-otp.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OTPCredential
