### PR TITLE
Add mdn_url for HTMLElement.enterKeyHint

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -830,6 +830,7 @@
         }
       },
       "enterKeyHint": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/enterKeyHint",
         "__compat": {
           "support": {
             "chrome": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -830,8 +830,8 @@
         }
       },
       "enterKeyHint": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/enterKeyHint",
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/enterKeyHint",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
Adding docs in https://github.com/mdn/content/pull/1190, so this should have an `mdn_url`.