### PR TITLE
Add Chromium versions for WEBGL_depth_texture API

### DIFF
--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": [
             {
-              "version_added": true
+              "version_added": "26"
             },
             {
               "version_added": true,
@@ -15,7 +15,7 @@
           ],
           "chrome_android": [
             {
-              "version_added": true
+              "version_added": "26"
             },
             {
               "version_added": true,
@@ -43,7 +43,7 @@
           },
           "opera": [
             {
-              "version_added": true
+              "version_added": "15"
             },
             {
               "version_added": true,
@@ -52,7 +52,7 @@
           ],
           "opera_android": [
             {
-              "version_added": true
+              "version_added": "14"
             },
             {
               "version_added": true,
@@ -67,7 +67,7 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_added": true,
@@ -76,7 +76,7 @@
           ],
           "webview_android": [
             {
-              "version_added": true
+              "version_added": "≤37"
             },
             {
               "version_added": true,


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_depth_texture` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_depth_texture
