### PR TITLE
Add missing features for StorageManager API

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -117,6 +117,53 @@
           }
         }
       },
+      "getDirectory": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "persist": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persist",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `StorageManager` API.

Spec: https://wicg.github.io/file-system-access/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/file-system-access.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StorageManager
