### PR TITLE
Mention 'fix' for Chrome's broken PDF loading

### DIFF
--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -9,14 +9,14 @@
               "version_added": "73",
               "notes": [
                 "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>.",
-                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+                "From version 80 to 85, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>. From version 86, partial PDF loading is disabled."
               ]
             },
             "chrome_android": {
               "version_added": "73",
               "notes": [
                 "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>.",
-                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+                "From version 80 to 85, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>. From version 86, partial PDF loading is disabled."
               ]
             },
             "edge": {
@@ -62,7 +62,7 @@
               "version_added": "73",
               "notes": [
                 "Until version 75, downloads for files with this header would fail in WebView. See <a href='https://crbug.com/952834'>bug 952834</a>.",
-                "From version 80, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>."
+                "From version 80 to 85, linearized PDFs served inline with this header fail to render properly. See <a href='https://crbug.com/1074261'>bug 1074261</a>. From version 86, partial PDF loading is disabled."
               ]
             }
           },


### PR DESCRIPTION
**Chromium team have disabled PDF partial loading entirely now due to issues it caused. This change obsoletes the previous issues and interaction with e.g. SameSite cookies as well as CORP.**

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
  - https://bugs.chromium.org/p/chromium/issues/detail?id=1115149
- [x] Data: if you tested something, describe how you tested with details like browser and version
  - Did not test specifically
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
  - I assume it'll fail the build after I open this PR if I've screwed it up. If it does I'll clone locally and fix.
- [X] Link to related issues or pull requests, if any
  - #6026 #4088
