### PR TITLE
Add IE/Edge versions for HTMLElement API

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2387,7 +2387,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElement('element'); instance.outerText !== undefined;`
