### PR TITLE
Add Safari versions for PluginArray API

### DIFF
--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,10 +81,10 @@
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -184,10 +184,10 @@
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -239,10 +239,10 @@
               "notes": "Since Opera Android 43, method parameters are required instead of optional."
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PluginArray` API, based upon manual testing.

Test Code Used: `navigator.plugins`
