### PR TITLE
Add Safari version for api.HTMLImageElement.lowsrc

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -822,10 +822,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -822,7 +822,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "2"


### PR DESCRIPTION
This PR replaces the ranged value for Safari for `api.HTMLImageElement.lowsrc` with a specific version number, based upon commit history.

Safari 3: https://trac.webkit.org/browser/webkit/tags/old/Safari-521.11/WebCore/html/HTMLImageElement.idl
Safari 3.1: https://trac.webkit.org/browser/webkit/tags/old/Safari-5525.13/WebCore/html/HTMLImageElement.idl#L43
