### PR TITLE
Better reflect EdgeHTML's partial support for object-fit/object-position

### DIFF
--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -11,10 +11,17 @@
             "chrome_android": {
               "version_added": "31"
             },
-            "edge": {
-              "version_added": "16",
-              "notes": "Edge supports <code>object-fit</code> on <code>img</code> elements only. <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/13603873/#comment-0'>See Edge issue 13603873 for details</a>."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Only supported for <code>&lt;img&gt;</code> elements."
+              }
+            ],
             "firefox": {
               "version_added": "36"
             },

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -11,9 +11,17 @@
             "chrome_android": {
               "version_added": "31"
             },
-            "edge": {
-              "version_added": "16"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Only supported for <code>&lt;img&gt;</code> elements."
+              }
+            ],
             "firefox": {
               "version_added": "36"
             },


### PR DESCRIPTION
The URL linked in the original note is gone, but the issue can be seen
here: https://web.archive.org/web/20171208010253/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13603873/

To confirm that this also applied to object-position, a test using
object-position for video was run on Edge 18 and 80 to confirm:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8889

In Edge 18, object-position has no effect. Changing the demo to use
`object-fit: fill` also confirms that object-fit didn't work in Edge 18.