### PR TITLE
Update WebView versions for GeolocationCoordinates API

### DIFF
--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -88,7 +88,7 @@
               "version_added": "79"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "78",
               "alternative_name": "Coordinates"
             }
@@ -150,7 +150,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -210,7 +210,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -270,7 +270,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -330,7 +330,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -390,7 +390,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -450,7 +450,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -558,7 +558,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `GeolocationCoordinates` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GeolocationCoordinates
