### PR TITLE
(TouchList) Add Safari Desktop to supporting browsers; add version for Safari Mobile

### DIFF
--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -35,10 +35,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -38,7 +38,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "2.0"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -136,10 +136,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -190,10 +190,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

iOS Desktop browser now supports TouchList according to the Apple official documentation for TouchList: https://developer.apple.com/documentation/webkitjs/touchlist (version 10.1+).
The documentation also states the minimum version of Safari iOS (Mobile) for TouchList: version 2.0+.
