### PR TITLE
Add Safari versions for File API

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -43,10 +43,10 @@
             "version_added": "11.5"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `File` API, based upon manual testing.

Test Code Used: `'File' in self`
