### PR TITLE
Add versions for Console worker support

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1657,7 +1657,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "31"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/Console.json
+++ b/api/Console.json
@@ -1621,10 +1621,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -1636,25 +1636,28 @@
               "version_added": "38"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": "10.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
+            },
+            "opera_android": {
+              "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "31"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds version numbers for the worker support for the Console API based upon manual testing in all of the browsers.
