### PR TITLE
Remove duplicated prefixes in IDB APIs

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -101,32 +101,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/advance",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -164,32 +150,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/continue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -236,16 +208,9 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "51"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "51",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "51"
             },
@@ -282,32 +247,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/delete",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -345,32 +296,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/direction",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -408,32 +345,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/key",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -519,32 +442,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/primaryKey",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -630,32 +539,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/source",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -693,32 +588,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursor/update",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -756,26 +637,12 @@
         "__compat": {
           "description": "Available in workers",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -788,52 +655,24 @@
             "ie": {
               "version_added": null
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "44",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "14",
-                "version_removed": "43",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "7"
             },
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -87,32 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBCursorWithValue/value",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -88,32 +88,18 @@
           "description": "<code>abort</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/abort_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -151,32 +137,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/close",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -263,32 +235,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/createObjectStore",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -326,32 +284,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/deleteObjectStore",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -390,32 +334,18 @@
           "description": "<code>error</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/error_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -453,32 +383,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/name",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -516,32 +432,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/objectStoreNames",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -579,32 +481,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/onabort",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -691,32 +579,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/onerror",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -754,32 +628,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/onversionchange",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -817,32 +677,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/transaction",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -880,32 +726,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/version",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -944,32 +776,18 @@
           "description": "<code>versionchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/versionchange_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1007,26 +825,12 @@
         "__compat": {
           "description": "Available in workers",
           "support": {
-            "chrome": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -1051,26 +855,12 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -87,32 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBFactory/cmp",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -135,16 +121,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -207,32 +186,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBFactory/deleteDatabase",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -255,16 +220,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -277,32 +235,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBFactory/open",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -325,16 +269,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -87,32 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/count",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -135,16 +121,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -157,32 +136,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/get",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -205,16 +170,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -335,32 +293,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/getKey",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -383,16 +327,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -453,32 +390,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/keyPath",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -501,16 +424,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -571,32 +487,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/multiEntry",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -619,16 +521,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -641,32 +536,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/name",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -689,16 +570,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -759,32 +633,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/objectStore",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -807,16 +667,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -829,32 +682,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/openCursor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -877,16 +716,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -899,32 +731,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/openKeyCursor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -947,16 +765,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -969,32 +780,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/unique",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1017,16 +814,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": true,
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -66,32 +66,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/bound",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -177,32 +163,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lower",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -240,32 +212,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lowerBound",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -303,32 +261,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lowerOpen",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -366,32 +310,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/only",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -429,32 +359,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upper",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -492,32 +408,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upperBound",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -555,32 +457,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upperOpen",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "24",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -87,39 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/add",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -139,26 +118,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -171,39 +136,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/autoIncrement",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -223,26 +167,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -255,39 +185,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/clear",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -307,26 +216,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -339,39 +234,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/count",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -391,26 +265,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -423,39 +283,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/createIndex",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -475,26 +314,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -507,39 +332,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/delete",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -559,26 +363,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -591,39 +381,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/deleteIndex",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -643,26 +412,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -675,39 +430,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/get",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -727,26 +461,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -903,39 +623,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/index",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -955,26 +654,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -987,39 +672,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/indexNames",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1039,26 +703,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1071,39 +721,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1123,26 +752,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1155,39 +770,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/name",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1207,26 +801,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1287,39 +867,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openCursor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1339,26 +898,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1371,26 +916,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openKeyCursor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -1422,26 +953,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1454,39 +971,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/put",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1506,26 +1002,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -1538,39 +1020,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBObjectStore/transaction",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -1590,26 +1051,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -88,39 +88,18 @@
           "description": "<code>blocked</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/blocked_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -140,26 +119,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -172,39 +137,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/onblocked",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -224,26 +168,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -256,39 +186,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/onupgradeneeded",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -308,26 +217,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -341,39 +236,18 @@
           "description": "<code>upgradeneeded</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -393,26 +267,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -87,39 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/error",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -139,26 +118,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -220,31 +185,18 @@
           "description": "<code>error</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/error_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -282,31 +234,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/onerror",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -344,31 +283,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/onsuccess",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -406,31 +332,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/readyState",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -468,31 +381,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/result",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -530,31 +430,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/source",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -593,31 +480,18 @@
           "description": "<code>success</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/success_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -655,31 +529,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBRequest/transaction",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -87,31 +87,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/abort",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -150,31 +137,18 @@
           "description": "<code>abort</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/abort_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -261,31 +235,18 @@
           "description": "<code>complete</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/complete_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -323,39 +284,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/db",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -375,26 +315,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -454,39 +380,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/error",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -506,26 +411,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -587,31 +478,18 @@
           "description": "<code>error</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/error_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -649,31 +527,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/mode",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -711,31 +576,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/objectStore",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -821,31 +673,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/onabort",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -883,31 +722,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/oncomplete",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -945,31 +771,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/onerror",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -65,39 +65,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBVersionChangeEvent/newVersion",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -117,26 +96,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -149,39 +114,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBVersionChangeEvent/oldVersion",
           "support": {
-            "chrome": [
-              {
-                "version_added": "24"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },
@@ -201,26 +145,12 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "version_removed": "7.0",
-                "prefix": "webkit",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": true,
-                "version_removed": "57",
-                "prefix": "webkit"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -242,15 +172,9 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "10"
+            },
             "firefox_android": {
               "version_added": "22"
             },


### PR DESCRIPTION
While working on the IDB APIs, I noticed that each of the individual properties had the same prefix data as the main API data.  However, this doesn't make sense; why would each of the members also be prefixed when the API itself is prefixed?  Additionally, I have verified this via manual testing.  This PR removes this copied prefix data.
