### PR TITLE
Fix Opera Android version for min-width CSS property

### DIFF
--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -30,7 +30,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>min-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>min-width</code> to <code>table</code> elements."
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"


### PR DESCRIPTION
This PR fixes the mirroring of Opera to Opera Android for the CSS `min-width` property.  For some odd reason, I had mirrored this improperly.
