### PR TITLE
Update Safari versions for SVGAnimatedPoints API

### DIFF
--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -31,10 +31,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `SVGAnimatedPoints` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedPoints
