### PR TITLE
Add Safari versions for SVGAnimatedPoints API

### DIFF
--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -31,10 +31,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGAnimatedPoints` API, based upon manual testing.

Test Code Used: `var instance = document.createElementNS('http://www.w3.org/2000/svg', 'polygon')`