### PR TITLE
aspect-ratio shipped in Chrome 88

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -5,21 +5,26 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "88"
+              },
+              {
+                "version_added": "84",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
-              "version_added": false
+              "version_added": "88"
             },
             "edge": {
-              "version_added": false
+              "version_added": "88"
             },
             "firefox": [
               {
@@ -69,7 +74,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "88"
             }
           },
           "status": {


### PR DESCRIPTION
Updating the CSS `aspect-ratio` property which shipped in Chrome 88: https://www.chromestatus.com/feature/5738050678161408
