### PR TITLE
Flatten HTMLHyperlinkElementUtils mixin to HTMLAnchorElement/HTMLAreaElement

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -1,57 +1,9 @@
 {
   "api": {
-    "HTMLHyperlinkElementUtils": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils",
-        "support": {
-          "chrome": {
-            "version_added": "1"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "firefox": {
-            "version_added": "1",
-            "notes": "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
-          },
-          "firefox_android": {
-            "version_added": "4",
-            "notes": "Firefox was a bug whereby single contained in URLs are escaped when accessed via URL APIs (<a href='https://bugzil.la/1386683'>bug 1386683</a>). This has been as of Firefox 57."
-          },
-          "ie": {
-            "version_added": "5"
-          },
-          "opera": {
-            "version_added": "≤12.1"
-          },
-          "opera_android": {
-            "version_added": "≤12.1"
-          },
-          "safari": {
-            "version_added": "1"
-          },
-          "safari_ios": {
-            "version_added": "1"
-          },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": "1"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
+    "HTMLAnchorElement": {
       "hash": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hash",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hash",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -101,7 +53,7 @@
       },
       "host": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/host",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/host",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -150,7 +102,7 @@
       },
       "hostname": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/hostname",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hostname",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -198,7 +150,7 @@
       },
       "href": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/href",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/href",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -246,7 +198,7 @@
       },
       "origin": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/origin",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/origin",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -296,7 +248,7 @@
       },
       "password": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/password",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/password",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -394,7 +346,7 @@
       },
       "port": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/port",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/port",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -442,7 +394,7 @@
       },
       "protocol": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/protocol",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/protocol",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -490,7 +442,7 @@
       },
       "search": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/search",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/search",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -540,7 +492,7 @@
       },
       "toString": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/toString",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/toString",
           "support": {
             "chrome": {
               "version_added": "52"
@@ -588,7 +540,7 @@
       },
       "username": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/username",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/username",
           "support": {
             "chrome": {
               "version_added": "32"

--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
@@ -1,0 +1,591 @@
+{
+  "api": {
+    "HTMLAreaElement": {
+      "hash": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/hash",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "From Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "From Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "host": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/host",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5",
+              "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code>&lt;a&gt;</code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hostname": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/hostname",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "href": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/href",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "origin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/origin",
+          "support": {
+            "chrome": {
+              "version_added": "8"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "26",
+              "notes": "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
+            },
+            "firefox_android": {
+              "version_added": "26",
+              "notes": "Before Firefox 49, results for URL using the <code>blob</code> scheme incorrectly returned <code>null</code>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "password": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/password",
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "32"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "26"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "19"
+            },
+            "opera_android": {
+              "version_added": "19"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
+            "webview_android": {
+              "version_added": "4.4.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pathname": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/pathname",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "port": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/port",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "protocol": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/protocol",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "search": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/search",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1",
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+            },
+            "ie": {
+              "version_added": "5"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toString": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/toString",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": "≤18"
+            },
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "52"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "username": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/username",
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "32"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "26"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "19"
+            },
+            "opera_android": {
+              "version_added": "19"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
+            "webview_android": {
+              "version_added": "4.4.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a proof of concept for https://github.com/mdn/browser-compat-data/issues/8929

Currently, BCD exposes `api.HTMLHyperlinkElementUtils`, a non-observable mixin and no real JS interface/class/object.

api.HTMLHyperlinkElementUtils.href
api.HTMLHyperlinkElementUtils.origin
api.HTMLHyperlinkElementUtils.protocol
api.HTMLHyperlinkElementUtils.username
api.HTMLHyperlinkElementUtils.password
api.HTMLHyperlinkElementUtils.host
api.HTMLHyperlinkElementUtils.hostname
api.HTMLHyperlinkElementUtils.port
api.HTMLHyperlinkElementUtils.pathname
api.HTMLHyperlinkElementUtils.search
api.HTMLHyperlinkElementUtils.hash

With this change, BCD extends HTMLAnchorElement and HTMLAreaElement and exposes instead: 

api.HTMLAnchorElement.href
api.HTMLAnchorElement.origin
api.HTMLAnchorElement.protocol
api.HTMLAnchorElement.username
api.HTMLAnchorElement.password
api.HTMLAnchorElement.host
api.HTMLAnchorElement.hostname
api.HTMLAnchorElement.port
api.HTMLAnchorElement.pathname
api.HTMLAnchorElement.search
api.HTMLAnchorElement.hash

api.HTMLAreaElement.href
api.HTMLAreaElement.origin
api.HTMLAreaElement.protocol
api.HTMLAreaElement.username
api.HTMLAreaElement.password
api.HTMLAreaElement.host
api.HTMLAreaElement.hostname
api.HTMLAreaElement.port
api.HTMLAreaElement.pathname
api.HTMLAreaElement.search
api.HTMLAreaElement.hash

It does so by having two files in the `/api/_mixins/` folder:
- `HTMLHyperlinkElementUtils__HTMLAnchorElement.json`
- `HTMLHyperlinkElementUtils__HTMLAreaElement.json`