### PR TITLE
Add IE/Edge versions for HTMLOptionElement API

### DIFF
--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLOptionElement` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLOptionElement
