### PR TITLE
Add Safari versions for HTMLElement API

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -29,7 +29,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1.3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -2312,10 +2312,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `HTMLElement` API, based upon manual testing.

Test Code Used: `document.createElement('element')`