### PR TITLE
Add WebView versions for ChannelSplitterNode API

### DIFF
--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -43,7 +43,7 @@
             "notes": "Starting in Samsung Internet 6.0, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "notes": "Starting in version 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           }
         },


### PR DESCRIPTION
This PR adds real values for WebView Android for the `ChannelSplitterNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ChannelSplitterNode
