### PR TITLE
Add required runs-on key to invalid issue workflow

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   close-issues-if-invalid:
+    runs-on: ubuntu-latest
     steps:
       - uses: ddbeck/invalid-issue-closer@v1
         with:


### PR DESCRIPTION
This is a minor follow up to https://github.com/mdn/browser-compat-data/pull/8703. I forgot to include one of the (two) required keys in the workflow file. I wish there was a way to validate GitHub Actions workflows ahead of time.

In the interest of not annoying @Elchi3 too much on this, I'm going to self-merge this, but I'm tagging him so that it's clear I'm not trying to sneak anything past anyone. 😄
