### PR TITLE
Add missing features for RTCRtpSender API

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -47,6 +47,53 @@
           "deprecated": false
         }
       },
+      "createEncodedStreams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": "61"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dtmf": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/dtmf",
@@ -392,6 +439,53 @@
             },
             "webview_android": {
               "version_added": "68"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setStreams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "79"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `RTCRtpSender` API.

Spec: https://w3c.github.io/webrtc-pc/ + https://w3c.github.io/webrtc-insertable-streams/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/webrtc.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpSender
