### PR TITLE
Add IE/Edge versions for NavigatorOnLine API

### DIFF
--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "4"
           },
           "opera": {
             "version_added": "3"
@@ -69,7 +69,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6",
+              "version_added": "4",
               "notes": "in Internet Explorer 8 'online' and 'offline' events are raised on the <code>document.body</code>; under IE 9 they are raised on both <code>document.body</code> and <code>window</code>."
             },
             "opera": {


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `NavigatorOnLine` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigatorOnLine
