### PR TITLE
Add Safari versions for HTMLBaseFontElement API

### DIFF
--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -31,11 +31,11 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "≤4",
+            "version_added": "1",
             "version_removed": "10"
           },
           "safari_ios": {
-            "version_added": "≤3",
+            "version_added": "1",
             "version_removed": "10"
           },
           "samsunginternet_android": {
@@ -82,11 +82,11 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10"
             },
             "samsunginternet_android": {
@@ -134,11 +134,11 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10"
             },
             "samsunginternet_android": {
@@ -186,11 +186,11 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10"
             },
             "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLBaseFontElement` API, based upon manual testing.

Test Code Used: `document.createElement('basefont')`
