### PR TITLE
Set Chrome versions for api.CanvasPattern.setTransform.dommatrix

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -99,13 +99,13 @@
             "description": "<code>DOMMatrix</code> parameter supported",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "68"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "68"
               },
               "edge": {
-                "version_added": true
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "79"
@@ -117,10 +117,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "55"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "safari": {
                 "version_added": true
@@ -129,10 +129,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "10.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "68"
               }
             },
             "status": {

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -96,7 +96,7 @@
         },
         "dommatrix": {
           "__compat": {
-            "description": "<code>DOMMatrix</code> parameter supported",
+            "description": "Accepts a <code>DOMMatrix2DInit</code>-like object parameter",
             "support": {
               "chrome": {
                 "version_added": "68"


### PR DESCRIPTION
This PR sets the Chromium versions for the `setTransform` method's `DOMMatrix` parameter for the `CanvasPattern` API based upon commit history.  It appears that the property was added at the same time as the method itself.

Source: https://source.chromium.org/chromium/chromium/src/+/f7028d961fb1cfd5d0f4abaecb582c61e0231c1f