### PR TITLE
Add Chromium versions for BeforeUnloadEvent API

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "edge": {
             "version_added": "12"
@@ -23,10 +23,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "17"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "safari": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BeforeUnloadEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/b883f78f288ac454f476487e6ca458c1f8ee8981
