### PR TITLE
Update Firefox versions to account for Firefox 85 release

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -609,27 +609,28 @@
         "84": {
           "release_date": "2020-12-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "84"
         },
         "85": {
           "release_date": "2021-01-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/85",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "87"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -476,27 +476,28 @@
         "84": {
           "release_date": "2020-12-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/84",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "84"
         },
         "85": {
           "release_date": "2021-01-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/85",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "87"
         },


### PR DESCRIPTION
Firefox 85 is launched today. I've got everything else in place, and this PR just updates the browser data for Fx and FxA to recognise v85 as the current version. Officially I think the release happens at 8am PT, so if you want, you can wait till then. But if you do want to just merge and be done with it, I doubt a few hours will make much difference really.