### PR TITLE
Add a couple more A-C HTML element spec URLs

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -604,6 +604,7 @@
           "noopener": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noopener",
+              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-noopener",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -654,6 +655,7 @@
           "noreferrer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noreferrer",
+              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer",
               "support": {
                 "chrome": {
                   "version_added": "16"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -616,6 +616,7 @@
           "noopener": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noopener",
+              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-noopener",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -666,6 +667,7 @@
           "noreferrer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/noreferrer",
+              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer",
               "support": {
                 "chrome": {
                   "version_added": "16"


### PR DESCRIPTION
This change adds spec URLs in the `html/elements/a.json` and `html/elements/area.json` data, for the `noopener` and `noreferrer` attributes, which have their own MDN articles.

This is a follow-up to https://github.com/mdn/browser-compat-data/pull/8810 (c84b9e1), which added the spec URLs for the HTML elements themselves whose names are in the A-C range.