### PR TITLE
Add IE/Edge versions for PluginArray API

### DIFF
--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "4"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -70,7 +70,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -122,7 +122,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "4"
             },
             "opera": {
               "version_added": true
@@ -173,7 +173,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1",
@@ -228,7 +228,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "6"
             },
             "opera": {
               "version_added": "≤12.1",


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `PluginArray` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/PluginArray
