### PR TITLE
Update Firefox versions for RTCStatsReport API

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": false
+            "version_added": "27"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "27"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `RTCStatsReport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCStatsReport
