### PR TITLE
Add worker_support for XMLHttpRequest

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -2097,7 +2097,7 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Not supported in service workers."
             },
             "chrome_android": {
@@ -2109,7 +2109,7 @@
               "notes": "Not supported in service workers."
             },
             "firefox": {
-              "version_added": "1",
+              "version_added": "3.5",
               "notes": "Not supported in service workers."
             },
             "firefox_android": {
@@ -2117,23 +2117,23 @@
               "notes": "Not supported in service workers."
             },
             "ie": {
-              "version_added": "7",
+              "version_added": "10",
               "notes": "Not supported in service workers."
             },
             "opera": {
-              "version_added": "8",
+              "version_added": "10.6",
               "notes": "Not supported in service workers."
             },
             "opera_android": {
-              "version_added": "10.1",
+              "version_added": "11",
               "notes": "Not supported in service workers."
             },
             "safari": {
-              "version_added": "1.2",
+              "version_added": "4",
               "notes": "Not supported in service workers."
             },
             "safari_ios": {
-              "version_added": "1",
+              "version_added": "5.1",
               "notes": "Not supported in service workers."
             },
             "samsunginternet_android": {
@@ -2141,7 +2141,7 @@
               "notes": "Not supported in service workers."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "4",
               "notes": "Not supported in service workers."
             }
           },

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -2091,6 +2091,66 @@
             "deprecated": false
           }
         }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "notes": "Not supported in service workers."
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "notes": "Not supported in service workers."
+            },
+            "edge": {
+              "version_added": "12",
+              "notes": "Not supported in service workers."
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Not supported in service workers."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "Not supported in service workers."
+            },
+            "ie": {
+              "version_added": "7",
+              "notes": "Not supported in service workers."
+            },
+            "opera": {
+              "version_added": "8",
+              "notes": "Not supported in service workers."
+            },
+            "opera_android": {
+              "version_added": "10.1",
+              "notes": "Not supported in service workers."
+            },
+            "safari": {
+              "version_added": "1.2",
+              "notes": "Not supported in service workers."
+            },
+            "safari_ios": {
+              "version_added": "1",
+              "notes": "Not supported in service workers."
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "Not supported in service workers."
+            },
+            "webview_android": {
+              "version_added": "1",
+              "notes": "Not supported in service workers."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Partial fix for https://github.com/mdn/content/issues/1515

XMLHttpRequest is intended to be used in workers
- Testing shows it cannot be used in serviceworkers but can in the other types (using https://worker-playground.glitch.me/)
- Docs indicated [XMLHttpRequest.responseXML](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML) returns null in worker
- [This doc](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) indicates XMLHttpRequest.channel returns null in workers (but other mentions of that item do not, and this should be verified).

What I've done is add "worker_support" key just to `XMLHttpRequest` (taking the support version from XMLHttpRequest) and adding a note for **every browser**: "notes": "Not supported in service workers.".
- I would prefer to add the note just once for all browsers but there does not appear to be a way (?) - because description is "hard coded" by toolchain to "available in workers".
- I have not added the notes about responseXML and channel because I wonder if these should got somehow as sub properties? Would appreciate advice on right way to do that?

@ddbeck FYI