### PR TITLE
Update Safari support for devicechange_event

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -77,10 +77,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
Per experiments done by @ddbeck [1], support begins with version 11, aligning with support for `ondevicechange`.

This seems to contradict what official documentation I can find. Changelogs[2] indicate support was added in technology preview version 72, and the change list for that release indicates support was committed[3] after the tag for Safari 11.1[4], but I'll defer to the experiments.

Fixes #8688

[1] https://github.com/mdn/browser-compat-data/issues/8688#issuecomment-763635181
[2] https://webkit.org/blog/8547/release-notes-for-safari-technology-preview-72/
[3] https://trac.webkit.org/changeset/238796/webkit/
[4] https://trac.webkit.org/changeset/230984/webkit
