### PR TITLE
Add/update Safari versions for CanvasPattern.setTransform

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -79,7 +79,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -123,10 +123,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": "10.0"


### PR DESCRIPTION
This was implemented in https://trac.webkit.org/changeset/225121/webkit,
where the argument was a DOMMatrix2DInit dictionary from the beginning.

That revision maps to WebKit trunk at version 605.1.15:
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=225121

Given that and the date, the right versions are 11.1 / 11.3, not 11,
which was released before this change.