### PR TITLE
Clear-Site-Data requires secure context

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -300,28 +300,28 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "61"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "61"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "62"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "62"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "48"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "safari": {
                 "version_added": false
@@ -330,10 +330,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "61"
               }
             },
             "status": {

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -338,7 +338,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -295,6 +295,54 @@
             }
           }
         },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "storage": {
           "__compat": {
             "description": "<code>&quot;storage&quot;</code>",

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -337,7 +337,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Clear-Site-Data header requires secure context, but this is not documented - see this issue: https://github.com/mdn/content/issues/991
- The requirement for secure context is not in the draft but is visible in Firefox code https://searchfox.org/mozilla-central/source/toolkit/components/clearsitedata/ClearSiteData.cpp#166
- It is also noted in the [W3C test code](https://github.com/w3c/webappsec-clear-site-data/tree/master/demo) (which was submitted/edited by the spec author) from this note in the readme: **(NOTE: Clear-Site-Data only works on localhost and https.**

This essentially just adds the `secure_context_required` keyword. I have added `false` for browsers that don't support the header and `true` for those that do. 

@ddbeck 
- Do we *have* to try get versions on this? 
- How much further testing is reasonable? I guess I could try set up a remote server and verify that this works locally but not via HTTP remotely, and perhaps bisect some versions. But I'd rather not if it can be avoided :-)