### PR TITLE
Add IE/Edge versions for DocumentOrShadowRoot API

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "4"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -213,7 +213,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -537,7 +537,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `DocumentOrShadowRoot` API, based upon manual testing.

Test Code Used: `document.*`
