### PR TITLE
Add IE/Edge versions for HTMLTextAreaElement API

### DIFF
--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "8"
@@ -209,7 +209,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -256,7 +256,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -350,7 +350,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -397,7 +397,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -586,7 +586,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -680,7 +680,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -822,7 +822,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -869,7 +869,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1246,7 +1246,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1387,7 +1387,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1481,7 +1481,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `HTMLTextAreaElement` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLTextAreaElement
