### PR TITLE
Add Safari versions for HTMLHtmlElement API

### DIFF
--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -29,7 +29,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -75,10 +75,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLHtmlElement` API, based upon manual testing.

Test Code Used: `document.createElement('html')`
