### PR TITLE
Add WebView versions for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -179,7 +179,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -227,7 +227,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -276,7 +276,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -324,7 +324,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -593,7 +593,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -641,7 +641,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -689,7 +689,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -738,7 +738,7 @@
               "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -786,7 +786,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -831,7 +831,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -879,7 +879,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -927,7 +927,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -975,7 +975,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1023,7 +1023,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -1193,7 +1193,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1315,7 +1315,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1363,7 +1363,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1411,7 +1411,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1471,7 +1471,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1531,7 +1531,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `HTMLImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement
