### PR TITLE
Update Firefox versions for HTMLHyperlinkElementUtils API

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -16,14 +16,14 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "22",
+            "version_added": "1",
             "notes": [
               "This mixin was called <code>URLUtils</code> before Firefox 45, and was also implemented to other by other interfaces, like <a href='https://developer.mozilla.org/docs/Web/API/Location'><code>Location</code></a>. From Firefox 45, the other interfaces implement their own version of the properties and methods they need.",
               "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
             ]
           },
           "firefox_android": {
-            "version_added": "22",
+            "version_added": "4",
             "notes": [
               "This mixin was called <code>URLUtils</code> before Firefox 45, and was also implemented to other by other interfaces, like <a href='https://developer.mozilla.org/docs/Web/API/Location'><code>Location</code></a>. From Firefox 45, the other interfaces implement their own version of the properties and methods they need.",
               "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
@@ -77,11 +77,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "ie": {
@@ -133,11 +133,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
@@ -190,11 +190,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
@@ -246,11 +246,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
@@ -420,14 +420,14 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": [
                 "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
                 "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
               ]
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": [
                 "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
                 "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
@@ -482,11 +482,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
@@ -538,11 +538,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
@@ -594,14 +594,14 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "1",
               "notes": [
                 "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
                 "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
               ]
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "4",
               "notes": [
                 "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface.",
                 "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `HTMLHyperlinkElementUtils` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLHyperlinkElementUtils

Note: the data corrections slightly conflict with the existing notes regarding what mixin it is on.  These notes are removed in #8106 as they are redundant.  (Unfortunately, there may be merge conflicts with that PR, since they modify the same lines.)