### PR TITLE
Add Safari versions for CSSValueList API

### DIFF
--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -31,7 +31,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -80,7 +80,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CSSValueList` API, based upon manual testing.

Test Code Used: `'CSSValueList' in self`
