### PR TITLE
ContactsManager only supported on Android

### DIFF
--- a/api/ContactsManager.json
+++ b/api/ContactsManager.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager",
         "support": {
           "chrome": {
-            "version_added": "80"
+            "version_added": false
           },
           "chrome_android": {
             "version_added": "80"
           },
           "edge": {
-            "version_added": "80"
+            "version_added": false
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "57"
           },
           "opera_android": {
             "version_added": true
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager/getProperties",
           "support": {
             "chrome": {
-              "version_added": "80"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "80"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -73,7 +73,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "57"
             },
             "safari": {
               "version_added": false
@@ -100,13 +100,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager/select",
           "support": {
             "chrome": {
-              "version_added": "80"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "80"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Changes BCD for `ContactsManager` to show that it is only supported in Android. This follows on from discussion about `navigator.contacts` in https://github.com/mdn/browser-compat-data/pull/801

Essentially this makes BCD for  `ContactsManager` match  `navigator.contacts` 

See also https://github.com/mdn/browser-compat-data/issues/7851