### PR TITLE
Add missing features for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -241,6 +241,100 @@
           }
         }
       },
+      "onenter": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onexit": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pauseOnExit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/pauseOnExit",

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -272,7 +272,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -319,7 +319,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `TextTrackCue` API.

Spec: https://html.spec.whatwg.org/multipage/media.html#texttrackcue

IDL: https://github.com/w3c/webref/blob/master/ed/idl/html.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue

Depends on data added in #8177 and #8179.