### PR TITLE
Add IE/Edge versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -181,7 +181,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -195,7 +195,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -259,7 +259,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -273,7 +273,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -337,7 +337,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -351,7 +351,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -459,7 +459,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -498,7 +498,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -507,7 +507,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -546,7 +546,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -555,7 +555,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -594,7 +594,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -603,7 +603,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -699,7 +699,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "9"
@@ -738,7 +738,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -747,7 +747,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -786,7 +786,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -795,7 +795,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -834,7 +834,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": [
               {
@@ -857,7 +857,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -896,7 +896,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -905,7 +905,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -1329,7 +1329,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1338,7 +1338,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -1377,7 +1377,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1386,7 +1386,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -1425,7 +1425,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1434,7 +1434,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -1530,7 +1530,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1617,7 +1617,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -1626,7 +1626,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"
@@ -1713,7 +1713,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": true
@@ -1722,7 +1722,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -1761,7 +1761,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1770,7 +1770,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -1809,7 +1809,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1818,7 +1818,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -1857,7 +1857,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1866,7 +1866,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -1953,7 +1953,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1962,7 +1962,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -2001,7 +2001,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2010,7 +2010,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -2108,7 +2108,7 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,
@@ -2153,7 +2153,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -2162,7 +2162,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"
@@ -2210,7 +2210,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -2354,7 +2354,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -2402,7 +2402,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -2450,7 +2450,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -2498,7 +2498,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -2585,7 +2585,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2594,7 +2594,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -2633,7 +2633,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2642,7 +2642,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -2681,7 +2681,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2690,7 +2690,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3049,7 +3049,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "13"
             },
             "firefox": {
               "version_added": null
@@ -3058,7 +3058,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -3097,7 +3097,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "13"
             },
             "firefox": {
               "version_added": null
@@ -3106,7 +3106,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -3465,7 +3465,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3474,7 +3474,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3513,7 +3513,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3522,7 +3522,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3561,7 +3561,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -3570,7 +3570,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -3657,7 +3657,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -3666,7 +3666,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3705,7 +3705,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3714,7 +3714,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3753,7 +3753,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3762,7 +3762,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3801,7 +3801,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -3810,7 +3810,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3882,7 +3882,7 @@
               }
             ],
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": "15"
@@ -3954,7 +3954,7 @@
               }
             ],
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": null
@@ -4089,7 +4089,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -4098,7 +4098,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -4146,7 +4146,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -4185,7 +4185,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.6"
@@ -4194,7 +4194,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -4233,7 +4233,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -4242,7 +4242,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -4486,7 +4486,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4551,7 +4551,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4601,7 +4601,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4663,7 +4663,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4716,7 +4716,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -4725,7 +4725,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -4764,7 +4764,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -4773,7 +4773,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
