### PR TITLE
Add Safari versions for api.CSSStyleSheet.insertRule.optional_index

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -270,10 +270,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": "≤4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "≤3"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
This PR adds the Safari and Safari iOS versions for the optional index parameter of the `insertRule` method of the `CSSStyleSheet` API, based upon manual testing (running `document.styleSheets[0].insertRule('p{ color: black;}');` and checking for errors).