### PR TITLE
Add missing features for ResizeObserverEntry API

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -191,6 +191,53 @@
           }
         }
       },
+      "devicePixelContentBoxSize": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": "84"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "70"
+            },
+            "opera_android": {
+              "version_added": "60"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry/target",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `ResizeObserverEntry` API.

Spec: https://drafts.csswg.org/resize-observer/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/resize-observer.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ResizeObserverEntry
