### PR TITLE
Update Chrome/Safari versions for SVGLengthList API

### DIFF
--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -26,13 +26,13 @@
             "version_added": "15"
           },
           "opera_android": {
-            "version_added": "15"
+            "version_added": "14"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGLengthList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGLengthList
