### PR TITLE
minor typo fix

### DIFF
--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -119,7 +119,7 @@
               },
               "firefox": {
                 "version_added": "47",
-                "notes": "Firefox 55 and earlier returns a language tag that's seperated with the underscore character instead of hyphen, see <a href='https://bugzil.la/1374552'>bug 1374552</a>."
+                "notes": "Firefox 55 and earlier returns a language tag that's separated with the underscore character instead of hyphen, see <a href='https://bugzil.la/1374552'>bug 1374552</a>."
               },
               "firefox_android": {
                 "version_added": "48"


### PR DESCRIPTION
Only fix the typo on i18n.json ("seperated" -> "seperated").
Closes #8673 
