### PR TITLE
Add worker_support to PushManager

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -607,7 +607,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -565,6 +565,9 @@
             },
             "edge": [
               {
+                "version_added": "17"
+              },
+              {
                 "version_added": "16",
                 "flags": [
                   {
@@ -572,9 +575,6 @@
                     "name": "Enable service workers"
                   }
                 ]
-              },
-              {
-                "version_added": "17"
               }
             ],
             "firefox": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -552,6 +552,66 @@
             "deprecated": true
           }
         }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": [
+              {
+                "version_added": "16",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable service workers"
+                  }
+                ]
+              },
+              {
+                "version_added": "17"
+              }
+            ],
+            "firefox": {
+              "version_added": "44",
+              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Effectively this just duplicates the main support for PushManager in a worker_support key.

Note that I did test that PushManager is supported in ALL worker types on Chrome and Opera (i.e. you can have a push manager in a dedicated worker or service worker or shared worker - using https://worker-playground.glitch.me/
