### PR TITLE
Add Safari versions for MediaList API

### DIFF
--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -172,10 +172,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -220,10 +220,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -268,10 +268,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaList` API, based upon manual testing.

Test Code Used: `document.styleSheets[0].media`
