### PR TITLE
Update beforeinput event support on Firefox

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -431,10 +431,24 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.input_events.beforeinput.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.input_events.beforeinput.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
beforeinput is implemented by https://bugzilla.mozilla.org/show_bug.cgi?id=970802 on Gecko 74.

This is shipped on nightly and early beta only.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
