### PR TITLE
Add IE/Edge versions for NamedNodeMap API

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -42,7 +42,7 @@
             }
           ],
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -89,7 +89,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -185,7 +185,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -233,7 +233,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -281,7 +281,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -377,7 +377,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `NamedNodeMap` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/NamedNodeMap
