### PR TITLE
Fix Chrome + Samsung Internet versions for TextTrackCue

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue",
         "support": {
           "chrome": {
-            "version_added": "9"
+            "version_added": "23"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤79"
@@ -35,7 +35,7 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/endTime",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -82,7 +82,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -101,10 +101,10 @@
           "description": "<code>enter</code> event",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -150,10 +150,10 @@
           "description": "<code>exit</code> event",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -198,10 +198,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/id",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -228,7 +228,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -340,10 +340,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/pauseOnExit",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -370,7 +370,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/startTime",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -418,7 +418,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -436,10 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/track",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -466,7 +466,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This was definitely wrong, because Chrome 9 was shipped before
https://trac.webkit.org/changeset/97926/webkit which added this
interface to WebKit.

http://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue was tested
in Chrome 22 and 23 to confirm.

The new data is consitent with data for HTMLTrackElement, TextTrack and
other APIs that all go together for the basic <track> functionality.

The Samsung Internet data must have been mirrored from Chrome and thus
fixed too. The data for other browsers is left alone even though there
are likely errors. In particular the Safari version numbers are
inconsistent, but not updated here.

Follow-up to https://github.com/mdn/browser-compat-data/pull/7640.