### PR TITLE
Add Safari versions for CDATASection API

### DIFF
--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -26,10 +26,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "webview_android": {
             "version_added": "≤37"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CDATASection` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/CDATASection
