### PR TITLE
Update WebView versions for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -98,8 +98,7 @@
               "notes": "Supported only by Google Daydream."
             },
             "webview_android": {
-              "version_added": "79",
-              "version_removed": "80"
+              "version_added": false
             }
           },
           "status": {
@@ -820,7 +819,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1050,7 +1049,7 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -1217,8 +1216,7 @@
               "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
-              "version_added": true,
-              "version_removed": "80"
+              "version_added": false
             }
           },
           "status": {
@@ -1266,7 +1264,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             }
           },
           "status": {
@@ -2676,7 +2674,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "63"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator
