### PR TITLE
api.Notification is unsupported in Chrome for Android

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -15,7 +15,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
             "version_added": "14"
@@ -81,7 +81,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "≤18"
@@ -237,7 +237,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -285,7 +285,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -333,7 +333,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "16"
@@ -381,7 +381,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -435,7 +435,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -543,7 +543,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -591,7 +591,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "18"
@@ -639,7 +639,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -687,7 +687,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -735,7 +735,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -783,7 +783,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -831,7 +831,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -979,7 +979,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "17"
@@ -1123,7 +1123,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -1171,7 +1171,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "17"
@@ -1219,7 +1219,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "14"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -141,7 +141,7 @@
               "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": false
             },
             "edge": {
               "version_added": "18"
@@ -189,7 +189,7 @@
               "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": false
             },
             "edge": {
               "version_added": "18"
@@ -495,7 +495,7 @@
               "version_added": "53"
             },
             "chrome_android": {
-              "version_added": "53"
+              "version_added": false
             },
             "edge": {
               "version_added": "18"
@@ -879,7 +879,7 @@
               "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "50"
+              "version_added": false
             },
             "edge": {
               "version_added": "79"
@@ -927,7 +927,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": false
             },
             "edge": {
               "version_added": "14"
@@ -1027,7 +1027,7 @@
               "version_added": "62"
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "edge": {
               "version_added": "≤79"
@@ -1075,7 +1075,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "edge": {
               "version_added": "17"
@@ -1267,7 +1267,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": "53",
+              "version_added": false,
               "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
             },
             "edge": {
@@ -1318,7 +1318,7 @@
               "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": false
             },
             "edge": {
               "version_added": "≤18"


### PR DESCRIPTION
This PR addresses issue #7923, updating chrome_android data.
