### PR TITLE
Update Chromium versions for SVGAnimatedLengthList API

### DIFF
--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAnimatedLengthList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedLengthList
