### PR TITLE
Add WebView versions for CDATASection API

### DIFF
--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -32,7 +32,7 @@
             "version_added": "≤3"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `CDATASection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CDATASection
