### PR TITLE
Add Chromium versions for api.CanvasRenderingContext2D.scrollPathIntoView

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -3611,7 +3611,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/scrollPathIntoView",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "36",
               "flags": [
                 {
                   "type": "preference",
@@ -3620,7 +3620,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "36",
               "flags": [
                 {
                   "type": "preference",
@@ -3647,7 +3647,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "23",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This PR adds the Chrome version for the `scrollPathIntoView` method of the `CanvasRenderingContext2D` API, based upon commit history.  By comparing the date of the [commit](https://source.chromium.org/chromium/chromium/src/+/f94c41e4874a70302feaa543be31a6c9c36323cd) to the feature freeze dates of Chrome, I've determined that this method was added in Chrome 36 behind the flag.
