### PR TITLE
Fix mirroring of Chrome -> WebView for css.properties.background-repeat

### DIFF
--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -86,7 +86,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "1"
               }
             },
             "status": {
@@ -140,7 +140,7 @@
                 "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4.4"
               }
             },
             "status": {


### PR DESCRIPTION
This PR fixes the WebView data for the `background-repeat` CSS property.  A while back, I had performed mirroring, however at the time I had not accounted for ranged versions, or Chrome 1.  This resolves said issues, as anything in Chrome 1 would certainly be in WebView 1.