### PR TITLE
Add Chromium versions for CanvasRenderingContext2D API hit regions

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -275,6 +275,18 @@
                     "name": "Experimental Web Platform Features"
                   }
                 ]
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             },
             "status": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -140,23 +140,29 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "45",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "canvas.hitregions.enabled"
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               },
               "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "≤79",
+                "version_added": "45",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "canvas.hitregions.enabled"
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
                   }
                 ]
               },
@@ -176,10 +182,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false
@@ -205,7 +223,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "45",
                 "flags": [
                   {
                     "type": "preference",
@@ -214,10 +232,16 @@
                 ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "edge": {
-                "version_added": "≤79",
+                "version_added": "79",
                 "flags": [
                   {
                     "type": "preference",
@@ -235,22 +259,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               }
             },
             "status": {
@@ -264,7 +288,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "45",
                 "flags": [
                   {
                     "type": "preference",
@@ -273,10 +297,16 @@
                 ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "edge": {
-                "version_added": "≤79",
+                "version_added": "79",
                 "flags": [
                   {
                     "type": "preference",
@@ -300,10 +330,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false
@@ -377,7 +419,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "45",
                 "flags": [
                   {
                     "type": "preference",
@@ -386,10 +428,16 @@
                 ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "edge": {
-                "version_added": "≤79",
+                "version_added": "79",
                 "flags": [
                   {
                     "type": "preference",
@@ -413,10 +461,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -52,7 +52,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/addHitRegion",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -61,10 +61,16 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -94,10 +100,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "safari": {
               "version_added": false
@@ -666,7 +684,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clearHitRegions",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -675,10 +693,16 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -687,7 +711,7 @@
               ]
             },
             "firefox": {
-              "version_added": "38",
+              "version_added": "30",
               "flags": [
                 {
                   "type": "preference",
@@ -696,7 +720,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "38",
+              "version_added": "30",
               "flags": [
                 {
                   "type": "preference",
@@ -708,10 +732,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "safari": {
               "version_added": false
@@ -3281,7 +3317,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/removeHitRegion",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -3290,7 +3326,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": [
               {
@@ -3329,7 +3371,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "32",
               "flags": [
                 {
                   "type": "preference",
@@ -3338,7 +3380,7 @@
               ]
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "32",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This PR adds real values for Chromium for the hit regions features of the CanvasRenderingContext2D API based upon Chromium commit history.  Tracking down the exact commit when this was added, I found it was introduced in [Chrome 45](https://storage.googleapis.com/chromium-find-releases-static/fcb.html#fcb1539c3aca167b9564907b6cf2592a1bc8cc8f), behind a flag.  Additionally, I had determined supported `addHitRegion` parameters by skimming through the [source C++ code](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc;l=1230;drc=58bee6c238631d129396b09df273b99bb0143e8b) itself to find references, along with [commit history for the `fillRule` option](https://storage.googleapis.com/chromium-find-releases-static/503.html#5031c5f9c5dc07384bf1ce00de4f924e1437864c).
