### PR TITLE
Add Safari versions for api.StyleSheetList.length

### DIFF
--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `StyleSheetList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StyleSheetList/length
