### PR TITLE
Add Firefox versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -189,10 +189,10 @@
               }
             ],
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "51"
             },
             "ie": {
               "version_added": null
@@ -453,10 +453,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -549,10 +549,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -597,10 +597,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -741,10 +741,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "ie": {
               "version_added": null
@@ -789,10 +789,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -899,10 +899,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1524,10 +1524,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -1716,10 +1716,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1764,10 +1764,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1812,10 +1812,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1860,10 +1860,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2204,10 +2204,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -2348,10 +2348,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -2396,10 +2396,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -2444,10 +2444,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -2492,10 +2492,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -3052,10 +3052,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": null
@@ -3100,10 +3100,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": null
@@ -3564,10 +3564,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -3612,10 +3612,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
               "version_added": true
@@ -3660,10 +3660,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -3804,10 +3804,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4140,10 +4140,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -4815,10 +4815,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "17"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
