### PR TITLE
Add Safari versions for SVGCursorElement API

### DIFF
--- a/api/SVGCursorElement.json
+++ b/api/SVGCursorElement.json
@@ -33,10 +33,10 @@
             "version_removed": "43"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGCursorElement` API, based upon manual testing.

Test Code Used: `document.createElementNS('http://www.w3.org/2000/svg', 'cursor')`
