### PR TITLE
Add IE/Edge versions for HTMLHeadElement API

### DIFF
--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -68,7 +68,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLHeadElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElement('head');`
