### PR TITLE
Add Chromium versions for PerformanceEntry API

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -38,12 +38,24 @@
             "version_added": "8.5.0",
             "notes": "Stability: Experimental"
           },
-          "opera": {
-            "version_added": "33"
-          },
-          "opera_android": {
-            "version_added": "33"
-          },
+          "opera": [
+            {
+              "version_added": "33"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "33"
+            },
+            {
+              "version_added": "14",
+              "prefix": "webkit"
+            }
+          ],
           "safari": {
             "version_added": "11"
           },
@@ -64,7 +76,7 @@
               "version_added": "46"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "prefix": "webkit"
             }
           ]
@@ -80,10 +92,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/duration",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -101,10 +113,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -113,10 +125,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -131,10 +143,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/entryType",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -152,10 +164,10 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -164,10 +176,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -182,10 +194,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -203,10 +215,10 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -215,10 +227,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -233,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -254,10 +266,10 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -266,10 +278,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -284,10 +296,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/toJSON",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "16"
@@ -305,10 +317,10 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "11"
@@ -317,10 +329,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "45"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PerformanceEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEntry
