### PR TITLE
Mark MediaRecorder as shipping in Safari 14

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -31,10 +31,10 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -79,10 +79,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -126,10 +126,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -224,10 +224,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -326,10 +326,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -391,10 +391,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -447,10 +447,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -495,10 +495,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -639,10 +639,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -687,10 +687,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -832,10 +832,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -928,10 +928,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -992,10 +992,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1048,10 +1048,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1112,10 +1112,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This was not in the initial releases of Safari 14, but was in Safari 
14.0.3 on macOS and in Safari iOS 14.3. These releases are not recorded 
in BCD, and this appears to be the only change introduced.

Using results collected for iOS 14.2 and 14.3 using
https://mdn-bcd-collector.appspot.com/.

Two entries were update manually:
 - the options object for the constructor, based on WebKit source
 - the error_event entry, based on the onerror entry