### PR TITLE
Firefox 79 for Android supports optional chaining.

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -56,7 +56,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This is already supported by Firefox 74 (https://github.com/mdn/browser-compat-data/pull/5656 and https://bugzilla.mozilla.org/show_bug.cgi?id=1566143).

Firefox for Android is restarted from 79, so we should update this data as 79.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
