### PR TITLE
Add IE versions for CredentialUserData API

### DIFF
--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -20,7 +20,7 @@
             "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "47"
@@ -67,7 +67,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"


### PR DESCRIPTION
This PR updates the Internet Explorer data for the `CredentialUserData` mixin based upon data from the FederatedCredential and PasswordCredential APIs.  These two APIs are the only ones that implement the mixin, and neither of those APIs are supported in IE; thus, it doesn't really make sense to say that this mixin would be supported.

