### PR TITLE
Add IE/Edge versions for HTMLHtmlElement API

### DIFF
--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -66,7 +66,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLHtmlElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElement('html');`
