### PR TITLE
Add Chromium versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "56"
           },
           "chrome_android": {
-            "version_added": "29"
+            "version_added": "56"
           },
           "edge": {
             "version_added": "≤79"
@@ -37,10 +37,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "43"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": "11"
@@ -49,10 +49,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "56"
           }
         },
         "status": {
@@ -66,10 +66,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/binaryType",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "29"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -96,10 +96,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "56"
             }
           },
           "status": {
@@ -508,7 +508,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/maxPacketLifeTime",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "78"
             },
             "chrome_android": {
               "version_added": "56"
@@ -701,7 +701,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onbufferedamountlow",
           "support": {
             "chrome": {
-              "version_added": "57",
+              "version_added": "56",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "chrome_android": {
@@ -825,7 +825,7 @@
               "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
               "version_added": false
@@ -1111,10 +1111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1381,10 +1381,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/stream",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": false
             },
             "edge": {
               "version_added": "≤79"
@@ -1399,10 +1399,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1411,10 +1411,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCDataChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannel
