### PR TITLE
Add Safari versions for HTMLOptionElement API

### DIFF
--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -29,7 +29,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1.2"
           },
           "safari_ios": {
             "version_added": "1"
@@ -77,10 +77,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLOptionElement` API, based upon manual testing.

Test Code Used: `document.createElement('option'); var o = new Option();`
