### PR TITLE
Add WebView versions for RTCIceCandidatePairStats API

### DIFF
--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -444,9 +444,15 @@
                 "alternative_name": "currentRtt"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": true,
+                "alternative_name": "currentRtt"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR adds real values for WebView Android for the `RTCIceCandidatePairStats` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidatePairStats
