### PR TITLE
Add Chromium versions for HTMLHyperlinkElementUtils API

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "edge": {
@@ -33,11 +33,11 @@
             "version_added": "5"
           },
           "opera": {
-            "version_added": true,
+            "version_added": "≤12.1",
             "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "opera_android": {
-            "version_added": true,
+            "version_added": "≤12.1",
             "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "safari": {
@@ -47,11 +47,11 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "notes": "Starting in Samsung Internet 6.0, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           }
         },
@@ -66,11 +66,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hash",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -88,11 +88,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -102,11 +102,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -122,11 +122,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/host",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -145,11 +145,11 @@
               "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code>&lt;a&gt;</code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -159,11 +159,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -179,11 +179,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hostname",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -201,11 +201,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -215,11 +215,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -235,11 +235,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/href",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -257,11 +257,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -271,11 +271,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -291,11 +291,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/origin",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "8",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -319,11 +319,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -333,11 +333,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -353,11 +353,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/password",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "32",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "32",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -375,11 +375,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "19",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "19",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -389,11 +389,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "2.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "4.4.3",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -409,11 +409,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/pathname",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -437,11 +437,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -451,11 +451,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -471,11 +471,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/port",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -493,11 +493,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -507,11 +507,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -527,11 +527,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/protocol",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -549,11 +549,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -563,11 +563,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -583,11 +583,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/search",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -611,11 +611,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -625,11 +625,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },
@@ -695,11 +695,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/username",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "32",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "32",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
@@ -717,11 +717,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "19",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "19",
               "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
@@ -731,11 +731,11 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "2.0",
               "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "4.4.3",
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLHyperlinkElementUtils` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAnchorElement

~~Notice: the diff may conflict with #8105 as they both perform modifications to the same lines.~~