### PR TITLE
Add/update Chromium data for api.CanvasRenderingContext2D.imageSmoothingEnabled

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2421,14 +2421,21 @@
                 "version_added": "30"
               },
               {
-                "version_added": true,
+                "version_added": "21",
                 "version_removed": "30",
                 "prefix": "webkit"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "30",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": "15"
             },
@@ -2456,21 +2463,42 @@
               "version_added": true,
               "prefix": "ms"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "17",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "18"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "18",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": {
               "version_added": "9.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "2.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": {
               "version_added": "4.4"
             }


### PR DESCRIPTION
This PR adds the Chromium version for the prefixed version of the `imageSmoothingEnabled` attribute of the `CanvasRenderingContext2D` API based upon commit history, as well as copies the data to other Chromium browsers.  Based upon the [commit](https://source.chromium.org/chromium/chromium/src/+/a2112e8cdfbb4888002ce3dff9f90c3e48936003) date, I've determined that it had been added in Chrome 21.
