### PR TITLE
Add FF android webshare support

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2506,8 +2506,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "79",
-              "notes": "Firefox Mobile displays custom share dialog (instead of the platform-native dialog indicated by the specification)."
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -445,7 +445,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -2506,7 +2506,8 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79",
+              "notes": "Firefox Mobile displays custom share dialog (instead of the platform-native dialog indicated by the specification)."
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -445,7 +445,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "79"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2506,7 +2506,9 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Firefox does not support sharing files."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #8833

#8833 points out that the web share API works on FF for Android but BCD indicates not supported. 

What I have done is:
- Verified that Navigator.share does indeed work on current FF for android using https://mdn.github.io/dom-examples/web-share/
- Verified that Navigator.canShare works using the [webshare tests](http://www1.www.wpt.live:8000/web-share/canShare-files.tentative.https.html)
- Verified custom gecko integration added in [Bugzilla 1402369](https://bugzilla.mozilla.org/show_bug.cgi?id=1402369) - you can see [code here](https://searchfox.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoSession.java#5062)

Bugzilla indicates this going in in FF72, but there is no FF72 for android so I updated BCD with the first version after that - FF79. 

Note, https://github.com/mdn/browser-compat-data/issues/4983 was created to track these sorts of items.