### PR TITLE
Add WebView versions for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2704,7 +2704,7 @@
               "version_removed": "10.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "69"
             }
           },


### PR DESCRIPTION
This PR adds real values for WebView Android for the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document
