### PR TITLE
Add Safari versions for Console substitution strings support

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -360,10 +360,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0",
@@ -581,10 +581,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -945,10 +945,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1057,10 +1057,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0",
@@ -1596,10 +1596,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for the substitution strings functionality of the Console API in Safari, based upon mirroring from Chrome, followed by manual testing in Safari 3 and up.
