### PR TITLE
Remove redundant prefix property for File.webkitRelativePath

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -310,12 +310,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath",
           "support": {
             "chrome": {
-              "version_added": "13",
-              "prefix": "webkit"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": "18",
-              "prefix": "webkit"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -342,7 +340,6 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": "1.0"
             },
             "webview_android": {


### PR DESCRIPTION
While updating data for the File API for Chrome, I noticed that Chrome had a prefix attribute for an already-prefixed attribute, `webkitRelativePath`.  It doesn't make sense to have a prefix listed for an already-prefixed attribute, so this PR removes said `prefix` property.
