### PR TITLE
Add IE/Edge versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera": {
             "version_added": true
@@ -723,7 +723,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "9"
@@ -819,7 +819,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -941,7 +941,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1842,7 +1842,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1890,7 +1890,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1938,7 +1938,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2318,7 +2318,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2462,7 +2462,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2510,7 +2510,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2558,7 +2558,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2606,7 +2606,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -3834,7 +3834,7 @@
               "version_added": "38"
             },
             "ie": {
-              "version_added": "≤6",
+              "version_added": "4",
               "partial_implementation": true,
               "notes": "In Internet Explorer, this handler was only supported on the <a href='https://developer.mozilla.org/docs/Web/API/Window'><code>Window</code></a> API."
             },
@@ -4124,7 +4124,7 @@
               }
             ],
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "15"
@@ -4196,7 +4196,7 @@
               }
             ],
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `GlobalEventHandlers` API, based upon manual testing.

Test Code Used: `window.onresize; document.*;`
