### PR TITLE
Add Chromium versions for MimeTypeArray API

### DIFF
--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "≤4"
@@ -72,10 +72,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"
@@ -122,10 +122,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "≤4"

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeTypeArray",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "≤4"
@@ -35,10 +35,10 @@
             "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,11 +52,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeTypeArray/item",
           "support": {
             "chrome": {
-              "version_added": "59",
+              "version_added": "1",
               "notes": "Prior to version 59, method parameters were optional"
             },
             "chrome_android": {
-              "version_added": "59",
+              "version_added": "18",
               "notes": "Prior to version 59, method parameters were optional"
             },
             "edge": {
@@ -72,10 +72,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "≤4"
@@ -84,11 +84,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0",
+              "version_added": "1.0",
               "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
-              "version_added": "59",
+              "version_added": "1",
               "notes": "Prior to version 59, method parameters were optional"
             }
           },
@@ -104,10 +104,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeTypeArray/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -122,10 +122,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -134,10 +134,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -152,11 +152,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeTypeArray/namedItem",
           "support": {
             "chrome": {
-              "version_added": "59",
+              "version_added": "1",
               "notes": "Prior to version 59, method parameters were optional"
             },
             "chrome_android": {
-              "version_added": "59",
+              "version_added": "18",
               "notes": "Prior to version 59, method parameters were optional"
             },
             "edge": {
@@ -172,10 +172,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "≤4"
@@ -184,11 +184,11 @@
               "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0",
+              "version_added": "1.0",
               "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
-              "version_added": "59",
+              "version_added": "1",
               "notes": "Prior to version 59, method parameters were optional"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MimeTypeArray` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MimeTypeArray
