### PR TITLE
Update Edge data for vrdisplayblur_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -10459,7 +10459,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This appears to have been an oversight. The new data matches the
onvrdisplayblur entry and multiple other vrdisplay*_event and
onvrdisplay* entries, but hasn't been verified with testing.

The event was minimally documented by Microsoft:
https://docs.microsoft.com/en-us/previous-versions/mt801971(v%3Dvs.85)