### PR TITLE
Add the ::target-text pseudo

### DIFF
--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "selectors": {
-      "target-within": {
+      "target-text": {
         "__compat": {
           "description": "<code>::target-text</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::target-text",

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "selectors": {
+      "target-within": {
+        "__compat": {
+          "description": "<code>::target-text</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::target-text",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding the `::target-text` pseudo. I'll be creating the rest of the docs.

Spec: https://drafts.csswg.org/css-pseudo/#selectordef-target-text
Chrome Status: https://www.chromestatus.com/feature/5689463273422848
