### PR TITLE
Update Opera versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -959,7 +959,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1007,7 +1007,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1055,7 +1055,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1152,7 +1152,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1200,7 +1200,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1248,7 +1248,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"
@@ -1296,7 +1296,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
