### PR TITLE
Add IE/Edge versions for Node API

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -438,7 +438,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -688,7 +688,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -736,7 +736,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "7"
@@ -1046,7 +1046,7 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1366,7 +1366,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1462,7 +1462,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -1881,7 +1881,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "7"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Node` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/Node
