### PR TITLE
Add ClientRect variant of DOMRect for Chromium browsers

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -4,19 +4,34 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRect",
         "support": {
-          "chrome": {
-            "version_added": "61"
-          },
-          "chrome_android": {
-            "version_added": "61"
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "2",
+              "version_removed": "61"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "18",
+              "version_removed": "61"
+            }
+          ],
           "edge": [
             {
               "version_added": "79"
             },
             {
               "alternative_name": "ClientRect",
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             }
           ],
           "firefox": [
@@ -39,21 +54,30 @@
               "version_removed": "27"
             }
           ],
-          "ie": [
+          "ie": {
+            "alternative_name": "ClientRect",
+            "version_added": "4"
+          },
+          "opera": [
             {
-              "version_added": false
+              "version_added": "48"
             },
             {
               "alternative_name": "ClientRect",
-              "version_added": true
+              "version_added": "9.5",
+              "version_removed": "48"
             }
           ],
-          "opera": {
-            "version_added": "48"
-          },
-          "opera_android": {
-            "version_added": "45"
-          },
+          "opera_android": [
+            {
+              "version_added": "45"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "10.1",
+              "version_removed": "45"
+            }
+          ],
           "safari": [
             {
               "version_added": "10.1"
@@ -74,12 +98,26 @@
               "version_removed": "11"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": "8.0"
-          },
-          "webview_android": {
-            "version_added": "61"
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "8.0"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "1.0",
+              "version_removed": "8.0"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "2",
+              "version_removed": "61"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/Element.json
+++ b/api/Element.json
@@ -3961,7 +3961,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "2"
             }
           },
           "status": {
@@ -4199,7 +4199,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "2"
             }
           },
           "status": {


### PR DESCRIPTION
ClientRect was replaced by DOMRect in Chromium 61:
https://storage.googleapis.com/chromium-find-releases-static/f01.html#f01e385c3f752c2bfd1163db74ecbf88e5390d25

The addition of ClientRect is more complicated, as it goes back to
WebKit, Presto and Trident.

WebKit: https://trac.webkit.org/changeset/40837/webkit

WebKit trunk then had version 530.0.0:
https://trac.webkit.org/browser/webkit/trunk/WebCore/Configurations/Version.xcconfig?rev=40837

The versions for Chrome, Samsung Internet and WebView are
based on that WebKit version.

For Trident/Presto, the data for api.Element.getBoundingClientRect is
trusted, giving IE 4 and Opera 9.5 as the version_added.

The getBoundingClientRect version for WebView is also updated to match,
where WebView cannot be right because it was released before the change
to WebKit trunk.

Similar to https://github.com/mdn/browser-compat-data/pull/8714.