### PR TITLE
Add the original HTMLMediaError alias for Firefox

### DIFF
--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -13,11 +13,18 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": {
-            "version_added": "3.5"
-          },
+          "firefox": [
+            {
+              "version_added": "4"
+            },
+            {
+              "alternative_name": "HTMLMediaError",
+              "version_added": "3.5",
+              "version_removed": "4"
+            }
+          ],
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -64,7 +71,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
MediaError is the type of object used for video.error, which was
shipped in Firefox 3.5. When TimeRanges was being implemented for
Firefox 4, it was discovered that MediaError was incorrectly called
HTMLMediaError, and manual testing in Firefox 3.6 confirms that
interface object was exposed. It was fixed here:
https://bugzilla.mozilla.org/show_bug.cgi?id=589561#c4
https://hg.mozilla.org/mozilla-central/rev/37f61e9d618a

The point of this is to avoid the situation in
https://github.com/mdn/browser-compat-data/pull/7963, where looking for
MediaError makes it seem like it was shipped in Firefox 4.