### PR TITLE
Safari support for ::marker is limited to color and font-size

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -64,10 +64,14 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11.1",
+              "partial_implementation": true,
+              "notes": "Safari support is limited to color and font-size. See: <a href='http://webkit.org/b/204163'>#204163</a>"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "Safari support is limited to color and font-size. See: <a href='http://webkit.org/b/204163'>#204163</a>"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -66,7 +66,7 @@
             "safari": {
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Safari support is limited to color and font-size. See: <a href='https://webkit.org/b/204163'>#204163</a>"
+              "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>"
             },
             "safari_ios": {
               "version_added": "11.3",

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -71,7 +71,7 @@
             "safari_ios": {
               "version_added": "11.3",
               "partial_implementation": true,
-              "notes": "Safari support is limited to color and font-size. See: <a href='https://webkit.org/b/204163'>#204163</a>"
+              "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -66,12 +66,12 @@
             "safari": {
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Safari support is limited to color and font-size. See: <a href='http://webkit.org/b/204163'>#204163</a>"
+              "notes": "Safari support is limited to color and font-size. See: <a href='https://webkit.org/b/204163'>#204163</a>"
             },
             "safari_ios": {
               "version_added": "11.3",
               "partial_implementation": true,
-              "notes": "Safari support is limited to color and font-size. See: <a href='http://webkit.org/b/204163'>#204163</a>"
+              "notes": "Safari support is limited to color and font-size. See: <a href='https://webkit.org/b/204163'>#204163</a>"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Fixes: https://github.com/mdn/content/issues/984

BCD indicated that `::marker` was fully supported in Safari, where in fact only a subset of properties are supported.
