### PR TITLE
Mark MediaQueryList#(add|remove)Listener as deprecated

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -192,7 +192,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -387,7 +387,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Those exist just for backward compatibility. https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-addlistener

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
