### PR TITLE
Add worker_support info for CacheStorage

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -6,17 +6,11 @@
         "support": {
           "chrome": {
             "version_added": "40",
-            "notes": [
-              "Accessible from <code>Window.caches</code> from version 43.",
-              "Accessible from <code>WorkerGlobalScope.caches</code> from version 43."
-            ]
+            "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
           },
           "chrome_android": {
             "version_added": "40",
-            "notes": [
-              "Accessible from <code>Window</code> from version 43.",
-              "Accessible from <code>WorkerGlobalScope</code> from version 43."
-            ]
+            "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
           },
           "edge": {
             "version_added": "≤18"
@@ -404,10 +398,12 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "40",
+              "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "40",
+              "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
             },
             "edge": {
               "version_added": "≤18"

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -6,11 +6,11 @@
         "support": {
           "chrome": {
             "version_added": "40",
-            "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           },
           "chrome_android": {
             "version_added": "40",
-            "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
           },
           "edge": {
             "version_added": "≤18"
@@ -26,10 +26,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "27"
+            "version_added": "27",
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
           },
           "opera_android": {
-            "version_added": "27"
+            "version_added": "27",
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
           },
           "safari": {
             "version_added": "11.1"
@@ -38,18 +40,11 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": "4.0",
-            "notes": [
-              "Accessible from <code>Window</code> from Samsung Internet 4.0.",
-              "Accessible from <code>WorkerGlobalScope</code> from Samsung Internet 4.0."
-            ]
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "40",
-            "notes": [
-              "Accessible from <code>Window</code> from version 43.",
-              "Accessible from <code>WorkerGlobalScope</code> from version 43."
-            ]
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
           }
         },
         "status": {
@@ -403,7 +398,7 @@
             },
             "chrome_android": {
               "version_added": "40",
-              "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
             },
             "edge": {
               "version_added": "≤18"
@@ -419,10 +414,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": "27",
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": "27",
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
             },
             "safari": {
               "version_added": "11.1"
@@ -434,7 +431,8 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "40",
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
             }
           },
           "status": {

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -7,8 +7,8 @@
           "chrome": {
             "version_added": "40",
             "notes": [
-              "Accessible from <code>Window</code> from version 43.",
-              "Accessible from <code>WorkerGlobalScope</code> from version 43."
+              "Accessible from <code>Window.caches</code> from version 43.",
+              "Accessible from <code>WorkerGlobalScope.caches</code> from version 43."
             ]
           },
           "chrome_android": {
@@ -394,6 +394,55 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": "≤18"
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27"
+            },
+            "opera_android": {
+              "version_added": "27"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -399,7 +399,7 @@
           "support": {
             "chrome": {
               "version_added": "40",
-              "notes": "Version 40 to 42: supported in service workers only. Version 43 enabled use in main thread and other worker types."
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
             },
             "chrome_android": {
               "version_added": "40",


### PR DESCRIPTION
[CacheStorage](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage) is defined in the service worker spec but also works in the main thread and other worker types. This PR updates CacheStorage information to have a  `worker_support` key.

What I did was duplicate the top level support for `CacheStorage` as the key `worker_support`. My assumption being that worker support went in for the first version unless otherwise documented (seems reasonable because this is in the service worker spec)

![image](https://user-images.githubusercontent.com/5368500/104870924-d8627200-599d-11eb-9fdf-1064a5ee1fe9.png)

There is a note indicating that for Chrome it became accessible through WorkerWindowScope (and window) in version 43. My assumption is therefore that this is a case where the class was available, but inaccessible. So I have updated the worker support information to 43 for that case. 

There is also a note for FF on all methods: *"notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."*. I copied this to just mention service workers.

@ddbeck 
- Does this make sense?
- The note about ESR versions appears on all methods. Is it necessary - ie propose to remove it except for the parent CacheStorege.

