### PR TITLE
Add Safari versions for SVGMetadataElement API

### DIFF
--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -29,10 +29,10 @@
             "version_added": "15"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGMetadataElement` API, based upon manual testing.

Test Code Used: `document.createElementNS('http://www.w3.org/2000/svg', 'metadata')`
