### PR TITLE
Update windows.create BCD to indicate focused:false is currently ignored

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -656,7 +656,8 @@
               "firefox": {
                 "notes": [
                   "'url' and 'tabId options can't both be set together.",
-                  "The returned 'Window' object contains the 'tabs' property only from version 52 onwards."
+                  "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
+                  "Firefox currently ignores the 'focused:false' option."
                 ],
                 "version_added": "45"
               },

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -657,7 +657,7 @@
                 "notes": [
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
-                  "Firefox currently ignores the 'focused:false' option."
+                  "Firefox currently ignores the <code>focused: false</code> option."
                 ],
                 "version_added": "45"
               },

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -657,7 +657,7 @@
                 "notes": [
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
-                  "Firefox currently ignores the <code>focused: false</code> option."
+                  "From Firefox 86, the <code>focused: false</code> option is ignored."
                 ],
                 "version_added": "45"
               },


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/1723 by adding a note to the BCD table in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create that `focused:false` is currently ignored. 
