### PR TITLE
iOS Safari 12.2 supports display-mode: standalone

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -574,7 +574,7 @@
                 "version_added": "13"
               },
               "safari_ios": {
-                "version_added": "13"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Background:
Working on a ticket on a hobby project where I still support iOS 10.3 and 12.4 (since they're device EoL versions).
Was expecting `(display-mode: standalone)` not to work on the latter, but to my surprise it did! (iPhone 5s / iOS 12.5).
Double-checked 12.2 (but not any lower) in a simulator as I recall it was the release in the 12 series that added PWA changes according to https://medium.com/@firt/whats-new-on-ios-12-2-for-progressive-web-apps-75c348f8e945 and it's indeed there.

User-Agent: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1`
Screenshot of my media query in action from Safari debugger on this user agent:
<img width="1092" alt="Screen Shot 2020-12-28 at 18 56 11" src="https://user-images.githubusercontent.com/427364/103250028-ed6c5800-493f-11eb-9616-c091d702b52d.png">

First-time contributor, let me know if there's anything else I can provide!