### PR TITLE
Add IE versions for CharacterData/Text API

### DIFF
--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/Text.json
+++ b/api/Text.json
@@ -17,7 +17,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": "≤6"
+            "version_added": "5"
           },
           "opera": {
             "version_added": true
@@ -269,7 +269,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "5"
             },
             "opera": {
               "version_added": true,

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -566,19 +566,26 @@
         "73": {
           "release_date": "2020-12-09",
           "release_notes": "https://blogs.opera.com/desktop/2020/12/opera-73-update/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "74": {
-          "status": "beta",
+          "release_date": "2021-02-02",
+          "release_notes": "https://blogs.opera.com/desktop/2021/02/opera-74-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "88"
         },
         "75": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "89"
+        },
+        "76": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "90"
         }
       }
     }


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Text` API (and in turn, the `CharacterData` mixin it implements), based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/Text & https://mdn-bcd-collector.appspot.com/tests/api/CharacterData

Resolves an issue blocking #8969.