### PR TITLE
Samsung Internet 13.2 is released

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -179,12 +179,13 @@
         },
         "13.0": {
           "release_date": "2020-12-02",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
         },
         "13.2": {
-          "status": "beta",
+          "release_date": "2021-01-20",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "83"
         }


### PR DESCRIPTION
This PR updates the browser data to represent the recently-released Samsung Internet 13.2.  Source: https://internet.en.uptodown.com/android/download/3156861
