### PR TITLE
Update DocumentFragment.json

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -53,13 +53,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentFragment/DocumentFragment",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "29"
             },
             "chrome_android": {
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "24"
@@ -71,16 +71,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "16"
             },
             "opera_android": {
               "version_added": true
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -83,7 +83,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -56,7 +56,7 @@
               "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "17"
@@ -74,7 +74,7 @@
               "version_added": "16"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "16"
             },
             "safari": {
               "version_added": "8"

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Updated compat data for `DocumentFragment constructor` :

- Chrome 29 is the first version with a working constructor
- Chrome 29 corresponds to Opera 16
- Edge 17 is the first version with a working constructor
- ~iOS/Safari 7 also has a working constructor~ kept it at `8` after looking through the git history

Ran this code in all browsers from Browserstack :

```js
var fixture = document.getElementById('the-fixture');

var fragment = new DocumentFragment();
var child = document.createElement('div');
child.id = "child-added-with-js";

fragment.appendChild(child);

fixture.appendChild(fragment);

var result = document.getElementById('child-added-with-js');

// cb checks for "true"
cb(
	!!result &&
	result.parentNode === fixture
);
```

https://romainmenke.github.io/web-tests/ (search for `DocumentFragment`)