### PR TITLE
CSSRule.type is deprecated

### DIFF
--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -236,7 +236,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/344

The CSSRule.type property is deprecated in the specification: https://drafts.csswg.org/cssom/#ref-for-dom-cssrule-type

I have been updating the docs to reflect this, this PR flags it as deprecated in BCD.
