### PR TITLE
Update correct version and flags for getTargetRanges support on Firefox

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -206,10 +206,24 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "83"
+              "version_added": "75",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.input_events.beforeinput.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "83"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.input_events.beforeinput.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/7279 is incorrect.

Originally, this API is implemented by https://bugzilla.mozilla.org/show_bug.cgi?id=1449831 (Firefox 75).
But `dom.input_events.beforeinput.enabled` is still false on release channel (see https://searchfox.org/mozilla-central/rev/8698fade12984b9a6a43a85a287a5f17e8fd4ddf/modules/libpref/init/StaticPrefList.yaml#1944-1947).
So this data should have `flags` section.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
