### PR TITLE
Fix mirroring of Chrome -> WebView for css.properties.word-spacing

### DIFF
--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR fixes the WebView data for the `word-spacing` CSS property. A while back, I had performed mirroring, however at the time I had not accounted for ranged versions, or Chrome 1. This resolves said issues, as anything in Chrome 1 would certainly be in WebView 1.
