### PR TITLE
Add HTML global attribute nonce

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1452,6 +1452,103 @@
           }
         }
       },
+      "nonce": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/nonce",
+          "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "nonce_hiding": {
+          "__compat": {
+            "description": "<code>nonce</code> hiding behavior",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": "79"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
       "part": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/part",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1458,13 +1458,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "31"
@@ -1473,25 +1473,25 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -1505,13 +1505,13 @@
             "description": "<code>nonce</code> hiding behavior",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "61"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "61"
               },
               "edge": {
-                "version_added": null
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "75"
@@ -1520,25 +1520,27 @@
                 "version_added": "79"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "45"
               },
               "safari": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/179728'>bug 179728</a>"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/179728'>bug 179728</a>"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "61"
               }
             },
             "status": {


### PR DESCRIPTION
Helping out on https://github.com/mdn/browser-compat-data/pull/7303 by adding the global attribute `nonce`.
mdn/content PR: https://github.com/mdn/content/pull/1318

- Firefox: 
  - Initial support for nonce attribute happened here: https://bugzilla.mozilla.org/show_bug.cgi?id=979580
  - Hiding was implemented when the IDL property got implemented https://bugzilla.mozilla.org/show_bug.cgi?id=1374612
- Chromiums:
  - Initial support: ?
  - Hiding support: Need to figure out the version from this https://groups.google.com/a/chromium.org/g/blink-dev/c/wu_fMIYkyaQ/m/85j16Cg6BAAJ (chromestatus seems outdated: https://www.chromestatus.com/feature/5685968463986688). 61 it is: https://storage.googleapis.com/chromium-find-releases-static/7bc.html#7bcb9ee52f2600bafddabaed884ccfea52916753

