### PR TITLE
Add WebView versions for IDBVersionChangeEvent API

### DIFF
--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -51,9 +51,15 @@
           "samsunginternet_android": {
             "version_added": true
           },
-          "webview_android": {
-            "version_added": true
-          }
+          "webview_android": [
+            {
+              "version_added": "≤37"
+            },
+            {
+              "version_added": "≤37",
+              "prefix": "webkit"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -100,7 +106,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -149,7 +155,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -197,7 +203,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `IDBVersionChangeEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBVersionChangeEvent
