### PR TITLE
Update Safari versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -282,10 +282,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {
@@ -360,10 +360,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -204,10 +204,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {
@@ -282,10 +282,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {
@@ -360,10 +360,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {
@@ -965,7 +965,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1013,7 +1013,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1061,7 +1061,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1158,7 +1158,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1206,7 +1206,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1254,7 +1254,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1302,7 +1302,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -2779,10 +2779,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2859,10 +2859,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2939,10 +2939,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3019,10 +3019,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3195,10 +3195,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3275,10 +3275,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3355,10 +3355,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3435,10 +3435,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -3891,10 +3891,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
