### PR TITLE
Add IE versions for CharacterData API

### DIFF
--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR replaces the ranges of ≤6 with just "6" for the members of the CharacterData API for IE.  Since the API itself was implemented in IE 6, it's not possible for its members to be implemented earlier.  (I'll be writing a linter update to prevent this from happening.)
