### PR TITLE
Remove misleading Chromium notes from HTMLHyperlinkElementUtils

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -5,12 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils",
         "support": {
           "chrome": {
-            "version_added": true,
-            "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": true,
-            "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           },
           "edge": {
             "version_added": "12"
@@ -33,12 +31,10 @@
             "version_added": "5"
           },
           "opera": {
-            "version_added": true,
-            "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           },
           "opera_android": {
-            "version_added": true,
-            "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -47,12 +43,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true,
-            "notes": "Starting in Samsung Internet 6.0, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           },
           "webview_android": {
-            "version_added": true,
-            "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            "version_added": true
           }
         },
         "status": {
@@ -66,12 +60,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hash",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -88,12 +80,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -102,12 +92,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -122,12 +110,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/host",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -145,12 +131,10 @@
               "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code>&lt;a&gt;</code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -159,12 +143,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -179,12 +161,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hostname",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -201,12 +181,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -215,12 +193,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -235,12 +211,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/href",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -257,12 +231,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -271,12 +243,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -291,12 +261,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/origin",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "17"
@@ -319,12 +287,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -333,12 +299,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -353,12 +317,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/password",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "79"
@@ -375,12 +337,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -389,12 +349,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -409,12 +367,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/pathname",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -437,12 +393,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -451,12 +405,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -471,12 +423,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/port",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -493,12 +443,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -507,12 +455,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -527,12 +473,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/protocol",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -549,12 +493,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -563,12 +505,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -583,12 +523,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/search",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -611,12 +549,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -625,12 +561,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {
@@ -695,12 +629,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/username",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "edge": {
               "version_added": "79"
@@ -717,12 +649,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -731,12 +661,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
This PR removes the misleading notes about member movement from the Chromium browsers for the `HTMLHyperlinkElementUtils` mixin.  Rather than a move from this mixin to the `URL` API, the mixin was renamed from `URLUtils` to `HTMLHyperlinkElementUtils`, and its members were _copied_ to the `URL` API (prior to Chrome 52, it inherited the mixin).

Fixes #7823.  Source of data is in the linked issue (specifically, https://github.com/mdn/browser-compat-data/issues/7823#issuecomment-749224815).
