### PR TITLE
Add Chromium versions for WEBGL_draw_buffers API

### DIFF
--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "36"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
             "version_added": "17"
@@ -37,10 +37,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "23"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
             "version_added": "9"
@@ -49,10 +49,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
-            "version_added": true
+            "version_added": false
           }
         },
         "status": {
@@ -66,10 +66,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers/drawBuffersWEBGL",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "17"
@@ -98,10 +98,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": "9"
@@ -110,10 +110,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_draw_buffers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_draw_buffers
