### PR TITLE
Update Chrome/Safari versions for api.CSSStyleSheet.insertRule.optional_index

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -271,7 +271,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -294,10 +294,10 @@
             "description": "<code>index</code> is optional",
             "support": {
               "chrome": {
-                "version_added": "60"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "60"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -312,22 +312,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "47"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "44"
+                "version_added": "≤14"
               },
               "safari": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "≤3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": "8.0"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "60"
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
Follow-up to #8461.  By running `document.styleSheets[0].insertRule('p{ color: black;}');` in Safari 1.0, I have determined that the `index` parameter was optional since the very first WebKit release.  As such, this marks Safari as "1", and corrects Chrome to "1" (the original data came from the wiki migration so I don't trust it).
