### PR TITLE
Fix page_action.show_matches support for Android

### DIFF
--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -199,7 +199,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "59"
+                "version_added": "79"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
When the feature initially landed, there was no support for mobile: https://bugzilla.mozilla.org/show_bug.cgi?id=1419842

`page_action.show_matches` support was added when the implementation was re-implemented from scratch based on the desktop implementation at https://bugzilla.mozilla.org/show_bug.cgi?id=1530402
