### PR TITLE
Remove duplicated prefixes in MutationObserverInit API

### DIFF
--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -116,7 +116,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -163,7 +163,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -210,7 +210,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -257,7 +257,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -304,7 +304,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -349,7 +349,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {
@@ -394,7 +394,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "18"
+              "version_added": "1.0"
             }
           },
           "status": {

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -83,26 +83,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributeFilter",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12",
               "notes": "Before Edge 79, this requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, then Edge throws a syntax error."
@@ -123,36 +109,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -165,26 +130,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributeOldValue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -205,36 +156,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -247,26 +177,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/attributes",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -287,36 +203,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -329,26 +224,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/characterData",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -369,36 +250,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -411,26 +271,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/characterDataOldValue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -451,36 +297,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -493,26 +318,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/childList",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -531,36 +342,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,
@@ -573,26 +363,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationObserverInit/subtree",
           "support": {
-            "chrome": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "26"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "18",
-                "version_removed": "26"
-              }
-            ],
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -611,36 +387,15 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "6",
-                "version_removed": "7"
-              }
-            ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.0",
-                "version_removed": "1.5"
-              }
-            ]
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "18"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
While working on the MutationObserverInit API, I noticed that each of the individual properties had the same prefix data as the main API data. However, this doesn't make sense; why would each of the members also be prefixed when the API itself is prefixed? Additionally, I have verified this via manual testing. This PR removes this copied prefix data.
