### PR TITLE
Add IE/Edge versions for api.Window.closed

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1328,7 +1328,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "3"
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1328,7 +1328,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "≤6"
+              "version_added": "3"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `closed` member of the `Window` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/closed
