### PR TITLE
Add Chromium versions for api.CanvasRenderingContext2D.drawImage.ImageBitmap_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1475,10 +1475,10 @@
             "description": "ImageBitmap as source image",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "79"
@@ -1493,10 +1493,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "safari": {
                 "version_added": null
@@ -1505,10 +1505,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds the Chromium versions for the ability to use an `ImageBitmap` as the source image for the `drawImage` method of the `CanvasRenderingContext2D` API, based upon its commit history.  Tracking down the [commit](https://source.chromium.org/chromium/chromium/src/+/8452e4d3b98f4a3fa247b498a8535c86f0db55bc), I mapped it to Chrome 30 based upon the date of the commit and the feature freeze.  I double-checked and determined that the flag it's under was enabled by default before this commit (https://source.chromium.org/chromium/chromium/src/+/0a4bce1f3e2fceefbe972b9332c526939036ab97).
