### PR TITLE
Update Chromium versions for RTCIceTransport API

### DIFF
--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "75"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "75"
           },
           "edge": {
             "version_added": "15",
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "54"
           },
           "safari": {
             "version_added": "11"
@@ -36,10 +36,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "75"
           }
         },
         "status": {
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/gatheringState",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -120,10 +120,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "11"
@@ -132,10 +132,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -199,10 +199,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalCandidates",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -217,10 +217,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -229,10 +229,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -247,10 +247,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getLocalParameters",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -265,10 +265,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -277,10 +277,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -295,10 +295,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteCandidates",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "15",
@@ -314,10 +314,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -326,10 +326,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -344,10 +344,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getRemoteParameters",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "15",
@@ -363,10 +363,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -375,10 +375,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -393,10 +393,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/getSelectedCandidatePair",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "alternative_name": "getNominatedCandidatePair",
@@ -413,10 +413,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -425,10 +425,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -443,10 +443,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/ongatheringstatechange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -461,10 +461,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -473,10 +473,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -491,10 +491,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onselectedcandidatepairchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -509,10 +509,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -521,10 +521,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -539,10 +539,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/onstatechange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -557,10 +557,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -569,10 +569,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -587,10 +587,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/role",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "15",
@@ -606,10 +606,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -618,10 +618,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {
@@ -685,10 +685,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/state",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": "15",
@@ -704,10 +704,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "11"
@@ -716,10 +716,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCIceTransport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceTransport
