### PR TITLE
Update Chromium versions for RTCStatsReport API

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "58"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "58"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "45"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "43"
           },
           "safari": {
             "version_added": "11"
@@ -35,10 +35,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "7.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "58"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCStatsReport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCStatsReport
