### PR TITLE
Add Safari versions for HTMLDirectoryElement API

### DIFF
--- a/api/HTMLDirectoryElement.json
+++ b/api/HTMLDirectoryElement.json
@@ -28,10 +28,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -74,10 +74,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLDirectoryElement` API, based upon manual testing.

Test Code Used: `document.createElement('dir')`
