### PR TITLE
Update IE/Edge versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -953,7 +953,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1001,7 +1001,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1049,7 +1049,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1146,7 +1146,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1194,7 +1194,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1242,7 +1242,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -1290,7 +1290,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3609,7 +3609,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -3618,7 +3618,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "32"
@@ -4281,7 +4281,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -4291,7 +4291,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4330,7 +4330,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -4340,7 +4340,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4379,7 +4379,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -4389,7 +4389,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4428,7 +4428,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": true,
@@ -4438,7 +4438,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4821,7 +4821,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "48"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3608,9 +3608,17 @@
             "chrome_android": {
               "version_added": "45"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "In EdgeHTML versions of Edge, this handler was only supported on the <a href='https://developer.mozilla.org/docs/Web/API/Window'><code>Window</code></a> API."
+              }
+            ],
             "firefox": {
               "version_added": true
             },
@@ -3618,7 +3626,9 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "≤6",
+              "partial_implementation": true,
+              "notes": "In Internet Explorer, this handler was only supported on the <a href='https://developer.mozilla.org/docs/Web/API/Window'><code>Window</code></a> API."
             },
             "opera": {
               "version_added": "32"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer and Edge for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
