### PR TITLE
Add WebView versions for XMLHttpRequest API

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -139,7 +139,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -287,7 +287,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -684,7 +684,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1032,7 +1032,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "55"
               }
             },
             "status": {
@@ -1080,7 +1080,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "55"
               }
             },
             "status": {
@@ -1128,7 +1128,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "55"
               }
             },
             "status": {
@@ -1182,7 +1182,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "55"
               }
             },
             "status": {
@@ -1476,7 +1476,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1525,7 +1525,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1574,7 +1574,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1623,7 +1623,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1672,7 +1672,7 @@
                 "version_added": "7.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "59"
               }
             },
             "status": {
@@ -1874,7 +1874,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2031,7 +2031,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `XMLHttpRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLHttpRequest
