### PR TITLE
Add Safari versions for DocumentType API

### DIFF
--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -83,11 +83,11 @@
               "version_removed": "21"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10"
             },
             "samsunginternet_android": {
@@ -140,11 +140,11 @@
               "version_removed": "24"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
@@ -192,10 +192,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -247,11 +247,11 @@
               "version_removed": "21"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "10"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10"
             },
             "samsunginternet_android": {
@@ -299,10 +299,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -347,10 +347,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `DocumentType` API, based upon manual testing.

Test Code Used: `document.doctype;`
