### PR TITLE
Add Safari versions for NodeList API

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -29,7 +29,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `NodeList` API, based upon manual testing.

Test Code Used: `document.childNodes`