### PR TITLE
Add WebView versions for TransitionEvent API

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -60,10 +60,10 @@
           ],
           "webview_android": [
             {
-              "version_added": true
+              "version_added": "≤37"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "71",
               "prefix": "WebKit"
             }
@@ -114,7 +114,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -211,7 +211,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -316,7 +316,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -364,7 +364,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `TransitionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TransitionEvent
