### PR TITLE
Add notes for getInstalledRelatedApps desktop platform support

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1115,10 +1115,13 @@
             "chrome": [
               {
                 "version_added": "85",
+                "partial_implementation": true,
                 "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
               },
               {
                 "version_added": "80",
+                "version_removed": "85",
+                "partial_implementation": true,
                 "notes": "Always resolves with an empty array."
               }
             ],
@@ -1128,10 +1131,13 @@
             "edge": [
               {
                 "version_added": "85",
+                "partial_implementation": true,
                 "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
               },
               {
                 "version_added": "80",
+                "version_removed": "85",
+                "partial_implementation": true,
                 "notes": "Always resolves with an empty array."
               }
             ],
@@ -1147,10 +1153,13 @@
             "opera": [
               {
                 "version_added": "71",
+                "partial_implementation": true,
                 "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
               },
               {
                 "version_added": "67",
+                "version_removed": "71",
+                "partial_implementation": true,
                 "notes": "Always resolves with an empty array."
               }
             ],

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1112,15 +1112,29 @@
       "getInstalledRelatedApps": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "80"
-            },
+            "chrome": [
+              {
+                "version_added": "85",
+                "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
+              },
+              {
+                "version_added": "80",
+                "notes": "Always resolves with an empty array."
+              }
+            ],
             "chrome_android": {
               "version_added": "80"
             },
-            "edge": {
-              "version_added": "80"
-            },
+            "edge": [
+              {
+                "version_added": "85",
+                "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
+              },
+              {
+                "version_added": "80",
+                "notes": "Always resolves with an empty array."
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -1130,9 +1144,16 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "67"
-            },
+            "opera": [
+              {
+                "version_added": "71",
+                "notes": "Only supported on Windows. Resolves with an empty array on other platforms."
+              },
+              {
+                "version_added": "67",
+                "notes": "Always resolves with an empty array."
+              }
+            ],
             "opera_android": {
               "version_added": false
             },


### PR DESCRIPTION
Windows support was enabled in Chromium 85:
https://storage.googleapis.com/chromium-find-releases-static/f6a.html#f6a7ad6cdaebeae308f52b168936155e6e62443f

Additional sources:
https://groups.google.com/a/chromium.org/g/blink-dev/c/wB7mDJqrUZ8/m/Hbj0qxj8BQAJ
https://groups.google.com/a/chromium.org/g/blink-dev/c/aq1Zxc8D_uI/m/zHkFrzs5AQAJ
https://chromestatus.com/feature/5695378309513216

Follow-up to https://github.com/mdn/browser-compat-data/pull/8033.