### PR TITLE
Add IE/Edge versions for HTMLLIElement API

### DIFF
--- a/api/HTMLLIElement.json
+++ b/api/HTMLLIElement.json
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLLIElement` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLLIElement
