### PR TITLE
Add WebView versions for FileError API

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -310,12 +310,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath",
           "support": {
             "chrome": {
-              "version_added": "13",
-              "prefix": "webkit"
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": "18",
-              "prefix": "webkit"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -342,7 +340,6 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "prefix": "webkit",
               "version_added": "1.0"
             },
             "webview_android": {

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -50,7 +50,7 @@
             "version_removed": "6.0"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "version_removed": "53",
             "prefix": "webkit"
           }


### PR DESCRIPTION
This PR adds real values for WebView Android for the `FileError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileError
