### PR TITLE
Add Opera Android version for CSS @property

### DIFF
--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -28,7 +28,7 @@
               "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Fixes: https://github.com/mdn/content/issues/1102

Issue reported that Opera Android had support, this seems to be from version 60 based on Chromium 85.