### PR TITLE
Add Safari versions for NavigatorOnLine API

### DIFF
--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -29,10 +29,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,10 +81,10 @@
               "notes": "From Opera 11.1 until Opera 12.1, the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `NavigatorOnLine` API, based upon manual testing.

Test Code Used: `navigator.onLine`
