### PR TITLE
Add Chromium versions for WEBGL_compressed_texture_s3tc_srgb API

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -5,12 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb",
         "support": {
           "chrome": {
-            "version_added": "60",
-            "version_removed": "78"
+            "version_added": "60"
           },
           "chrome_android": {
-            "version_added": "60",
-            "version_removed": "78"
+            "version_added": "60"
           },
           "edge": {
             "version_added": "≤79"
@@ -25,12 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "47",
-            "version_removed": "65"
+            "version_added": "47"
           },
           "opera_android": {
-            "version_added": "44",
-            "version_removed": "56"
+            "version_added": "44"
           },
           "safari": {
             "version_added": false
@@ -39,12 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "8.0",
-            "version_removed": "12.0"
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "60",
-            "version_removed": "78"
+            "version_added": "60"
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -5,10 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "60",
+            "version_removed": "78"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "60",
+            "version_removed": "78"
           },
           "edge": {
             "version_added": "≤79"
@@ -23,10 +25,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "47",
+            "version_removed": "65"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "44",
+            "version_removed": "56"
           },
           "safari": {
             "version_added": false
@@ -35,10 +39,12 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0",
+            "version_removed": "12.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "60",
+            "version_removed": "78"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_s3tc_srgb` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_compressed_texture_s3tc_srgb
