### PR TITLE
Remove redundant Firefox notes from HTMLHyperlinkElementUtils

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -17,17 +17,11 @@
           },
           "firefox": {
             "version_added": "22",
-            "notes": [
-              "This mixin was called <code>URLUtils</code> before Firefox 45, and was also implemented to other by other interfaces, like <a href='https://developer.mozilla.org/docs/Web/API/Location'><code>Location</code></a>. From Firefox 45, the other interfaces implement their own version of the properties and methods they need.",
-              "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
-            ]
+            "notes": "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
           },
           "firefox_android": {
             "version_added": "22",
-            "notes": [
-              "This mixin was called <code>URLUtils</code> before Firefox 45, and was also implemented to other by other interfaces, like <a href='https://developer.mozilla.org/docs/Web/API/Location'><code>Location</code></a>. From Firefox 45, the other interfaces implement their own version of the properties and methods they need.",
-              "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
-            ]
+            "notes": "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
           },
           "ie": {
             "version_added": "5"
@@ -78,11 +72,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
+              "notes": "From Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
+              "notes": "From Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "ie": {
               "version_added": "5"
@@ -133,12 +127,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": "5",
@@ -190,12 +182,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": "5"
@@ -246,12 +236,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": "5"
@@ -303,17 +291,11 @@
             },
             "firefox": {
               "version_added": "26",
-              "notes": [
-                "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
-              ]
+              "notes": "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
             },
             "firefox_android": {
               "version_added": "26",
-              "notes": [
-                "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
-              ]
+              "notes": "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
             },
             "ie": {
               "version_added": false
@@ -364,12 +346,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "26",
-              "notes": "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": "26",
-              "notes": "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
@@ -421,17 +401,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": [
-                "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
-              ]
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": [
-                "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
-              ]
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"
@@ -482,12 +456,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": "5"
@@ -538,12 +510,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": "5"
@@ -595,17 +565,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": [
-                "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
-              ]
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": [
-                "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
-                "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
-              ]
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"
@@ -654,12 +618,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "22",
-              "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -706,12 +668,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "26",
-              "notes": "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": "26",
-              "notes": "From Firefox 26 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
+              "version_added": "26"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR is a sister to #8105, which removes the redundant notes from Firefox.  Web developers would not see a difference due to the renaming of its mixin and the copying of its members to other interfaces.  As such, it's not really useful to mention the mixin rename.
