### PR TITLE
Add IE/Edge versions for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "8"
@@ -816,7 +816,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": true
@@ -1005,7 +1005,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLImageElement` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement
