### PR TITLE
Update Firefox versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -947,10 +947,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -995,10 +995,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1043,10 +1043,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1140,10 +1140,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1188,10 +1188,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1236,10 +1236,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1284,10 +1284,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "9"
             },
             "ie": {
               "version_added": "10"
@@ -1332,10 +1332,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1380,10 +1380,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1428,10 +1428,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -1575,7 +1575,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -1623,7 +1623,7 @@
               "version_added": "59"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "59"
             },
             "ie": {
               "version_added": null
@@ -1668,10 +1668,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": "9"
@@ -1956,10 +1956,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2004,10 +2004,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2102,10 +2102,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "52"
+              "version_added": "9"
             },
             "ie": {
               "version_added": true
@@ -2159,7 +2159,7 @@
               "version_added": "59"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "59"
             },
             "ie": {
               "version_added": null
@@ -2588,10 +2588,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2636,10 +2636,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2684,10 +2684,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -2753,16 +2753,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -2833,16 +2838,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -2913,16 +2923,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -2993,16 +3008,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -3169,16 +3189,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -3249,16 +3274,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -3329,16 +3359,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -3409,16 +3444,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "29",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.w3c_pointer_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"
@@ -3468,10 +3508,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -3516,10 +3556,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -3708,10 +3748,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -3756,10 +3796,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4092,10 +4132,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4188,10 +4228,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4236,10 +4276,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4284,11 +4324,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": "67"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4333,11 +4372,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": "67"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4382,11 +4420,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": "67"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4431,11 +4468,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true,
-              "version_removed": "67"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": null
@@ -4719,10 +4755,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null
@@ -4767,10 +4803,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GlobalEventHandlers
