### PR TITLE
Close incomplete issue templates with GitHub Actions

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -1,0 +1,15 @@
+name: Close incomplete issue templates
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  close-issues-if-invalid:
+    steps:
+      - uses: ddbeck/invalid-issue-closer@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'invalid :no_entry_sign:'
+          comment: 'This issue was automatically closed because it appears that the issue template has not been completed. If this has been closed in error, edit the title and body, and post a follow-up comment.'
+          title-contains: '<PUT TITLE HERE>'
+          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n\r\n#### What did you expect to see?\r\n\r\n#### Did you test this? If so, how?\r\n\r\n"

--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -10,6 +10,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'invalid :no_entry_sign:'
-          comment: 'This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided. If this has been closed in error, edit the title and body, and post a follow-up comment.'
+          comment: |
+            This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
+
+            If this has been closed in error, edit the title and body, and post a follow-up comment.
           title-contains: '<PUT TITLE HERE>'
           body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n\r\n#### What did you expect to see?\r\n\r\n#### Did you test this? If so, how?\r\n\r\n"

--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -10,6 +10,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'invalid :no_entry_sign:'
-          comment: 'This issue was automatically closed because it appears that the issue template has not been completed. If this has been closed in error, edit the title and body, and post a follow-up comment.'
+          comment: 'This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided. If this has been closed in error, edit the title and body, and post a follow-up comment.'
           title-contains: '<PUT TITLE HERE>'
           body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n\r\n#### What did you expect to see?\r\n\r\n#### Did you test this? If so, how?\r\n\r\n"


### PR DESCRIPTION
This is my attempt to solve the nuisance issue problem.

## Background

I spent some quality time with GitHub Actions today. I checked for prior art and couldn't find anything that had the behavior we were looking for. I also started out trying to avoid creating a custom action with [actions/github-script](https://github.com/actions/github-script) but soon found that the logic was more complex than I wanted to stuff into a YAML string. I also found that there's no good way to have a per-repo action.

So I've created [ddbeck/invalid-issue-closer](https://github.com/ddbeck/invalid-issue-closer) to house this code. I _strongly_ recommend you take a look at the repo there to see what madness I've wrought. It's not that bad, actually; it's mostly derived from GitHub's own [actions/javascript-action](https://github.com/actions/javascript-action) template.

Putting this code outside the repo does present a visibility and security problem (I could conceivably do malicious things in the action such that nobody would notice, unless they were closely monitoring the action repo). We could mitigate that by pinning the workflow to a specific hash of ddbeck/invalid-issue-closer.

## Here's what will happen if we merge this

If you open an issue containing:

* `<PUT TITLE HERE>`
* mostly unmodified text from the MDN report-a-problem link

then

1. the issue is closed
2. the invalid label is applied
3. a comment is added explaining why and what to do about it

This workflow only triggers on new issues (so you can force an issue to stay open by reopening it, regardless of the title and body). Also, the workflow only closes the issue if both the title and body criteria are met, so if you write a detailed description, but forget to modify the title, you won't be penalized. I think this represents a good compromise between kindness to real contributors and keeping the noise level down.

This fixes #8017, hopefully.