### PR TITLE
Add Safari versions for HTMLHeadElement API

### DIFF
--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -29,7 +29,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLHeadElement` API, based upon manual testing.

Test Code Used: `document.createElement('head')`
