### PR TITLE
Add note about nightly-only for private_class_fields (fixed #7446)

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -489,7 +489,8 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "81",
+              "version_added": false,
+              "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1562054'>bug 1562054</a>.",
               "flags": [
                 {
                   "type": "preference",
@@ -504,7 +505,8 @@
               ]
             },
             "firefox_android": {
-              "version_added": "81",
+              "version_added": false,
+              "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1562054'>bug 1562054</a>.",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Private class fields are enabled only in nightly, behind pref.
https://searchfox.org/mozilla-central/rev/1d34bd022de0b55c81d9db6026f69bda1d4a86d2/js/xpconnect/src/XPCJSContext.cpp#1017-1020

Like other nightly-only feature, added `"notes": "Available only in nightly builds.",`.

