### PR TITLE
Add missing features for FileReaderSync API

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -49,6 +49,56 @@
           "deprecated": false
         }
       },
+      "FileReaderSync": {
+        "__compat": {
+          "description": "<code>FileReaderSync()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "6",
+              "version_removed": "6.1"
+            },
+            "safari_ios": {
+              "version_added": "6",
+              "version_removed": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "readAsArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReaderSync/readAsArrayBuffer",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `FileReaderSync` API.

Spec: https://w3c.github.io/FileAPI/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/FileAPI.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileReaderSync
