### PR TITLE
updating Fx support for rel=preload

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1073,16 +1073,26 @@
                 "edge": {
                   "version_added": "≤79"
                 },
-                "firefox": {
-                  "version_added": "56",
-                  "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
-                },
-                "firefox_android": {
-                  "version_added": "56",
-                  "version_removed": "57",
-                  "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
-                },
+                "firefox": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                  }
+                ],
                 "ie": {
                   "version_added": null
                 },
@@ -1106,7 +1116,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1626997

I've updated the `<link>` element JSON to add support for `rel="preload"` by default in Firefox 85.

I've also marked it as no longer experiment, because well, it is supported in Gecko and Chromiums now.