### PR TITLE
Add Chromium versions for Path params of CanvasRenderingContext2D methods

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -833,10 +833,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤18"
@@ -851,10 +851,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": "7"
@@ -863,10 +863,10 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {
@@ -1379,10 +1379,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤79"
@@ -1397,10 +1397,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "safari": {
                 "version_added": true
@@ -1409,10 +1409,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {
@@ -1813,10 +1813,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤18"
@@ -1831,10 +1831,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": false
@@ -1843,10 +1843,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {
@@ -2582,10 +2582,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤18"
@@ -2600,10 +2600,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": false
@@ -2612,10 +2612,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {
@@ -2692,10 +2692,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "79"
@@ -2710,10 +2710,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": false
@@ -2722,10 +2722,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {
@@ -4066,10 +4066,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤18"
@@ -4084,10 +4084,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": false
@@ -4096,10 +4096,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -833,10 +833,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "≤18"
@@ -851,10 +851,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": "7"
@@ -863,10 +863,10 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {
@@ -1379,10 +1379,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "≤79"
@@ -1397,10 +1397,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": true
@@ -1409,10 +1409,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {
@@ -1813,10 +1813,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "≤18"
@@ -1831,10 +1831,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": false
@@ -1843,10 +1843,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {
@@ -2582,10 +2582,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "≤18"
@@ -2600,10 +2600,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": false
@@ -2612,10 +2612,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {
@@ -2692,10 +2692,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "79"
@@ -2710,10 +2710,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": false
@@ -2722,10 +2722,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {
@@ -4066,10 +4066,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "≤18"
@@ -4084,10 +4084,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "23"
               },
               "safari": {
                 "version_added": false
@@ -4096,10 +4096,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "36"
               }
             },
             "status": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1379,10 +1379,10 @@
             "description": "<code>Path</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "chrome_android": {
-                "version_added": "36"
+                "version_added": "37"
               },
               "edge": {
                 "version_added": "≤79"
@@ -1397,7 +1397,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "opera_android": {
                 "version_added": "24"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -854,7 +854,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "7"
@@ -866,7 +866,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {
@@ -1400,7 +1400,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": true
@@ -1412,7 +1412,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {
@@ -1834,7 +1834,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": false
@@ -1846,7 +1846,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {
@@ -2603,7 +2603,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": false
@@ -2615,7 +2615,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {
@@ -2713,7 +2713,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": false
@@ -2725,7 +2725,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {
@@ -4087,7 +4087,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": false
@@ -4099,7 +4099,7 @@
                 "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "36"
+                "version_added": "37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds Chromium versions for the `Path` parameters of various methods (`fill`, `stroke`, `drawFocusIfNeeded`, `clip`, `isPointInPath`, `isPointInStroke`) of the CanvasRenderingContext2D API, based upon commit history and dates.  By seeing the commit date and comparing it to the feature freeze for the Chrome versions, I've found that support was [enabled by default in Chrome 39](https://source.chromium.org/chromium/chromium/src/+/9a0ff42f9f7b5b5100bb57a77ff06456f01eaa27).