### PR TITLE
Update Safari support info for static class variables

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -734,10 +734,10 @@
               }
             ],
             "safari": {
-              "version_added": "9"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": false
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
As of Safari 14, this feature is not supported on desktop or mobile. This PR updates the `classes.json` file to reflect that `static` is not supported by Safari for either platform.

Closes #8468.