### PR TITLE
Update translate global attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1928,10 +1928,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-translate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -1946,26 +1946,26 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Version data from reflection, see 
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement#Browser_compatibility
https://github.com/mdn/browser-compat-data/blob/master/api/HTMLElement.json#L3588

Also, shouldn't be marked experimental, imo. (I couldn't find any reason why Firefox isn't shipping this.)