### PR TITLE
Add missing features for RTCRtpReceiver API

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "createEncodedStreams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": "61"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getCapabilities": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getCapabilities",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `RTCRtpReceiver` API.

Spec: https://w3c.github.io/webrtc-insertable-streams/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/webrtc-insertable-streams.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpReceiver
