### PR TITLE
Update Firefox versions for SVGFilterPrimitiveStandardAttributes API

### DIFF
--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -14,12 +14,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": "3",
-            "version_removed": "22"
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": "4",
-            "version_removed": "22"
+            "version_added": "4"
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `SVGFilterPrimitiveStandardAttributes` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGFilterPrimitiveStandardAttributes
