### PR TITLE
Add Chromium versions for api.CanvasRenderingContext2D.currentTransform

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1123,6 +1123,7 @@
           "support": {
             "chrome": {
               "version_added": "32",
+              "version_removed": "68",
               "flags": [
                 {
                   "type": "preference",
@@ -1132,6 +1133,7 @@
             },
             "chrome_android": {
               "version_added": "32",
+              "version_removed": "68",
               "flags": [
                 {
                   "type": "preference",
@@ -1140,7 +1142,8 @@
               ]
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤18",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false,
@@ -1154,6 +1157,7 @@
             },
             "opera": {
               "version_added": "19",
+              "version_removed": "55",
               "flags": [
                 {
                   "type": "preference",
@@ -1163,6 +1167,7 @@
             },
             "opera_android": {
               "version_added": "19",
+              "version_removed": "48",
               "flags": [
                 {
                   "type": "preference",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1122,7 +1122,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/currentTransform",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "32",
               "flags": [
                 {
                   "type": "preference",
@@ -1131,7 +1131,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "edge": {
               "version_added": "≤18"
@@ -1147,10 +1153,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "19",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "19",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "safari": {
               "version_added": false,


### PR DESCRIPTION
This PR adds Chromium versions for the CanvasRenderingContext2D API's `currentTransform` attribute based upon commit history.  Finding the [commit to add this feature](https://source.chromium.org/chromium/chromium/src/+/59ad6176c26b21afd28c5c64d0f294d3a72c52a6), I have mapped it to Chrome 32 as per its date and the according feature freeze.
