### PR TITLE
Add missing features for PaymentManager API

### DIFF
--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "enableDelegations": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "instruments": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/instruments",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `PaymentManager` API.

Spec: https://w3c.github.io/payment-handler/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/payment-handler.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PaymentManager
