### PR TITLE
Add Safari versions for ApplicationCache API

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -33,10 +33,10 @@
             "version_removed": "60"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "3.1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -136,10 +136,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -188,10 +188,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -240,10 +240,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -292,10 +292,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -344,10 +344,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -396,10 +396,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -448,10 +448,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -500,10 +500,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -552,10 +552,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -604,10 +604,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -656,10 +656,10 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ApplicationCache` API, based upon manual testing.

Test Code Used: `'ApplicationCache' in self`
