### PR TITLE
css.properties.list-style-image - Add a note for Firefox <image> support

### DIFF
--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -15,7 +15,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Prior to Firefox 86 this property did not accept an <image> type, and required the url of an image."
             },
             "firefox_android": {
               "version_added": "4"

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -19,7 +19,8 @@
               "notes": "Before Firefox 86, this property did not accept an <code>&lt;image&gt;</code> type, and required the URL of an image."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Before Firefox 86, this property did not accept an <code>&lt;image&gt;</code> type, and required the URL of an image."
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -16,7 +16,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Prior to Firefox 86 this property did not accept an <image> type, and required the url of an image."
+              "notes": "Before Firefox 86, this property did not accept an <code>&lt;image&gt;</code> type, and required the URL of an image."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Firefox 86 implements any `<image>` for `list-style-type`.

I have tested and it seems other browsers have supported this from a long way back Safari 6.2/Chrome 26/IE10 so I think just having a note for Firefox is probably sufficient. We could make it in to a subfeature, but I don't think this is a thing a lot of people run into.