### PR TITLE
Remove duplicated prefixes in ScriptProcessorNode API

### DIFF
--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -68,8 +68,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/audioprocess_event",
           "support": {
             "chrome": {
-              "version_added": "14",
-              "prefix": "webkit"
+              "version_added": "14"
             },
             "chrome_android": {
               "version_added": true
@@ -86,31 +85,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -131,8 +116,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/bufferSize",
           "support": {
             "chrome": {
-              "version_added": "14",
-              "prefix": "webkit"
+              "version_added": "14"
             },
             "chrome_android": {
               "version_added": true
@@ -149,31 +133,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -194,8 +164,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/onaudioprocess",
           "support": {
             "chrome": {
-              "version_added": "14",
-              "prefix": "webkit"
+              "version_added": "14"
             },
             "chrome_android": {
               "version_added": true
@@ -212,31 +181,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
While working on the ScriptProcessorNode API, I noticed that each of the individual properties had the same prefix data as the main API data. However, this doesn't make sense; why would each of the members also be prefixed when the API itself is prefixed? Additionally, I have verified this via manual testing. This PR removes this copied prefix data.
