### PR TITLE
Update Safari versions for SVGAnimatedLength API

### DIFF
--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -29,10 +29,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `SVGAnimatedLength` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedLength
