### PR TITLE
Add ClientRect variant of DOMRect for Safari

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -40,12 +40,26 @@
           "opera_android": {
             "version_added": "45"
           },
-          "safari": {
-            "version_added": "10.1"
-          },
-          "safari_ios": {
-            "version_added": "10.3"
-          },
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "4",
+              "version_removed": "11"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.3"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "3.2",
+              "version_removed": "11"
+            }
+          ],
           "samsunginternet_android": {
             "version_added": "8.0"
           },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3951,10 +3951,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "4",
+              "version_added": "3.2",
               "notes": "Safari for iOS will modify the effective viewport based on the user zoom. This results in incorrect values whenever the user has zoomed."
             },
             "samsunginternet_android": {
@@ -4190,10 +4190,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This was added with the implementation of Element.getBoundingClientRect
and Element.getClientRects:
https://trac.webkit.org/changeset/40837/webkit

Also checked but already correct was the addition of
Range.getClientRects/getBoundingClientRect, which came slightly later:
https://trac.webkit.org/changeset/48806/webkit

For the removal date, the transition to DOMRect for these APIs was used:
https://trac.webkit.org/changeset/215892/webkit
https://trac.webkit.org/changeset/215946/webkit

Indeed DOMRect was added some time before this:
https://trac.webkit.org/changeset/207438/webkit

The Safari versions are derived using the method in
https://developer.mozilla.org/en-US/docs/MDN/Contribute/Processes/Matching_features_to_browser_version#safari

Finally, http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8797
was tested in Safari 4 to verify it was supported then. It couldn't have
been in Safari 3.2 since that was released before the change itself.

Similar to https://github.com/mdn/browser-compat-data/pull/8711.