### PR TITLE
Fill out Chrome data for html.elements.source.{sizes,srcset}

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -30,7 +30,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -101,12 +101,26 @@
         "sizes": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "34",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "34",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
               "edge": {
                 "version_added": "≤18"
               },
@@ -143,12 +157,26 @@
               "ie": {
                 "version_added": null
               },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "25",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "25",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
               "safari": [
                 {
                   "version_added": "9"
@@ -169,12 +197,26 @@
                   "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "3.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "version_removed": "3.0",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "≤37",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -233,12 +275,26 @@
         "srcset": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "34",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "34",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
               "edge": {
                 "version_added": "≤18"
               },
@@ -275,12 +331,26 @@
               "ie": {
                 "version_added": null
               },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "25",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "version_added": "21",
+                  "version_removed": "25",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
               "safari": [
                 {
                   "version_added": "9"
@@ -301,12 +371,26 @@
                   "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "3.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "version_removed": "3.0",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "version_added": "≤37",
+                  "version_removed": "38",
+                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
+                }
+              ]
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
Initially, both Safari and Chrome had partial implementation of `srcset` and `sizes`. In the process of reviewing #7353, which fixed the data for Safari, I learned a bit about how those changes corresponded in Chrome. This PR applies that data and mirrors it into Chromiums.