### PR TITLE
Add Safari versions for api.MediaQueryList.EventListener_objects

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `EventListener_objects` member of the `MediaQueryList` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/dc95aca04b6b10c4023c14921fad1463c4bb5f0a#diff-d1998af1820803564b137487dc59bba1a9dbc682eb764335351af22f02463818
