### PR TITLE
Add WebView versions for RTCConfiguration API

### DIFF
--- a/api/RTCConfiguration.json
+++ b/api/RTCConfiguration.json
@@ -38,7 +38,7 @@
             "version_added": "7.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -133,7 +133,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -229,7 +229,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -277,7 +277,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -376,7 +376,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "57"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `RTCConfiguration` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCConfiguration
