### PR TITLE
[api] Remove range if parent is at same version

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -115,7 +115,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLLegendElement.json
+++ b/api/HTMLLegendElement.json
@@ -66,7 +66,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -165,7 +165,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2114,7 +2114,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "62"

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "29"
@@ -155,7 +155,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "29",
@@ -205,7 +205,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -253,7 +253,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "29"

--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -117,10 +117,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -164,10 +164,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -211,10 +211,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -258,10 +258,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -305,10 +305,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -450,10 +450,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -497,10 +497,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -544,10 +544,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"


### PR DESCRIPTION
This PR corrects the issues within the `api/` folder caught by the linter updates in #8969, where it disallows a subfeature having a range that is at the same version as a parent with a non-range (ex. if the parent is `6`, the subfeature cannot be `≤6` since it implies potential earlier support).
