### PR TITLE
Safari supports pointerenter events since version 13

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2570,10 +2570,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
It seems that Safari supports pointerevnts since version 13 ( https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes ). I just updated the related json file. I have not test it yet on a real device. 
Related issue: https://github.com/mdn/browser-compat-data/issues/8709