### PR TITLE
Add missing features for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -285,6 +285,53 @@
           }
         }
       },
+      "eventCounts": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "85"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "71"
+            },
+            "opera_android": {
+              "version_added": "60"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "85"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "getEntries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/getEntries",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `Performance` API.

Spec: https://wicg.github.io/event-timing/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/event-timing.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Performance
