### PR TITLE
Add IE/Edge versions for NodeList API

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "8"
@@ -163,7 +163,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -259,7 +259,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `NodeList` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/NodeList
