### PR TITLE
Add IE/Edge versions for HTMLDocument API

### DIFF
--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "4"
           },
           "opera": {
             "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLDocument` API, based upon manual testing.

Test Code Used: `var instance = document;`
