### PR TITLE
Add Chromium versions for SVGAnimatedPoints API

### DIFF
--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPoints",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -25,10 +25,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari": {
             "version_added": false
@@ -37,10 +37,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAnimatedPoints` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedPoints
