### PR TITLE
Add Chromium versions for MediaQueryListEvent API

### DIFF
--- a/api/MediaQueryListEvent.json
+++ b/api/MediaQueryListEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "45"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "45"
           },
           "edge": {
             "version_added": "≤79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "32"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "32"
           },
           "safari": {
             "version_added": "14"
@@ -35,10 +35,10 @@
             "version_added": "14"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "45"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>MediaQueryListEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "≤79"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "14"
@@ -83,10 +83,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "45"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/matches",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "≤79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "14"
@@ -131,10 +131,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "45"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/media",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "edge": {
               "version_added": "≤79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "14"
@@ -179,10 +179,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "45"
             }
           },
           "status": {

--- a/api/MediaQueryListEvent.json
+++ b/api/MediaQueryListEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent",
         "support": {
           "chrome": {
-            "version_added": "45"
+            "version_added": "39"
           },
           "chrome_android": {
-            "version_added": "45"
+            "version_added": "39"
           },
           "edge": {
             "version_added": "≤79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "32"
+            "version_added": "26"
           },
           "opera_android": {
-            "version_added": "32"
+            "version_added": "26"
           },
           "safari": {
             "version_added": "14"
@@ -35,10 +35,10 @@
             "version_added": "14"
           },
           "samsunginternet_android": {
-            "version_added": "5.0"
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": "39"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>MediaQueryListEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "≤79"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -83,10 +83,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/matches",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "≤79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -131,10 +131,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/media",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "≤79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -179,10 +179,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium for the MediaQueryListEvent API, as well as corrects the WebView data, based upon commit history.  Doing some digging around, I found that the API and all of its members were available since [Chrome 39](https://storage.googleapis.com/chromium-find-releases-static/5fc.html#5fc555b830a9b5b1536e242d8754d7e507bcc75a).  Additionally, the API is [not disabled in WebView](https://source.chromium.org/chromium/chromium/src/+/master:android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt;l=1?q=not-webview-exposed&sq=&ss=chromium), and considering the `false` values had come from the initial wiki migration, I'm led to simply disregard them.
