### PR TITLE
Add Chrome support for overflow-clip-margin and overflow: clip

### DIFF
--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "overflow-clip-margin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1661582'>bug 1661582</a>."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -55,13 +55,13 @@
             "description": "<code>clip</code> value",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "89"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "89"
               },
               "edge": {
-                "version_added": false
+                "version_added": "89"
               },
               "firefox": [
                 {
@@ -102,11 +102,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "89"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Chrome is shipping `overflow:clip` and the new `overflow-clip-margin` property in 89. Adding data for these (I'm going to document `overflow-clip-margin`). Also removing experimental flag for `overflow: clip` as Firefox already implements it so that is two engines. 

https://www.chromestatus.com/feature/5638444178997248
