### PR TITLE
Add IE/Edge versions for NavigatorID API

### DIFF
--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "3"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -67,7 +67,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -215,7 +215,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -311,7 +311,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -361,7 +361,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `NavigatorID` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigatorID
