### PR TITLE
Add Safari versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -468,10 +468,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -516,10 +516,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -564,10 +564,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -612,10 +612,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -804,10 +804,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -866,10 +866,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -914,10 +914,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1347,10 +1347,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1395,10 +1395,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1443,10 +1443,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1539,10 +1539,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1635,10 +1635,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -1683,10 +1683,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1731,10 +1731,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1779,10 +1779,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1827,10 +1827,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1875,10 +1875,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1971,10 +1971,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2019,10 +2019,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2119,11 +2119,11 @@
               "notes": "The <code>loadstart</code> event is not fired on <code>&lt;img&gt;</code> elements."
             },
             "safari": {
-              "version_added": true,
+              "version_added": "9",
               "notes": "The <code>loadstart</code> event is not fired on <code>&lt;img&gt;</code> elements."
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "9",
               "notes": "The <code>loadstart</code> event is not fired on <code>&lt;img&gt;</code> elements."
             },
             "samsunginternet_android": {
@@ -2171,10 +2171,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -2219,10 +2219,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2267,10 +2267,10 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2315,10 +2315,10 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2363,10 +2363,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2411,10 +2411,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2459,10 +2459,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2507,10 +2507,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2603,10 +2603,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2651,10 +2651,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2699,10 +2699,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3067,10 +3067,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3115,10 +3115,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -3483,10 +3483,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3531,10 +3531,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3579,10 +3579,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3627,10 +3627,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -3675,10 +3675,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3723,10 +3723,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3771,10 +3771,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3819,10 +3819,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3966,7 +3966,7 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4107,10 +4107,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4155,10 +4155,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4203,10 +4203,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4300,10 +4300,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4349,10 +4349,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4398,10 +4398,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4447,10 +4447,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4560,10 +4560,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -4734,10 +4734,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4782,10 +4782,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4830,10 +4830,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
