### PR TITLE
Add Safari versions for SVGViewElement API

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGViewElement` API, based upon manual testing.

Test Code Used: `document.createElementNS('http://www.w3.org/2000/svg', 'view')`
