### PR TITLE
Add Safari versions for HTMLLIElement API

### DIFF
--- a/api/HTMLLIElement.json
+++ b/api/HTMLLIElement.json
@@ -31,7 +31,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -77,7 +77,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "≤3"
@@ -124,10 +124,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLLIElement` API, based upon manual testing.

Test Code Used: `document.createElement('li')`
