### PR TITLE
Mark ImageCapture as unsupported in Firefox (fixes #7569)

### DIFF
--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -14,10 +14,12 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
           },
           "ie": {
             "version_added": false
@@ -62,10 +64,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false
@@ -110,10 +114,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false
@@ -158,10 +164,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false
@@ -206,10 +214,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false
@@ -270,10 +280,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false
@@ -350,10 +362,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The `ImageCapture` API has never been exposed in Firefox. https://bugzilla.mozilla.org/show_bug.cgi?id=888177

