### PR TITLE
Add Safari versions for SVGElement API

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -269,10 +269,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -419,11 +419,11 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "11"
             },
             "samsunginternet_android": {
@@ -474,11 +474,11 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "11"
             },
             "samsunginternet_android": {
@@ -529,11 +529,11 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "11"
             },
             "samsunginternet_android": {
@@ -584,11 +584,11 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "11"
             },
             "samsunginternet_android": {
@@ -639,11 +639,11 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "11"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "11"
             },
             "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGElement` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/SVGElement`
