### PR TITLE
Add missing features for HTMLAreaElement API

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -239,6 +239,53 @@
           }
         }
       },
+      "ping": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "12"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "referrerPolicy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `HTMLAreaElement` API.

Spec: https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlareaelement

IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAreaElement
