### PR TITLE
Update Chromium versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -938,10 +938,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondrag",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -968,10 +968,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -986,10 +986,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondragend",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1016,10 +1016,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1034,10 +1034,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondragenter",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1064,10 +1064,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1131,10 +1131,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondragleave",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1161,10 +1161,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1179,10 +1179,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondragover",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1209,10 +1209,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1227,10 +1227,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondragstart",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1257,10 +1257,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1275,10 +1275,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ondrop",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1305,10 +1305,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -1353,10 +1353,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3603,10 +3603,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onresize",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "34"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "34"
             },
             "edge": {
               "version_added": "12"
@@ -3621,10 +3621,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "21"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "21"
             },
             "safari": {
               "version_added": true
@@ -3633,10 +3633,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "37"
             }
           },
           "status": {
@@ -3843,7 +3843,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onselectionchange",
           "support": {
             "chrome": {
-              "version_added": "12"
+              "version_added": "11"
             },
             "chrome_android": {
               "version_added": "18"
@@ -4275,10 +4275,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontouchcancel",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -4294,10 +4294,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": null
@@ -4306,10 +4306,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4324,10 +4324,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontouchend",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -4343,10 +4343,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": null
@@ -4355,10 +4355,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4373,10 +4373,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontouchmove",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -4392,10 +4392,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": null
@@ -4404,10 +4404,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4422,10 +4422,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontouchstart",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -4441,10 +4441,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": null
@@ -4453,10 +4453,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4471,13 +4471,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontransitioncancel",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": "53"
@@ -4489,10 +4489,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -4518,7 +4518,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {
@@ -4540,10 +4540,15 @@
               "version_added": true,
               "alternative_name": "onwebkittransitionend"
             },
-            "edge": {
-              "version_added": "≤79",
-              "alternative_name": "onwebkittransitionend"
-            },
+            "edge": [
+              {
+                "version_added": "18"
+              },
+              {
+                "version_added": "≤79",
+                "alternative_name": "onwebkittransitionend"
+              }
+            ],
             "firefox": {
               "version_added": "51"
             },
@@ -4586,13 +4591,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontransitionrun",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": "53"
@@ -4604,10 +4609,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -4633,7 +4638,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {
@@ -4648,13 +4653,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontransitionstart",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": "53"
@@ -4666,10 +4671,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -4695,7 +4700,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {
@@ -4806,10 +4811,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onwheel",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -4824,10 +4829,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -4836,10 +4841,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
