### PR TITLE
Add Safari versions for SVGFilterPrimitiveStandardAttributes API

### DIFF
--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -31,10 +31,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGFilterPrimitiveStandardAttributes` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFilterPrimitiveStandardAttributes
