### PR TITLE
Add missing features for IDBTransaction API

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -403,6 +403,53 @@
           }
         }
       },
+      "durability": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "70"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/error",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `IDBTransaction` API.

Spec: https://w3c.github.io/IndexedDB/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/IndexedDB.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBTransaction
