### PR TITLE
Add Safari versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -29,7 +29,7 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1.3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -2378,10 +2378,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLMediaElement` API, based upon manual testing.

Test Code Used: `HTMLMediaElement`
