### PR TITLE
Add data for Set.prototype.keys (alias of values)

### DIFF
--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -748,45 +748,117 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
             "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.values",
             "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "24"
-              },
-              "firefox_android": {
-                "version_added": "24"
-              },
+              "chrome": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "38"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "38"
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "12"
+                }
+              ],
+              "firefox": [
+                {
+                  "version_added": "24"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "24"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "24"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "24"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "0.12.0"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
+              "nodejs": [
+                {
+                  "version_added": "0.12.0"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "0.12.0"
+                }
+              ],
+              "opera": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "25"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "25"
+                }
+              ],
+              "safari": [
+                {
+                  "version_added": "8"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "8"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "8"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "8"
+                }
+              ],
+              "samsunginternet_android": [
+                {
+                  "version_added": "3.0"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "3.0"
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "38"
+                },
+                {
+                  "alternative_name": "keys",
+                  "version_added": "38"
+                }
+              ]
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This is part of the spec and the MDN page redirects:
https://tc39.es/ecma262/#sec-set.prototype.keys
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys

All that's missing is the support in BCD. It looks as though `keys` and
`values` were introduced at the same time in all cases.

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8881 was
tested in the following browsers:
- Chrome 37 + 38 on Windows 7
- Edge 15 on Windows 10 (not 12, so leaves room for error)
- Firefox 23 + 24 on Windows 7
- Safari on iOS 8 (7 not tested)

Node.JS 0.12.18 was manually tested, and Set.prototype.keys is there.

The remaining changes are Chromium-based browsers and assumed to match
Chrome desktop.