### PR TITLE
Add Chromium versions for Gamepad.displayId

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -388,8 +388,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/displayId",
           "support": {
             "chrome": {
+              "version_added": "55",
               "version_removed": "80",
-              "version_added": true,
               "flags": [
                 {
                   "type": "preference",
@@ -399,8 +399,8 @@
               "notes": "Only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "chrome_android": {
+              "version_added": "55",
               "version_removed": "80",
-              "version_added": true,
               "notes": "Currently supported only by Google Daydream."
             },
             "edge": {
@@ -423,7 +423,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -432,8 +432,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
+              "version_added": "6.0",
               "version_removed": "13.0",
-              "version_added": true,
               "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {


### PR DESCRIPTION
This PR adds version numbers for Chromium for `api.Gamepad.displayId` based upon [commit history](https://storage.googleapis.com/chromium-find-releases-static/3ee.html#3ee1b2d10a9e09f725b4121a6dd114c3cb43fcaf).
