### PR TITLE
Add missing features for RTCError API

### DIFF
--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -141,6 +141,53 @@
           }
         }
       },
+      "httpRequestStatusCode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "74"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "receivedAlert": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `RTCError` API.

Spec: https://w3c.github.io/webrtc-identity/identity.html

IDL: https://github.com/w3c/webref/blob/master/ed/idl/webrtc-identity.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCError
