### PR TITLE
Add Chromium versions for Comment API

### DIFF
--- a/api/Comment.json
+++ b/api/Comment.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +35,10 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>Comment()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "16"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "16"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "16"
             },
             "safari": {
               "version_added": "7"
@@ -83,10 +83,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Comment` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Comment
