### PR TITLE
Add Safari versions for SVGUseElement API

### DIFF
--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -80,11 +80,11 @@
               "version_removed": "24"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "9"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "9"
             },
             "samsunginternet_android": {
@@ -131,10 +131,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -183,11 +183,11 @@
               "version_removed": "24"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3",
               "version_removed": "9"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "version_removed": "9"
             },
             "samsunginternet_android": {
@@ -234,10 +234,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -281,10 +281,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -328,10 +328,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGUseElement` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/SVGUseElement`
