### PR TITLE
Update Chromium versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -49,10 +49,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/AddSearchProvider",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -68,7 +68,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -77,10 +80,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "54"
+              "version_added": "1"
             }
           },
           "status": {
@@ -95,10 +98,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/IsSearchProviderInstalled",
           "support": {
             "chrome": {
-              "version_added": "54"
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": "54"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -113,7 +116,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -122,10 +128,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "54"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
