### PR TITLE
Add Chromium versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/External",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,7 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
           },
           "safari": {
             "version_added": false
@@ -32,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
