### PR TITLE
Fix mirroring of Chrome -> WebView for css.selectors.hover

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -41,7 +41,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR fixes the WebView data for the `hover` CSS selection. A while back, I had performed mirroring, however at the time I had not accounted for ranged versions, or Chrome 1. This resolves said issues, as anything in Chrome 1 would certainly be in WebView 1.
