### PR TITLE
Add HTTPS-only to privacy.network

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -76,7 +76,7 @@
               }
             }
           },
-          "HTTPS-only": {
+          "httpsOnlyMode": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -89,7 +89,8 @@
                   "version_added": "84"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "84",
+                  "notes": "There is no visible UI to enable this feature for Firefox for Android, so it's currently always `never`."
                 },
                 "opera": {
                   "version_added": true

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -75,6 +75,30 @@
                 }
               }
             }
+          },
+          "HTTPS-only": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "84"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "services": {

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -89,8 +89,7 @@
                   "version_added": "84"
                 },
                 "firefox_android": {
-                  "version_added": "84",
-                  "notes": "There is no visible UI to enable this feature for Firefox for Android, so it's currently always `never`."
+                  "version_added": "84"
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
Adds HTTPS-only to privacy.network WebExtensions API, per https://bugzilla.mozilla.org/show_bug.cgi?id=1678306. Partial fix for https://github.com/mdn/content/issues/289. 
