### PR TITLE
[css] Remove range if parent is at same version

### DIFF
--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -140,7 +140,7 @@
                 "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -188,7 +188,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -140,7 +140,7 @@
                 "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "37"
               }
             },
             "status": {
@@ -188,7 +188,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "37"
               }
             },
             "status": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -387,11 +387,11 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "≤14"
+                  "version_added": "14"
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "≤14",
+                  "version_added": "14",
                   "version_removed": "35"
                 }
               ],

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -134,7 +134,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "37"
               }
             },
             "status": {

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -189,7 +189,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR corrects the issues within the `css/` folder caught by the linter updates in #8969, where it disallows a subfeature having a range that is at the same version as a parent with a non-range (ex. if the parent is `6`, the subfeature cannot be `≤6` since it implies potential earlier support).
