### PR TITLE
Deprecate HTMLMediaElement: mozGetMetadata, and mark it as non-standard

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2099,8 +2099,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
See https://github.com/mdn/content/pull/1504 and see also https://bugzilla.mozilla.org/show_bug.cgi?id=1336402

> This method was never standardized and Gecko's media team have plans to remove it… Mark it as deprecated to signal more strongly that it should not be used and will be removed.