### PR TITLE
Add WebView versions for NodeIterator API

### DIFF
--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -145,7 +145,7 @@
               "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "41"
             }
           },
@@ -194,7 +194,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -242,7 +242,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -290,7 +290,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -338,7 +338,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -386,7 +386,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -434,7 +434,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -482,7 +482,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `NodeIterator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NodeIterator
