### PR TITLE
Add Chromium versions for WEBGL_compressed_texture_atc API

### DIFF
--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_atc",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "36",
             "version_removed": "68"
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "36",
             "version_removed": "68"
           },
           "edge": {
@@ -33,11 +33,11 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true,
+            "version_added": "23",
             "version_removed": "55"
           },
           "opera_android": {
-            "version_added": true,
+            "version_added": "23",
             "version_removed": "48"
           },
           "safari": {
@@ -47,11 +47,11 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "3.0",
             "version_removed": "10.0"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "37",
             "version_removed": "68"
           }
         },

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": "23",
+            "version_added": "24",
             "version_removed": "48"
           },
           "safari": {

--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -5,8 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_atc",
         "support": {
           "chrome": {
-            "version_added": "36",
-            "version_removed": "68"
+            "version_added": false
           },
           "chrome_android": {
             "version_added": "36",
@@ -33,8 +32,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "23",
-            "version_removed": "55"
+            "version_added": false
           },
           "opera_android": {
             "version_added": "23",


### PR DESCRIPTION
This PR adds the Chromium version for the `WEBGL_compressed_texture_atc` API based upon bug reports and commits.  It appears that this was added in Chrome 36 ([bug](https://bugs.chromium.org/p/chromium/issues/detail?id=364564), [commit](https://storage.googleapis.com/chromium-find-releases-static/8ae.html#8aec81ec90782e74e4adfb1e848d26dde693e3bc)), and then removed in Chrome 68 ([bug](https://bugs.chromium.org/p/chromium/issues/detail?id=845288&q=webgl_compressed_texture_atc&can=1), [commit](https://storage.googleapis.com/chromium-find-releases-static/344.html#344f339a3b379b4dab61a35be40c5effbbf468fb)).

Reading the removal bug, however, it mentions that support is only available on Qualcomm processors ("the tests fail currently on Qualcomm (the only platform where they're available)"), and since Qualcomm processors are mobile processors, this couldn't have been in desktop editions of Chrome.  As such, this sets Chrome Desktop and Opera desktop to `false`.