### PR TITLE
Add IE versions for Attr API

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "6"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -328,7 +328,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/Attr.json
+++ b/api/Attr.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "6"
           },
           "opera": {
             "version_added": "8"
@@ -122,7 +122,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -328,7 +328,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -375,7 +375,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR replaces the ranged versions for IE ≤6 with specific version numbers.  Looking at `api.Element.getAttributeNode` (the method to get an `Attr` instance), it marks support in IE as 6, so it wouldn't make sense for the interface or its members to be supported before then.  (Confirmed by running https://mdn-bcd-collector.appspot.com/tests/api/Attr on IE 5.5.)
