### PR TITLE
Add IE/Edge versions for HTMLMetaElement API

### DIFF
--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -66,7 +66,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -113,7 +113,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -160,7 +160,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -207,7 +207,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLMetaElement` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMetaElement
