### PR TITLE
Mark TimeRanges as shipped in Firefox 4

### DIFF
--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -109,10 +109,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -157,10 +157,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This matches api.HTMLMediaElement.buffered, the first property that used
TimeRanges.

This was implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=589561,
which by the date also matches Firefox 4.

State of the IDL file in the last patch on the bug:
https://hg.mozilla.org/mozilla-central/file/37f61e9d618a32ade3367c514598454b9b735a54/dom/interfaces/html/nsIDOMTimeRanges.idl