### PR TITLE
Update note for Firefox support for CSS flex-direction with reverse

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -38,7 +38,7 @@
                 "partial_implementation": true,
                 "notes": [
                   "Since Firefox 28, multi-line flexbox is supported.",
-                  "Does not support overflow when using <code>*-reverse</code>. See <a href='https://bugzil.la/1042151'>bug 1042151</a> for more info."
+                  "Before Firefox 81, overflow with <code>*-reverse</code> is unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
                 ]
               },
               {
@@ -74,7 +74,7 @@
                 "partial_implementation": true,
                 "notes": [
                   "Since Firefox 28, multi-line flexbox is supported.",
-                  "Does not support overflow when using <code>*-reverse</code>. See <a href='https://bugzil.la/1042151'>bug 1042151</a> for more info."
+                  "Before Firefox 81, overflow with <code>*-reverse</code> is unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
                 ]
               },
               {


### PR DESCRIPTION
This PR addresses issue #8883 for both Firefox and Firefox for Android.

Fixes #8883