### PR TITLE
Add Opera versions for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -23,10 +23,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "6"
@@ -70,10 +70,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -216,10 +216,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -264,10 +264,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -312,10 +312,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -360,10 +360,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `TextTrackCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue
