### PR TITLE
Add Safari versions for api.SVGMaskElement.mask[Content]Units

### DIFF
--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -122,10 +122,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -169,10 +169,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds Safari versions for the `maskUnits` and `maskContentUnits` attributes of the `SVGMaskElement` API based upon commit history.  https://trac.webkit.org/browser/webkit/tags/old/Safari-5525.13/WebCore/svg/SVGMaskElement.idl
