### PR TITLE
Add Safari versions for Node API

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -33,7 +33,7 @@
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "safari": {
-            "version_added": "1.1",
+            "version_added": "1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "safari_ios": {
@@ -349,10 +349,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -647,11 +647,11 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "7"
             },
             "samsunginternet_android": {
@@ -697,7 +697,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -841,7 +841,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -889,7 +889,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -949,7 +949,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1003,7 +1003,7 @@
               "version_removed": "21"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10"
             },
             "safari_ios": {
@@ -1113,11 +1113,11 @@
               "version_removed": "33"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
@@ -1167,7 +1167,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1215,7 +1215,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1273,11 +1273,11 @@
               "version_removed": "33"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
@@ -1519,7 +1519,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1742,11 +1742,11 @@
               "version_removed": "21"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "10.3"
             },
             "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Node` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/Node`
