### PR TITLE
Add IE/Edge versions for HTMLDirectoryElement API

### DIFF
--- a/api/HTMLDirectoryElement.json
+++ b/api/HTMLDirectoryElement.json
@@ -19,7 +19,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -65,7 +65,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLDirectoryElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElement('dir');`
