### PR TITLE
Add Firefox versions for CredentialUserData API

### DIFF
--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -14,10 +14,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": null
@@ -61,10 +61,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -109,10 +109,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Firefox data for the `CredentialUserData` mixin based upon data from the FederatedCredential and PasswordCredential APIs.  These two APIs are the only ones that implement the mixin, and neither of those APIs are supported in Firefox; thus, it doesn't really make sense to say that this mixin would be supported.
