### PR TITLE
Remove Chromium 89 from String.at.

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -111,13 +111,13 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-array-prototype-additions",
             "support": {
               "chrome": {
-                "version_added": "89"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "89"
+                "version_added": false
               },
               "edge": {
-                "version_added": "89"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -147,7 +147,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "89"
+                "version_added": false
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -164,13 +164,13 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-string-prototype-additions",
             "support": {
               "chrome": {
-                "version_added": "89"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "89"
+                "version_added": false
               },
               "edge": {
-                "version_added": "89"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -200,7 +200,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "89"
+                "version_added": false
               }
             },
             "status": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -110,13 +110,13 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-%typedarray.prototype%-additions",
             "support": {
               "chrome": {
-                "version_added": "89"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "89"
+                "version_added": false
               },
               "edge": {
-                "version_added": "89"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -146,7 +146,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "89"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
The `String.at()` function did not make the cut for Chromium 89. I set the value to `false`. Even though it will probably be in 90, we won't know for sure for as six weeks.
