### PR TITLE
Update Edge versions for CredentialUserData API

### DIFF
--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -11,7 +11,7 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -58,7 +58,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR updates the Edge data for the `CredentialUserData` mixin based upon data from the FederatedCredential and PasswordCredential APIs.  These two APIs are the only ones that implement the mixin, and neither of those APIs are supported in EdgeHTML versions of Edge; thus, it doesn't really make sense to say that this mixin would be supported in those versions.