### PR TITLE
Add missing features for SVGClipPathElement API

### DIFF
--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -93,6 +93,53 @@
             "deprecated": false
           }
         }
+      },
+      "transform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `SVGClipPathElement` API.

Spec: https://drafts.fxtf.org/css-masking-1/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/css-masking.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGClipPathElement
