### PR TITLE
Add Chromium versions for api.DOMTokenList.toggle.force_argument

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -772,10 +772,10 @@
             "description": "<code>force</code> argument",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "25"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "≤18"
@@ -790,10 +790,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "6.1"
@@ -802,10 +802,10 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -772,10 +772,10 @@
             "description": "<code>force</code> argument",
             "support": {
               "chrome": {
-                "version_added": "25"
+                "version_added": "24"
               },
               "chrome_android": {
-                "version_added": "25"
+                "version_added": "24"
               },
               "edge": {
                 "version_added": "≤18"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `toggle.force_argument` member of the `DOMTokenList` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/7f56e8d21f5ca85c05c41251c28dfdb4a71bca0a
