### PR TITLE
Add Safari versions for CSSFontFaceRule API

### DIFF
--- a/api/CSSFontFaceRule.json
+++ b/api/CSSFontFaceRule.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CSSFontFaceRule` API, based upon manual testing.

Test Code Used: `https://mdn-bcd-collector.appspot.com/tests/api/CSSFontFaceRule`
