### PR TITLE
Add Chromium versions for WEBGL_compressed_texture_s3tc API

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -14,8 +14,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": true,
-            "prefix": "WEBKIT_"
+            "version_added": false
           },
           "edge": {
             "version_added": "≤18"
@@ -46,8 +45,7 @@
             }
           ],
           "opera_android": {
-            "version_added": true,
-            "prefix": "WEBKIT_"
+            "version_added": false
           },
           "safari": {
             "version_added": "8"
@@ -56,12 +54,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true,
-            "prefix": "WEBKIT_"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": true,
-            "prefix": "WEBKIT_"
+            "version_added": false
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -6,22 +6,17 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "26"
             },
             {
               "version_added": true,
               "prefix": "WEBKIT_"
             }
           ],
-          "chrome_android": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": true,
-              "prefix": "WEBKIT_"
-            }
-          ],
+          "chrome_android": {
+            "version_added": true,
+            "prefix": "WEBKIT_"
+          },
           "edge": {
             "version_added": "≤18"
           },
@@ -43,46 +38,31 @@
           },
           "opera": [
             {
-              "version_added": true
+              "version_added": "15"
             },
             {
               "version_added": true,
               "prefix": "WEBKIT_"
             }
           ],
-          "opera_android": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": true,
-              "prefix": "WEBKIT_"
-            }
-          ],
+          "opera_android": {
+            "version_added": true,
+            "prefix": "WEBKIT_"
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": true,
-              "prefix": "WEBKIT_"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": true
-            },
-            {
-              "version_added": true,
-              "prefix": "WEBKIT_"
-            }
-          ]
+          "samsunginternet_android": {
+            "version_added": true,
+            "prefix": "WEBKIT_"
+          },
+          "webview_android": {
+            "version_added": true,
+            "prefix": "WEBKIT_"
+          }
         },
         "status": {
           "experimental": false,


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_s3tc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_compressed_texture_s3tc
