### PR TITLE
Add WebView versions for DeviceOrientationEvent API

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -140,7 +140,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -188,7 +188,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -236,7 +236,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -284,7 +284,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `DeviceOrientationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceOrientationEvent
