### PR TITLE
add BCD for HTMLPortalElement

### DIFF
--- a/api/HTMLPortalElement.json
+++ b/api/HTMLPortalElement.json
@@ -1,0 +1,68 @@
+{
+  "api": {
+    "HTMLPortalElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLPortalElement",
+        "support": {
+          "chrome": {
+            "version_added": "85",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-portals",
+                "value_to_set": "enabled"
+              }
+            ],
+            "notes": "See <a href='https://www.chromestatus.com/feature/4828882419056640'>Chrome Platform Status</a>."
+          },
+          "chrome_android": {
+            "version_added": "85",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-portals",
+                "value_to_set": "enabled"
+              }
+            ],
+            "notes": "See <a href='https://www.chromestatus.com/feature/4828882419056640'>Chrome Platform Status</a>."
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The API HTMLPortalElement is behind a flag in Chrome.

- https://web.dev/hands-on-portals/
- https://wicg.github.io/portals/

I'm writing the docs for it, at the moment the MDN page doesn't exist.