### PR TITLE
Add IE/Edge versions for SVGFilterPrimitiveStandardAttributes API

### DIFF
--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3",
@@ -22,7 +22,7 @@
             "version_removed": "22"
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGFilterPrimitiveStandardAttributes` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFilterPrimitiveStandardAttributes
