### PR TITLE
html.elements.legend: Remove range if parent is at same version

### DIFF
--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -68,7 +68,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "≤6"
+                "version_added": "6"
               },
               "opera": {
                 "version_added": "≤12.1"


### PR DESCRIPTION
This PR corrects the issues within the `html/` folder caught by the linter updates in #8969, where it disallows a subfeature having a range that is at the same version as a parent with a non-range (ex. if the parent is `6`, the subfeature cannot be `≤6` since it implies potential earlier support).
