### PR TITLE
Add WebView versions for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -116,16 +116,9 @@
                 "version_removed": "2.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -195,16 +188,9 @@
                 "version_removed": "2.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -400,16 +386,9 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": true,
-                "version_removed": "37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -479,16 +458,9 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": true,
-                "version_removed": "37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -572,16 +544,9 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": true,
-                "version_removed": "37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -644,16 +609,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -716,16 +674,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -893,16 +844,9 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "version_added": "≤37",
-                "version_removed": "≤37",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -46,7 +46,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -195,9 +195,16 @@
                 "version_removed": "2.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -272,7 +279,7 @@
                 "version_added": "46"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -393,9 +400,16 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": true,
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -465,9 +479,16 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": true,
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -551,9 +572,16 @@
                 "version_removed": "3.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": true,
+                "version_removed": "37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -616,9 +644,16 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -681,9 +716,16 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": {
-              "version_added": "46"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -733,7 +775,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -784,7 +826,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -851,9 +893,16 @@
             "samsunginternet_android": {
               "version_added": "1.5"
             },
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -928,7 +977,7 @@
                 "version_added": "46"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "57",
                 "alternative_name": "onwebkitresourcetimingbufferfull"
               }
@@ -1008,7 +1057,7 @@
                 "version_added": "46"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "57",
                 "alternative_name": "webkitresourcetimingbufferfull"
               }
@@ -1087,7 +1136,7 @@
                 "version_added": "46"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "57",
                 "prefix": "webkit"
               }
@@ -1195,7 +1244,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `Performance` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Performance
