### PR TITLE
Add Manifest V3 for Chrome

### DIFF
--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -91,7 +91,7 @@
             "description": "Version 3",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Fixes #8474

Manifest Version 3 on Chrome Extensions deprecates multiple features in the manifest and `chrome` API and is still a work in progress. It is being released in Chrome 88.

https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/