### PR TITLE
adding forced-color-adjust CSS property

### DIFF
--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -1,0 +1,63 @@
+{
+  "css": {
+    "properties": {
+      "forced-color-adjust": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust",
+          "support": {
+            "chrome": {
+              "version_added": "89",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "forced-colors",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79",
+              "alternative_name": "-ms-high-contrast-adjust"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10",
+              "alternative_name": "-ms-high-contrast-adjust"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust",
           "support": {
             "chrome": {
-              "version_added": "89",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
BCD for `forced-color-adjust` as I am working on the page for MDN in https://github.com/mdn/content/issues/678

This is currently behind the `forced-colors` flag in Chrome 89, I've tested this.

The property is a standardized version of `-ms-high-contrast-adjust` which shipped in IE10 https://docs.microsoft.com/en-us/previous-versions/hh771863%28v%3dvs.85%29
