### PR TITLE
Add Safari versions for Text API

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -26,10 +26,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "webview_android": {
             "version_added": true
@@ -224,11 +224,11 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "4",
               "version_removed": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "3",
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
@@ -280,11 +280,11 @@
               "notes": "Before Opera 17, the <code>offset</code> argument was optional."
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "1",
               "notes": "The <code>offset</code> argument is optional."
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "1",
               "notes": "The <code>offset</code> argument is optional."
             },
             "samsunginternet_android": {
@@ -329,10 +329,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3.2"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Text` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/Text`
