### PR TITLE
css.properties.clip-path.path - Add Chrome and Safari data

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -323,10 +323,10 @@
             "description": "<code>path()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
                 "version_added": false
@@ -365,17 +365,29 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari": [
+                {
+                  "version_added": "13.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "10"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "13.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "10"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "88"
               }
             },
             "status": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -329,7 +329,7 @@
                 "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": [
                 {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -376,7 +376,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "13.1"
+                  "version_added": "13"
                 },
                 {
                   "prefix": "-webkit-",


### PR DESCRIPTION
Fixes #8661 

Tested in Chrome 88, and it is working.

Thanks for the Safari data @myakura!
