### PR TITLE
Cache: Add worker support info

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -5,12 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Cache",
         "support": {
           "chrome": {
-            "version_added": "43",
-            "notes": "From 40 to 42, this was only available on service workers."
+            "version_added": "40",
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           },
           "chrome_android": {
-            "version_added": "43",
-            "notes": "From 40 to 42, this was only available on service workers."
+            "version_added": "40",
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           },
           "edge": {
             "version_added": "≤18"
@@ -26,12 +26,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "30",
-            "notes": "From 27 to 29, this was only available on service workers."
+            "version_added": "27",
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
           },
           "opera_android": {
-            "version_added": "30",
-            "notes": "From 27 to 29, this was only available on service workers."
+            "version_added": "27",
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
           },
           "safari": {
             "version_added": "11"
@@ -40,12 +40,11 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "4.0",
-            "notes": "From 40 to 42, this was only available on service workers."
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "43",
-            "notes": "From 40 to 42, this was only available on service workers."
+            "version_added": "40",
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           }
         },
         "status": {
@@ -411,6 +410,60 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "40",
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
+            },
+            "chrome_android": {
+              "version_added": "40",
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
+            },
+            "edge": {
+              "version_added": "≤18"
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "27",
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
+            },
+            "opera_android": {
+              "version_added": "27",
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40",
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -27,11 +27,11 @@
           },
           "opera": {
             "version_added": "27",
-            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
           },
           "opera_android": {
             "version_added": "27",
-            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
+            "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
           },
           "safari": {
             "version_added": "11.1"
@@ -44,7 +44,7 @@
           },
           "webview_android": {
             "version_added": "40",
-            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
+            "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           }
         },
         "status": {
@@ -415,11 +415,11 @@
             },
             "opera": {
               "version_added": "27",
-              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
             },
             "opera_android": {
               "version_added": "27",
-              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported"
+              "notes": "Before version 30, only service workers are supported. From version 30, all worker types and the main thread are supported."
             },
             "safari": {
               "version_added": "11.1"
@@ -432,7 +432,7 @@
             },
             "webview_android": {
               "version_added": "40",
-              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
+              "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
             }
           },
           "status": {


### PR DESCRIPTION
Updates `Cache` to use the same patterns as done in `CacheStorage`: #8783

This is an information reformatting, not "new" information. 

@ddbeck Note, this also adds a couple of full stops to the CacheStorage docs.