### PR TITLE
Update data for CSS types min, max, and clamp on Android

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -20,7 +20,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -29,7 +29,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "safari": {
               "version_added": "13.1"

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -29,7 +29,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": "66"
+              "version_added": "57"
             },
             "safari": {
               "version_added": "13.1"

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -28,7 +28,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": "66"
+              "version_added": "57"
             },
             "safari": {
               "version_added": "11.1"

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -19,7 +19,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -28,7 +28,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "safari": {
               "version_added": "11.1"

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -28,7 +28,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": "66"
+              "version_added": "57"
             },
             "safari": {
               "version_added": "11.1"

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -19,7 +19,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -28,7 +28,7 @@
               "version_added": "66"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "safari": {
               "version_added": "11.1"


### PR DESCRIPTION
Raised on the content repo as https://github.com/mdn/content/issues/1901

This PR fixes the Android values for `min()`, `max()`, and `clamp()` CSS types.
