### PR TITLE
Add IE/Edge versions for HTMLEmbedElement API

### DIFF
--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -166,7 +166,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -213,7 +213,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -260,7 +260,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -354,7 +354,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLEmbedElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElement('embed'); instance.*;`
