### PR TITLE
Update Safari versions for SVGAnimatedAngle API

### DIFF
--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -29,7 +29,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "≤4"
           },
           "safari_ios": {
             "version_added": "3"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `SVGAnimatedAngle` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedAngle
