### PR TITLE
Add IE/Edge versions for SVGPreserveAspectRatio API

### DIFF
--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGPreserveAspectRatio` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGPreserveAspectRatio
