### PR TITLE
Update Edge data for :where()

### DIFF
--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -39,7 +39,7 @@
               }
             ],
             "edge": {
-              "version_added": false
+              "version_added": "88"
             },
             "firefox": [
               {
@@ -100,7 +100,7 @@
                 "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
                 "version_added": "82"


### PR DESCRIPTION
Fixes #8931 

Adding support for `where` in Edge.
