### PR TITLE
Add Chromium versions for WEBGL_compressed_texture_etc API

### DIFF
--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_etc",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "63"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "63"
           },
           "edge": {
             "version_added": "79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "50"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "46"
           },
           "safari": {
             "version_added": false
@@ -35,10 +35,10 @@
             "version_added": "14"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "63"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_etc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_compressed_texture_etc
