### PR TITLE
Mark object-fit/object-position as supported in Chrome 32 (not 31)

### DIFF
--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-fit",
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "16",

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-position",
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "16"
@@ -65,11 +65,11 @@
             "description": "Support for three-value syntax of position",
             "support": {
               "chrome": {
-                "version_added": "31",
+                "version_added": "32",
                 "version_removed": "68"
               },
               "chrome_android": {
-                "version_added": "31",
+                "version_added": "32",
                 "version_removed": "68"
               },
               "edge": {


### PR DESCRIPTION
The data for the other Chromium-based browsers was correct, and the
unusual offset between Opera and Chrome is how this was noticed. (The
offset was always 13 until Opera 69, but was 12 here.)

Confirmed by testing in Chrome 31 and 32:
http://mdn-bcd-collector.appspot.com/tests/css/properties/object-fit
http://mdn-bcd-collector.appspot.com/tests/css/properties/object-position
https://fregante.github.io/object-fit-images/demo/