### PR TITLE
Use newline normalization with invalid issue closer

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -15,8 +15,9 @@ jobs:
             This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
 
             If this has been closed in error, edit the title and body, and post a follow-up comment.
+          normalize-newlines: true
           title-contains: '<PUT TITLE HERE>'
-          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n\r\n#### What did you expect to see?\r\n\r\n#### Did you test this? If so, how?\r\n\r\n"
+          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\n\n#### What information was incorrect, unhelpful, or incomplete?\n\n#### What did you expect to see?\n\n#### Did you test this? If so, how?\n\n"
       - uses: ddbeck/invalid-issue-closer@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,5 +26,6 @@ jobs:
             This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
 
             If this has been closed in error, edit the title and body, and post a follow-up comment.
+          normalize-newlines: true
           title-contains: '<SUMMARIZE THE PROBLEM>'
-          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\r\n\r\n#### What information was incorrect, unhelpful, or incomplete?\r\n#### What did you expect to see?\r\n#### Did you test this? If so, how?\r\n"
+          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\n\n#### What information was incorrect, unhelpful, or incomplete?\n#### What did you expect to see?\n#### Did you test this? If so, how?\n"


### PR DESCRIPTION
Some recent issues (for example, #8776) have not been closed by the issue closer changes in #8753. I did some testing I'm pretty certain it was caused by CRLF/LF newline problems. To fix this properly, I added a new option to ddbeck/invalid-issue-closer that normalizes newlines before evaluating the closing conditions. The change to the GitHub Action is backwards compatible, so this PR is needed to turn on the new behavior.

I tagged this as ddbeck/invalid-issue-closer v1.1.0. You can see the changes to the issue closer here: https://github.com/ddbeck/invalid-issue-closer/compare/v1.0.0...v1.1.0