### PR TITLE
Remove several needless "Enabled by default" notes

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7445,24 +7445,34 @@
             },
             "firefox": [
               {
-                "version_added": "55",
-                "notes": "Enabled by default."
+                "version_added": "55"
               },
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "notes": "Implemented but disabled by default."
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.requestIdleCallback.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "firefox_android": [
               {
-                "version_added": "55",
-                "notes": "Enabled by default."
+                "version_added": "55"
               },
               {
                 "version_added": "53",
                 "version_removed": "55",
-                "notes": "Implemented but disabled by default."
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.requestIdleCallback.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               }
             ],
             "ie": {

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "3",
@@ -46,8 +45,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "3",
@@ -46,8 +45,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "3",
@@ -46,8 +45,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "3",
@@ -46,8 +45,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "3",
@@ -46,8 +45,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -26,8 +26,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               }
             ],
             "firefox_android": [
@@ -42,8 +41,7 @@
                     "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "Enabled by default since Firefox 41."
+                ]
               }
             ],
             "ie": {


### PR DESCRIPTION
I stumbled on (via #8834) a bunch of notes that needlessly use notes to describe their own support statements.

In the case of `requestIdleCallback`, I did dig up the preference name. In the other cases, it was self evident based on adjacent support statements.