### PR TITLE
Add Intl.Collator option for collation

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -205,7 +205,7 @@
                     "version_added": false
                   },
                   "webview_android": {
-                    "version_added": false
+                    "version_added": "87"
                   }
                 },
                 "status": {

--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -163,6 +163,57 @@
                   "deprecated": false
                 }
               }
+            },
+            "collation": {
+              "__compat": {
+                "description": "<code>collation</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "87"
+                  },
+                  "chrome_android": {
+                    "version_added": "87"
+                  },
+                  "edge": {
+                    "version_added": "87"
+                  },
+                  "firefox": {
+                    "version_added": "85"
+                  },
+                  "firefox_android": {
+                    "version_added": "85"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "15.0.0"
+                  },
+                  "opera": {
+                    "version_added": "73"
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "compare": {


### PR DESCRIPTION
Support for a `collation` option was added to the Intl.Collator constructor. 
- MDN bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1670062
- Docs tracking: https://github.com/mdn/content/issues/293
- Spec: https://github.com/tc39/ecma402/pull/459

From spec and testing verify that this is in FF85, Chrome 87. Also tested that it is in nodejs 15. Have applied to various android builds based on that. Note - Opera android and samsung android are false because they don't  yet have builds. 

Not sure about Webkit. I know it is present from safari 114 but not sure how this maps to BCD builds - search on collation under https://developer.apple.com/safari/technology-preview/release-notes/#r114

My test code for this is as below - on supported builds the collation will be shown as 'phonebk'
```
var options = Intl.Collator('de',{collation: 'phonebk'}).resolvedOptions();
for (var property in options) {
  console.log(property + ': ' + options[property]);
}
```

@ddbeck FYI

