### PR TITLE
Auto issue closer: close local template blank issues

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -17,3 +17,13 @@ jobs:
             If this has been closed in error, edit the title and body, and post a follow-up comment.
           title-contains: '<PUT TITLE HERE>'
           body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n\r\n#### What did you expect to see?\r\n\r\n#### Did you test this? If so, how?\r\n\r\n"
+      - uses: ddbeck/invalid-issue-closer@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'invalid :no_entry_sign:'
+          comment: |
+            This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
+
+            If this has been closed in error, edit the title and body, and post a follow-up comment.
+          title-contains: '<SUMMARIZE THE PROBLEM>'
+          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n#### What did you expect to see?\r\n#### Did you test this? If so, how?\r\n"


### PR DESCRIPTION
This PR updates the auto issue closer script to auto-close blank issues using the local template from our GitHub repository, as well as issues from the new Yari links.  Confirmed functionality in my own fork before submitting this PR.