### PR TITLE
Remove api.WEBGL_color_buffer_float.RGB32F_EXT constant

### DIFF
--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -46,54 +46,6 @@
           "standard_track": true,
           "deprecated": false
         }
-      },
-      "RGB32F_EXT": {
-        "__compat": {
-          "description": "<code>RGB32F_EXT</code> constant",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "30"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `RGB32F_EXT` constant from the `WEBGL_color_buffer_float` as per the new no-constant data guideline.
