### PR TITLE
Add note about Chromium not supporting rel=preload with as=document

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1066,15 +1066,15 @@
               "support": {
                 "chrome": {
                   "version_added": "50",
-                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
+                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
                 },
                 "chrome_android": {
                   "version_added": "50",
-                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
+                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
                 },
                 "edge": {
                   "version_added": "≤79",
-                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
+                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
                 },
                 "firefox": {
                   "version_added": "56",
@@ -1102,11 +1102,12 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": "5.0"
+                  "version_added": "5.0",
+                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
                 },
                 "webview_android": {
                   "version_added": "50",
-                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
+                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
                 }
               },
               "status": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1065,13 +1065,16 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/preload",
               "support": {
                 "chrome": {
-                  "version_added": "50"
+                  "version_added": "50",
+                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
                 },
                 "chrome_android": {
-                  "version_added": "50"
+                  "version_added": "50",
+                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
                 },
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "≤79",
+                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
                 },
                 "firefox": {
                   "version_added": "56",
@@ -1102,7 +1105,8 @@
                   "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": "50"
+                  "version_added": "50",
+                  "notes": "Doesn't support as=\"document\", see <a href='https://crbug.com/593267'>chromium bug 593267</a>."
                 }
               },
               "status": {


### PR DESCRIPTION
Chromium doesn't support preloading as document, which has implications of preloading iframes, here's a bug: https://bugs.chromium.org/p/chromium/issues/detail?id=593267.

Tested it on latest Brave (87 with disabled shields) and I believe it applies to all chromium-based browsers

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
