### PR TITLE
Mark Window#event and onorientationchange as deprecated

### DIFF
--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -282,7 +282,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -2162,7 +2162,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -5125,7 +5125,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
The corresponding attribute `orientation` is already marked as deprecated.

https://dom.spec.whatwg.org/#interface-window-extensions
https://compat.spec.whatwg.org/#windoworientation-interface

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
