### PR TITLE
Add missing features for WritableStream API

### DIFF
--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -144,6 +144,53 @@
           }
         }
       },
+      "close": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "68"
+            },
+            "opera_android": {
+              "version_added": "58"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "81"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getWriter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.7), for the `WritableStream` API.

Spec: https://streams.spec.whatwg.org/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/streams.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStream
