### PR TITLE
Add WebView versions for MutationObserverInit API

### DIFF
--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -71,7 +71,10 @@
               "version_added": "1.0",
               "version_removed": "1.5"
             }
-          ]
+          ],
+          "webview_android": {
+            "version_added": "≤37"
+          }
         },
         "status": {
           "experimental": false,
@@ -117,6 +120,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -164,6 +170,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -211,6 +220,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -258,6 +270,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -305,6 +320,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -350,6 +368,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -395,6 +416,9 @@
             },
             "samsunginternet_android": {
               "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `MutationObserverInit` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationObserverInit
