### PR TITLE
Update Safari version for arrayBuffer()

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -128,10 +128,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
This PR addresses issue #8798 updating data for Safari and Safari iOS.