### PR TITLE
Add Chromium versions for api.Document.createElement.options

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2049,11 +2049,11 @@
             "description": "<code>options</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
@@ -2072,11 +2072,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "43",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "43",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
@@ -2086,11 +2086,11 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true,
+                "version_added": "6.0",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               }
             },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createElement.options` member of the `Document` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/fc1.html#fc17d505758c284f99624ac69b6e2fb72ea7b623
