### PR TITLE
Update Chrome/Safari versions for SVGAnimatedRect API

### DIFF
--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -29,16 +29,16 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGAnimatedRect` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedRect
