### PR TITLE
feat(link-rel-preload): update Firefox support

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1073,16 +1073,48 @@
                 "edge": {
                   "version_added": "≤79"
                 },
-                "firefox": {
-                  "version_added": "56",
-                  "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
-                },
-                "firefox_android": {
-                  "version_added": "56",
-                  "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
-                },
+                "firefox": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.preload",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  {
+                    "partial_implementation": true,
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.preload",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  {
+                    "partial_implementation": true,
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                  }
+                ],
                 "ie": {
                   "version_added": null
                 },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1099,7 +1099,7 @@
                     "version_added": "85"
                   },
                   {
-                    "version_added": "78",
+                    "version_added": "79",
                     "flags": [
                       {
                         "type": "preference",


### PR DESCRIPTION
this updates support of `<link rel=preload>` in Firefox (desktop and mobile).

* the new implementation has been available since Firefox 78 behind the flag
* it is enabled by default in Firefox 85
https://hg.mozilla.org/releases/mozilla-beta/rev/c46b088d9a1d

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
