### PR TITLE
Update Chromium versions for CanvasPattern API

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasPattern",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "6"
           },
           "chrome_android": {
             "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CanvasPattern` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasPattern
