### PR TITLE
Add Safari support for Animation.currentTime/play/pause. Fixes #7992

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -350,10 +350,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -916,10 +916,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1090,10 +1090,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This addresses #7992 by indicating that Animation.currentTime/play/pause support was introduced in Safari 13.1 (and mobile Safari 13.4). It's likely that there are probably more properties of Animation available in Safari, but these are the ones I was able to verify (as detailed in the ticket)