### PR TITLE
Add Safari versions for Comment API

### DIFF
--- a/api/Comment.json
+++ b/api/Comment.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Comment` API, based upon manual testing.

Test Code Used: `'Comment' in self`
