### PR TITLE
Add Safari versions for TimeRanges API

### DIFF
--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -29,10 +29,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,10 +124,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -172,10 +172,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `TimeRanges` API, based upon manual testing.

Test Code Used: `http://mdn-bcd-collector.appspot.com/tests/api/TimeRanges`
