### PR TITLE
A subfeature cannot have a range at same version as non-range parent

### DIFF
--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -325,7 +325,7 @@ class ConsistencyChecker {
       return compareVersions.compare(
         a_version_added.replace('≤', ''),
         b_version_added,
-        '<',
+        a_version_added.startsWith('≤') ? '<=' : '<',
       );
     }
 


### PR DESCRIPTION
This PR adds an additional update to the consistency check to disallow a subfeature having a range that is at the same version as a parent with a non-range.  In other words, if a parent is set to `6`, and a subfeature is set to `≤6`, the linter throws an error as the subfeature cannot imply earlier support than its parent.

Because there are such consistency issues already in our data, the linter will *fail* for the time being.  I will be writing PRs to resolve this.
