### PR TITLE
Add ClientRect variant of DOMRect for Firefox

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -19,12 +19,26 @@
               "version_added": "12"
             }
           ],
-          "firefox": {
-            "version_added": "27"
-          },
-          "firefox_android": {
-            "version_added": "27"
-          },
+          "firefox": [
+            {
+              "version_added": "27"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "3",
+              "version_removed": "27"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "27"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "4",
+              "version_removed": "27"
+            }
+          ],
           "ie": [
             {
               "version_added": false


### PR DESCRIPTION
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8797 was
used to check that ClientRect was supported in Firefox 26, and also
manually checked that it wasn't there in Firefox 27.

The version_added versions are taken from
api.Element.getBoundingClientRect, which is assumed to be correct.

Follow-up to https://github.com/mdn/browser-compat-data/pull/7694.