### PR TITLE
Replace matrix builds with with named jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,20 +10,27 @@ on:
     branches: [ ] # Test on push to every branch
 
 jobs:
-  test:
-
+  maintenance_lts:
+    name: "Node.js maintenance LTS"
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [ 10.x, 14.x ]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2-beta
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 10.x
+    - run: npm install
+    - run: npm test
+      env:
+        FORCE_COLOR: 3
+
+  active_lts:
+    name: "Node.js active LTS"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2-beta
+      with:
+        node-version: 14.x
     - run: npm install
     - run: npm test
       env:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ ] # Test on push to every branch
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -28,3 +28,17 @@ jobs:
     - run: npm test
       env:
         FORCE_COLOR: 3
+
+  # This succeeds if all the matrix builds succeed. This allows us to set branch
+  # protection rules on this job in particular, rather than having to change
+  # branch protection rules when the matrix changes. See
+  # https://github.community/t/status-check-for-a-matrix-jobs/127354/7.
+  testall:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Test (matrix)
+    needs: test
+    steps:
+      - name: Check test matrix status
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,27 +10,21 @@ on:
     branches: [ ] # Test on push to every branch
 
 jobs:
-  maintenance_lts:
-    name: "Maintenance LTS"
+  test:
+    strategy:
+      matrix:
+        include:
+          - name: Maintenance LTS
+            node-version: 10.x # use oldest
+          - name: Active LTS
+            node-version: 14.x
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        node-version: 10.x
-    - run: npm install
-    - run: npm test
-      env:
-        FORCE_COLOR: 3
-
-  active_lts:
-    name: "Active LTS"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2-beta
-      with:
-        node-version: 14.x
+        node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm test
       env:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,17 +28,3 @@ jobs:
     - run: npm test
       env:
         FORCE_COLOR: 3
-
-  # This succeeds if all the matrix builds succeed. This allows us to set branch
-  # protection rules on this job in particular, rather than having to change
-  # branch protection rules when the matrix changes. See
-  # https://github.community/t/status-check-for-a-matrix-jobs/127354/7.
-  testall:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: Test (matrix)
-    needs: test
-    steps:
-      - name: Check test matrix status
-        if: ${{ needs.test.result != 'success' }}
-        run: exit 1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   maintenance_lts:
-    name: "Node.js maintenance LTS"
+    name: "Maintenance LTS"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         FORCE_COLOR: 3
 
   active_lts:
-    name: "Node.js active LTS"
+    name: "Active LTS"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As a prerequisite to #7171 and turning on branch protection rules, this PR replaces the matrix builds with jobs named for the specific release types of Node.js that we're targeting (Maintenance LTS and Active LTS). This allows us to require the release types succeed, without naming the exact version numbers in the branch protection rules.

~As a prerequisite to #7171 and turning on branch protection rules, this PR adds a new job to our testing workflow to summarize the results of all the matrix builds. This allows us to require the the complete build matrix succeeds, without specifying what builds make up that matrix.~

This was raised as a potential issue by @foolip in https://github.com/mdn/browser-compat-data/issues/7171#issuecomment-723052182:

> When one changes which checks are required, all open PRs turn into a pending state, and typically require rebasing to trigger the new check. For WPT, this has been pretty annoying to deal with, because we have so many open PRs.
> 
> For BCD, it would be smart to think twice about what the names of the checks we require are. Make sure we're happy with them, and that they don't include anything like version numbers which will change over time.

This ought to avoid an easy-to-anticipate problem for BCD: invalidating the state of PRs when the supported versions of Node.js change.

You can see what a failure would look like in https://github.com/ddbeck/browser-compat-data/pull/14.

