### PR TITLE
Mark NetworkInformation#type and #ontypechange as supported on Firefox/Chrome

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -209,8 +209,8 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "31",
-              "alternative_name": "ontypechange"
+              "version_added": false,
+              "notes": "On Firefox, the event handler property corresponding to the <code>change</code> event is <code>ontypechange</code>."
             },
             "ie": {
               "version_added": false
@@ -237,6 +237,54 @@
           "status": {
             "experimental": true,
             "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ontypechange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/ontypechange",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -209,8 +209,8 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "On Firefox, the event handler property corresponding to the <code>change</code> event is <code>ontypechange</code>."
+              "version_added": "31",
+              "alternative_name": "ontypechange"
             },
             "ie": {
               "version_added": false
@@ -232,54 +232,6 @@
             },
             "webview_android": {
               "version_added": "50"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ontypechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/ontypechange",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
             }
           },
           "status": {
@@ -403,7 +355,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "31"
             },
             "ie": {
               "version_added": false

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -285,7 +285,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
Closes #8402

`type` and `ontypechange` is added together with the interface itself in https://bugzilla.mozilla.org/show_bug.cgi?id=960426.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
  * https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/netinfo/network_information.idl;l=31;bpv=0;bpt=0
  * https://github.com/WICG/netinfo/commit/03737022a05f6825e5e99ae514f44e00e748ef14
