### PR TITLE
Add spec_url for HTML elements A to C

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -4,6 +4,7 @@
       "a": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/a",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -4,6 +4,7 @@
       "abbr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/abbr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/html/elements/acronym.json
+++ b/html/elements/acronym.json
@@ -4,6 +4,7 @@
       "acronym": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/acronym",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#acronym",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -4,6 +4,7 @@
       "address": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/address",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-address-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/applet.json
+++ b/html/elements/applet.json
@@ -4,6 +4,7 @@
       "applet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/applet",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#applet",
           "support": {
             "chrome": {
               "version_added": true,

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -4,6 +4,7 @@
       "area": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/area",
+          "spec_url": "https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/article.json
+++ b/html/elements/article.json
@@ -4,6 +4,7 @@
       "article": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/article",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-article-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/aside.json
+++ b/html/elements/aside.json
@@ -4,6 +4,7 @@
       "aside": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/aside",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-aside-element",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -4,6 +4,7 @@
       "audio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/audio",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#the-audio-element",
           "support": {
             "chrome": {
               "version_added": "3"

--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -4,6 +4,7 @@
       "b": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/b",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -4,6 +4,7 @@
       "base": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/base",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-base-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/basefont.json
+++ b/html/elements/basefont.json
@@ -4,6 +4,7 @@
       "basefont": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/basefont",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#basefont",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -4,6 +4,7 @@
       "bdi": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdi",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element",
           "support": {
             "chrome": {
               "version_added": "16"

--- a/html/elements/bdo.json
+++ b/html/elements/bdo.json
@@ -4,6 +4,7 @@
       "bdo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdo",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/bgsound.json
+++ b/html/elements/bgsound.json
@@ -4,6 +4,7 @@
       "bgsound": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bgsound",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#bgsound",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/big.json
+++ b/html/elements/big.json
@@ -4,6 +4,7 @@
       "big": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/big",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#big",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -4,6 +4,7 @@
       "blink": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/blink",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#blink",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/blockquote.json
+++ b/html/elements/blockquote.json
@@ -4,6 +4,7 @@
       "blockquote": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/blockquote",
+          "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -4,6 +4,7 @@
       "body": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/body",
+          "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-body-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -4,6 +4,7 @@
       "br": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/br",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -4,6 +4,7 @@
       "button": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/button",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -4,6 +4,7 @@
       "canvas": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/canvas",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/caption.json
+++ b/html/elements/caption.json
@@ -4,6 +4,7 @@
       "caption": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/caption",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-caption-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/center.json
+++ b/html/elements/center.json
@@ -4,6 +4,7 @@
       "center": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/center",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#center",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/cite.json
+++ b/html/elements/cite.json
@@ -4,6 +4,7 @@
       "cite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/cite",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/code.json
+++ b/html/elements/code.json
@@ -4,6 +4,7 @@
       "code": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/code",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -4,6 +4,7 @@
       "col": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/col",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-col-element",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -4,6 +4,7 @@
       "colgroup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/colgroup",
+          "spec_url": "https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
Trying to make more progress on this again. This adds `spec_url` to the main HTML elements letters A to C.

One thing that might be debatable is obsolete elements. I've added spec links for them, e.g. acronym: https://html.spec.whatwg.org/multipage/obsolete.html#acronym 

I think it is worth showing that even the spec calls them obsolete (vs. just the docs saying that). Happy to hear thoughts, though.

The `<command>` and `<content>` elements weren't in the latest HTML spec (not even under obsolete, so I couldn't add a spec_url. Not sure if the spec maintainers would be willing to call these out as obsolete explicitly. The <`command>` page looks like something we should archive, but `<content>` has implementation.