### PR TITLE
Update Chromium versions for ImageBitmapRenderingContext API (#8120)

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext",
         "support": {
           "chrome": {
-            "version_added": "66"
+            "version_added": "56"
           },
           "chrome_android": {
-            "version_added": "66"
+            "version_added": "56"
           },
           "edge": {
             "version_added": "≤79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "43"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "9.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "66"
+            "version_added": "56"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -96,10 +96,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -23,10 +23,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "6"
@@ -70,10 +70,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -216,10 +216,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -264,10 +264,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -312,10 +312,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -360,10 +360,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ImageBitmapRenderingContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageBitmapRenderingContext
