### PR TITLE
Add Safari versions for SVGTextPathElement API

### DIFF
--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -75,10 +75,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -122,10 +122,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -169,10 +169,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGTextPathElement` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/SVGTextPathElement`
