### PR TITLE
Opera 74 is released

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -566,19 +566,26 @@
         "73": {
           "release_date": "2020-12-09",
           "release_notes": "https://blogs.opera.com/desktop/2020/12/opera-73-update/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "74": {
-          "status": "beta",
+          "release_date": "2021-02-02",
+          "release_notes": "https://blogs.opera.com/desktop/2021/02/opera-74-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "88"
         },
         "75": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "89"
+        },
+        "76": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "90"
         }
       }
     }


### PR DESCRIPTION
This PR updates the Opera Desktop data to represent the newly-released Opera 74.  Source: https://blogs.opera.com/desktop/2021/02/opera-74-stable/
