### PR TITLE
updated support for scroll-margin/padding-* properties on safari TP

### DIFF
--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -29,12 +29,18 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-bottom",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-bottom",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-bottom",

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -29,12 +29,18 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-left",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-left",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-left",

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -29,12 +29,18 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-right",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-right",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-right",

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -29,12 +29,18 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-top",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-top",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-top",

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -29,12 +29,18 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -29,11 +29,17 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -29,11 +29,17 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -29,11 +29,17 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -29,11 +29,17 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -29,11 +29,17 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": false
+              }
+            ],
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,


### PR DESCRIPTION
these properties are supported in Safari Technology Preview.

note that safari still does not support `scroll-margin/padding-block/inline-*` props
https://webkit.org/blog/11364/release-notes-for-safari-technology-preview-117/

I tested it with Safari TP using this pen, works as expected with both `scroll-padding-top` and `scroll-margin-top`: https://codepen.io/fabb64/pen/YzXYQPW

Related:
* https://github.com/mdn/browser-compat-data/issues/4945#issuecomment-748449872
* https://github.com/mdn/browser-compat-data/pull/5803

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

Note that linting fails because Safari 15 is not yet released and therefore not yet contained in `browser/safari.json`. I'm not sure how to target the TP version of Safari in `version_added`, please help.
![image](https://user-images.githubusercontent.com/153960/102789762-dad4aa80-43a4-11eb-97ec-9d549c24159a.png)
