### PR TITLE
Add missing features for NodeList API

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -334,6 +334,55 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "27",
+              "version_removed": "36"
+            },
+            "firefox_android": {
+              "version_added": "27",
+              "version_removed": "36"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `NodeList` API.

Spec: https://dom.spec.whatwg.org/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/dom.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NodeList
