### PR TITLE
adding range syntax support

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -855,56 +855,6 @@
             }
           }
         },
-        "range_syntax": {
-          "__compat": {
-            "description": "Level 4 range syntax",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1034465'>Bug 1034465</a>."
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "63"
-              },
-              "firefox_android": {
-                "version_added": "63"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "media_features": {
           "__compat": {
             "description": "Media feature expressions",
@@ -1622,6 +1572,56 @@
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "range_syntax": {
+          "__compat": {
+            "description": "Level 4 range syntax",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1034465'>Bug 1034465</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1584,7 +1584,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/1034465'>Bug 1034465</a>."
+                "notes": "See <a href='https://crbug.com/1034465'>bug 1034465</a>."
               },
               "chrome_android": {
                 "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1621,7 +1621,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1579,7 +1579,7 @@
         },
         "range_syntax": {
           "__compat": {
-            "description": "Level 4 range syntax",
+            "description": "Range syntax from Media Queries Level 4",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
             "support": {
               "chrome": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -855,6 +855,56 @@
             }
           }
         },
+        "range_syntax": {
+          "__compat": {
+            "description": "Level 4 range syntax",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1034465'>Bug 1034465</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "media_features": {
           "__compat": {
             "description": "Media feature expressions",


### PR DESCRIPTION
Fixes #8677 

Adds a line to detail support for the range syntax in Level 4 of the media queries spec. 
