### PR TITLE
Mark -o-prefixed support from Presto as removed in Opera 15/14

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -51,7 +51,8 @@
             },
             {
               "prefix": "o",
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "15"
             }
           ],
           "opera_android": [
@@ -69,7 +70,8 @@
             },
             {
               "prefix": "o",
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "14"
             }
           ],
           "safari": [

--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -30,7 +30,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "11.6"
+                "version_added": "11.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -39,7 +40,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -29,7 +29,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "11.6"
+                "version_added": "11.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -38,7 +39,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -93,7 +95,8 @@
                 },
                 {
                   "prefix": "-o-",
-                  "version_added": "11.6"
+                  "version_added": "11.6",
+                  "version_removed": "15"
                 }
               ],
               "opera_android": [
@@ -103,7 +106,8 @@
                 },
                 {
                   "prefix": "-o-",
-                  "version_added": "12"
+                  "version_added": "12",
+                  "version_removed": "14"
                 }
               ],
               "safari": {

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -42,7 +42,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "10.5"
+                "version_added": "10.5",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -51,7 +52,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "11"
+                "version_added": "11",
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -37,7 +37,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "9"
+                "version_added": "9",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -46,7 +47,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "10.1"
+                "version_added": "10.1",
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -103,7 +103,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "10.5"
+                "version_added": "10.5",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -120,7 +121,8 @@
               },
               {
                 "prefix": "-o-",
-                "version_added": "11"
+                "version_added": "11",
+                "version_removed": "14"
               }
             ],
             "safari": [


### PR DESCRIPTION
Blink doesn't have any -o-prefixed APIs, so all of these can be set to
removed in the first release based on Blink.

The features were identified with the follow local modification:

```diff
--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -41,19 +41,12 @@ function traverseFeatures(obj, depth, identifier) {
           if (!Array.isArray(browser)) {
             browser = [browser];
           }
-          for (const range in browser) {
-            if (browser[range] === undefined) {
-              if (values.includes('null')) features.push(`${identifier}${i}`);
-            } else if (
-              values.includes(String(browser[range].version_added)) ||
-              values.includes(String(browser[range].version_removed))
-            ) {
-              let f = `${identifier}${i}`;
-              if (browser[range].prefix)
-                f += ` (${browser[range].prefix} prefix)`;
-              if (browser[range].alternative_name)
-                f += ` (as ${browser[range].alternative_name})`;
-              features.push(f);
+          for (const support of browser) {
+            if (!support) continue;
+            if (support.prefix && !support.version_removed) {
+              if (support.prefix.toLowerCase().includes('o')) {
+                features.push(`${identifier}${i}`);
+              }
             }
           }
         }
```

The updated feature are:
api.AnimationEvent
css.properties.object-fit
css.properties.object-position
css.properties.object-position.three_value_syntax
css.properties.tab-size
css.properties.text-overflow
css.properties.transform-origin