### PR TITLE
Update Firefox versions for SVGMPathELement API

### DIFF
--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": "20"
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": "20"
+            "version_added": "4"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `SVGMPathELement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGMPathELement
