### PR TITLE
Remove api.CanvasRenderingContext2D.addHitRegion.other_hit_region_options

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -307,54 +307,6 @@
             }
           }
         },
-        "other_hit_region_options": {
-          "__compat": {
-            "description": "other hit region options",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "path": {
           "__compat": {
             "support": {


### PR DESCRIPTION
It is unclear what options this subfeature is referring to in the first place.  However, I've searched through the source code of various browsers, and have not found any other options available for the hit region options; all of the options are already defined individually.  I don't think it makes sense to keep this around.
