### PR TITLE
Add missing features for PerformanceMeasure API

### DIFF
--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -49,6 +49,53 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "detail": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "78"
+            },
+            "chrome_android": {
+              "version_added": "78"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "65"
+            },
+            "opera_android": {
+              "version_added": "56"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "78"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `PerformanceMeasure` API.

Spec: https://w3c.github.io/user-timing/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/user-timing.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceMeasure
