### PR TITLE
Add missing features for SVGGlyphRefElement API

### DIFF
--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -52,6 +52,324 @@
           "standard_track": true,
           "deprecated": true
         }
+      },
+      "dx": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "format": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "glyphRef": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "40"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "27"
+            },
+            "opera_android": {
+              "version_added": "14",
+              "version_removed": "27"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8), for the `SVGGlyphRefElement` API.

Spec: https://svgwg.org/svg2-draft/

IDL: https://github.com/w3c/webref/blob/master/ed/idl/SVG.idl

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGGlyphRefElement
