### PR TITLE
Add Safari versions for HTMLHyperlinkElementUtils API

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -41,10 +41,10 @@
             "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true,
@@ -96,10 +96,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -153,10 +153,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -209,10 +209,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -265,10 +265,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -327,10 +327,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -445,10 +445,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -501,10 +501,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -557,10 +557,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -619,10 +619,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -725,10 +725,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -383,10 +383,10 @@
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true,


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLHyperlinkElementUtils` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLHyperlinkElementUtils
