### PR TITLE
Add missing features for IntersectionObserverEntry API

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -54,6 +54,55 @@
           "deprecated": false
         }
       },
+      "IntersectionObserverEntry": {
+        "__compat": {
+          "description": "<code>IntersectionObserverEntry()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "15",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "boundingClientRect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/boundingClientRect",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `IntersectionObserverEntry` API.

Spec: https://w3c.github.io/IntersectionObserver/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/intersection-observer.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IntersectionObserverEntry
