### PR TITLE
Fix CI failure from #8482

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -775,7 +775,7 @@
                 "version_added": "24"
               },
               "chrome_android": {
-                "version_added": "24"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "≤18"


### PR DESCRIPTION
This fixes the test failure accidentally introduced in https://github.com/mdn/browser-compat-data/pull/8482#discussion_r557258214.

CC @Elchi3.
