### PR TITLE
Add Firefox versions for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "31"
           },
           "ie": {
             "version_added": "10"
@@ -61,10 +61,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -207,10 +207,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -255,10 +255,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -303,10 +303,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -351,10 +351,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TextTrackCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue
