### PR TITLE
Add Safari data for CredentialUserData API

### DIFF
--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -29,10 +29,10 @@
             "version_added": "44"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "8.0"
@@ -76,10 +76,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -124,10 +124,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR updates the Safari data for the `CredentialUserData` mixin based upon data from the FederatedCredential and PasswordCredential APIs.  These two APIs are the only ones that implement the mixin, and neither of those APIs are supported in Safari; thus, it doesn't really make sense to say that this mixin would be supported.
