### PR TITLE
Add WebView versions for PannerNode API

### DIFF
--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -914,7 +914,7 @@
               "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "56"
             }
           },


### PR DESCRIPTION
This PR adds real values for WebView Android for the `PannerNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PannerNode
