### PR TITLE
Add WebView versions for MutationObserver API

### DIFF
--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -164,11 +164,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
-                "version_added": true,
-                "version_removed": true,
+                "version_added": "≤37",
+                "version_removed": "≤37",
                 "prefix": "WebKit"
               }
             ]
@@ -218,7 +218,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -314,7 +314,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `MutationObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationObserver
