### PR TITLE
Add Firefox versions for api.DOMTokenList.toggle.force_argument

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -781,10 +781,10 @@
                 "version_added": "≤18"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "24"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "24"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `toggle.force_argument` member of the `DOMTokenList` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/814090
