### PR TITLE
Add Safari versions for SVGPreserveAspectRatio API

### DIFF
--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -75,10 +75,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -122,10 +122,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGPreserveAspectRatio` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/SVGPreserveAspectRatio`
