### PR TITLE
Add WebView versions for GeolocationPositionError API

### DIFF
--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -83,7 +83,7 @@
               "version_added": "79"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "78",
               "alternative_name": "PositionError"
             }
@@ -133,7 +133,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `GeolocationPositionError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GeolocationPositionError
