### PR TITLE
Remove irrelevant global attribute 'dropzone'

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -815,61 +815,6 @@
           }
         }
       },
-      "dropzone": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/dropzone",
-          "support": {
-            "chrome": {
-              "version_added": "14",
-              "version_removed": "59"
-            },
-            "chrome_android": {
-              "version_added": "18",
-              "version_removed": "59"
-            },
-            "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1",
-              "version_removed": "15"
-            },
-            "opera_android": {
-              "version_added": "≤12.1",
-              "version_removed": "14"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": "7.0"
-            },
-            "webview_android": {
-              "version_added": "4.4",
-              "version_removed": "59"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "enterKeyHint": {
         "__compat": {
           "support": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -750,66 +750,6 @@
           }
         }
       },
-      "dropzone": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/dropzone",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "58"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "58"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "45"
-            },
-            "opera_android": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "43"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "7.0"
-            },
-            "webview_android": {
-              "version_added": true,
-              "prefix": "-webkit-",
-              "version_removed": "58"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "enterkeyhint": {
         "__compat": {
           "support": {


### PR DESCRIPTION
Not in any standard and not implemented anywhere anymore for a long time.

I'll open an mdn/content PR that deletes the sparingly existing content, too.