### PR TITLE
Add IE/Edge versions for HTMLBaseFontElement API

### DIFF
--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -22,7 +22,7 @@
             "version_added": false
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLBaseFontElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.1.8).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLBaseFontElement
