### PR TITLE
Add WebView versions for Blob API

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -185,7 +185,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -263,9 +263,16 @@
                 "version_removed": "1.5"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -410,7 +417,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -263,16 +263,9 @@
                 "version_removed": "1.5"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR adds real values for WebView Android for the `Blob` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Blob
