### PR TITLE
Add Safari versions for Location API

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -761,10 +761,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Location` API, based upon manual testing.

Test Code Used: `window.location`
