### PR TITLE
Mark three-value syntax for object-position as removed everywhere

### DIFF
--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -81,7 +81,8 @@
                 "version_removed": "70"
               },
               "firefox_android": {
-                "version_added": "36"
+                "version_added": "36",
+                "version_removed": "79"
               },
               "ie": {
                 "version_added": false
@@ -93,7 +94,8 @@
                 },
                 {
                   "prefix": "-o-",
-                  "version_added": "11.6"
+                  "version_added": "11.6",
+                  "version_removed": "15"
                 }
               ],
               "opera_android": [
@@ -103,14 +105,17 @@
                 },
                 {
                   "prefix": "-o-",
-                  "version_added": "12"
+                  "version_added": "12",
+                  "version_removed": "14"
                 }
               ],
               "safari": {
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "13.1"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": "2.0",
@@ -123,8 +128,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
This was the motivating case for https://github.com/mdn/browser-compat-data/issues/8964,
and fixing just this entry ensures that this will eventually resurface
when removing irrelevant features removed from all browsers.

WebKit removal: https://trac.webkit.org/changeset/251668/webkit

WebKit trunk was then at version 609.1.9.