### PR TITLE
Add Chromium versions for NamedNodeMap API

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -218,10 +218,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NamedNodeMap/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -236,10 +236,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -248,10 +248,10 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `NamedNodeMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NamedNodeMap
