### PR TITLE
Update Edge versions for RTCIceTransport API

### DIFF
--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -11,8 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "15",
-            "version_removed": "79"
+            "version_added": "13"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +58,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
+              "version_added": "13",
               "version_removed": "79"
             },
             "firefox": {
@@ -108,7 +107,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -205,7 +204,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -253,7 +252,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -301,8 +300,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": false
@@ -350,8 +348,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": false
@@ -398,11 +395,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "alternative_name": "getNominatedCandidatePair",
-              "version_added": "15",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "alternative_name": "getNominatedCandidatePair",
+                "version_added": "13",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -449,7 +451,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -497,7 +499,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -545,7 +547,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -593,8 +595,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": false
@@ -691,8 +692,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "15",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `RTCIceTransport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceTransport
