### PR TITLE
Add missing features for SVGFETileElement API

### DIFF
--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -46,6 +46,53 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "in1": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8), for the `SVGFETileElement` API.

Spec: https://drafts.fxtf.org/filter-effects-1/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/filter-effects.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFETileElement
