### PR TITLE
Add WebView versions for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2126,7 +2126,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -393,7 +393,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "webkit"
               }
             ]
@@ -472,7 +472,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "webkit"
               }
             ]
@@ -551,7 +551,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "webkit"
               }
             ]
@@ -958,7 +958,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2126,7 +2126,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -3208,7 +3208,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -3528,7 +3528,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -4709,7 +4709,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {
@@ -5081,7 +5081,7 @@
               }
             ],
             "webview_android": {
-              "version_added": "37"
+              "version_added": false
             }
           },
           "status": {
@@ -5164,7 +5164,7 @@
               }
             ],
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -5308,7 +5308,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -7365,7 +7365,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -9482,7 +9482,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window
