### PR TITLE
Add WebView versions for DedicatedWorkerGlobalScope API

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -375,7 +375,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `DedicatedWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DedicatedWorkerGlobalScope
