### PR TITLE
Add WebView versions for WebGLShaderPrecisionFormat API

### DIFF
--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -38,7 +38,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -133,7 +133,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `WebGLShaderPrecisionFormat` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGLShaderPrecisionFormat
