### PR TITLE
Add missing features for ImageBitmapRenderingContext API

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "canvas": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "56"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transferFromImageBitmap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `ImageBitmapRenderingContext` API.

Spec: https://html.spec.whatwg.org/multipage/canvas.html#imagebitmaprenderingcontext

IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageBitmapRenderingContext

Depends on corrections made in #8120.