### PR TITLE
Add Safari versions for Notation API

### DIFF
--- a/api/Notation.json
+++ b/api/Notation.json
@@ -29,11 +29,11 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "≤4",
+            "version_added": "3",
             "version_removed": "9"
           },
           "safari_ios": {
-            "version_added": "≤3",
+            "version_added": "1",
             "version_removed": "9"
           },
           "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Notation` API, based upon manual testing.

Test Code Used: `'Notation' in self`
