### PR TITLE
Add Chromium versions for SVGFilterPrimitiveStandardAttributes API

### DIFF
--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFilterPrimitiveStandardAttributes",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "5"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18"
           },
           "edge": {
             "version_added": null
@@ -25,10 +25,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": null
@@ -37,10 +37,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGFilterPrimitiveStandardAttributes` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFilterPrimitiveStandardAttributes
