### PR TITLE
Add text-decoration-thickness for Opera 73+

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -40,7 +40,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73",
+              "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Opera 73 is [based on Chromium 87.0.4280.88][1] and so has the same support for `text-decoration-thickess` as Chrome 87 and Edge 87.

I’ve verified that the behaviour is the same – including the same issue with `text-decoration-offset` or `text-decoration-color` needing to be set.

## Opera 72

![Screenshot 2021-01-27 at 09 47 53](https://user-images.githubusercontent.com/121939/105974275-a92abf80-6085-11eb-9a5a-9455eeb8d30a.png)

## Opera 73

![Screenshot 2021-01-27 at 09 47 24](https://user-images.githubusercontent.com/121939/105974296-ab8d1980-6085-11eb-9bfa-9cd5c5419cc0.png)

[1]: https://blogs.opera.com/desktop/2020/12/opera-73-0-3856-284-stable-update/

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
