### PR TITLE
management is an optional permission in Firefox 77

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -461,7 +461,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "77"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1630419 "management" is supported as optional permission in Firefox 77. It also seems there's an optional "devtools" permission https://bugzilla.mozilla.org/show_bug.cgi?id=1606862.