### PR TITLE
Add Safari versions for FileList API

### DIFF
--- a/api/FileList.json
+++ b/api/FileList.json
@@ -32,7 +32,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `FileList` API, based upon manual testing.

Test Code Used: `'FileList' in self`
