### PR TITLE
Demix DocumentOrShadowRoot

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -121,56 +121,6 @@
           }
         }
       },
-      "documentorshadowroot": {
-        "__compat": {
-          "description": "Features included from the <code>DocumentOrShadowRoot</code> mixin",
-          "support": {
-            "chrome": {
-              "version_added": "53"
-            },
-            "chrome_android": {
-              "version_added": "53"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "63"
-            },
-            "firefox_android": {
-              "version_added": "63"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "40"
-            },
-            "opera_android": {
-              "version_added": "41"
-            },
-            "safari": {
-              "version_added": false,
-              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
-            },
-            "safari_ios": {
-              "version_added": false,
-              "notes": "Features still implemented on the <a href='https://developer.mozilla.org/docs/Web/API/Document'>Document</a> interface"
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "53"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "host": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/host",

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -1,55 +1,9 @@
 {
   "api": {
-    "DocumentOrShadowRoot": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot",
-        "support": {
-          "chrome": {
-            "version_added": "1"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "firefox": {
-            "version_added": "1"
-          },
-          "firefox_android": {
-            "version_added": "4"
-          },
-          "ie": {
-            "version_added": "4"
-          },
-          "opera": {
-            "version_added": "≤12.1"
-          },
-          "opera_android": {
-            "version_added": "≤12.1"
-          },
-          "safari": {
-            "version_added": "4"
-          },
-          "safari_ios": {
-            "version_added": "3.2"
-          },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": "1"
-          }
-        },
-        "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
+    "Document": {
       "activeElement": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/activeElement",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/activeElement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -89,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -97,7 +51,7 @@
       },
       "adoptedStyleSheets": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/adoptedStyleSheets",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/adoptedStyleSheets",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -137,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -145,7 +99,7 @@
       },
       "caretPositionFromPoint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/caretPositionFromPoint",
           "support": {
             "chrome": {
               "version_added": false
@@ -185,7 +139,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -193,7 +147,7 @@
       },
       "elementFromPoint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/elementFromPoint",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/elementFromPoint",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -239,7 +193,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -247,7 +201,7 @@
       },
       "elementsFromPoint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/elementsFromPoint",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/elementsFromPoint",
           "support": {
             "chrome": {
               "version_added": "43",
@@ -295,7 +249,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -303,7 +257,7 @@
       },
       "fullscreenElement": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/fullscreenElement",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenElement",
           "support": {
             "chrome": [
               {
@@ -423,7 +377,7 @@
       },
       "getSelection": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/getSelection",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getSelection",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -463,7 +417,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -471,7 +425,7 @@
       },
       "pointerLockElement": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/pointerLockElement",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerLockElement",
           "support": {
             "chrome": {
               "version_added": "37"
@@ -511,7 +465,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -519,7 +473,7 @@
       },
       "styleSheets": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentOrShadowRoot/styleSheets",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/styleSheets",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -559,7 +513,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -211,11 +211,17 @@
               "version_added": "43",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
-            "edge": {
-              "version_added": "12",
-              "alternative_name": "msElementsFromPoint",
-              "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "alternative_name": "msElementsFromPoint",
+                "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
+              }
+            ],
             "firefox": {
               "version_added": "46"
             },
@@ -336,14 +342,24 @@
               "version_added": true,
               "prefix": "ms"
             },
-            "opera": {
-              "version_added": "40",
-              "prefix": "webkit"
-            },
-            "opera_android": {
-              "version_added": "41",
-              "prefix": "webkit"
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "40",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "41",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": true,
               "prefix": "webkit"
@@ -354,10 +370,15 @@
               "partial_implementation": true,
               "notes": "Full-screen mode is only supported on the iPad."
             },
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "prefix": "webkit"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "6.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
@@ -443,7 +464,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "24"
@@ -452,10 +473,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -1,0 +1,577 @@
+{
+  "api": {
+    "ShadowRoot": {
+      "activeElement": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/activeElement",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "adoptedStyleSheets": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/adoptedStyleSheets",
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "caretPositionFromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/caretPositionFromPoint",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elementFromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/elementFromPoint",
+          "support": {
+            "chrome": {
+              "version_added": "53",
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "chrome_android": {
+              "version_added": "53",
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40",
+              "notes": "Before Opera 53, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "opera_android": {
+              "version_added": "41",
+              "notes": "Before Opera Android 47, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 9.0, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "webview_android": {
+              "version_added": "53",
+              "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elementsFromPoint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/elementsFromPoint",
+          "support": {
+            "chrome": {
+              "version_added": "53",
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "chrome_android": {
+              "version_added": "53",
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 9.0, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            },
+            "webview_android": {
+              "version_added": "53",
+              "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fullscreenElement": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/fullscreenElement",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40",
+              "prefix": "webkit"
+            },
+            "opera_android": {
+              "version_added": "41",
+              "prefix": "webkit"
+            },
+            "safari": {
+              "version_added": true,
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": "12",
+              "alternative_name": "webkitFullscreenElement",
+              "partial_implementation": true,
+              "notes": "Full-screen mode is only supported on the iPad."
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0",
+              "prefix": "webkit"
+            },
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "53",
+                "prefix": "webkit"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSelection": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/getSelection",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerLockElement": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/pointerLockElement",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "styleSheets": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/styleSheets",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -281,24 +281,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/fullscreenElement",
           "support": {
-            "chrome": [
-              {
-                "version_added": "71"
-              },
-              {
-                "version_added": "53",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "71"
-              },
-              {
-                "version_added": "53",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -312,36 +300,23 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "40",
-              "prefix": "webkit"
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": "41",
-              "prefix": "webkit"
+              "version_added": "50"
             },
             "safari": {
-              "version_added": true,
-              "prefix": "webkit"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "12",
-              "alternative_name": "webkitFullscreenElement",
-              "partial_implementation": true,
-              "notes": "Full-screen mode is only supported on the iPad."
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0",
-              "prefix": "webkit"
+              "version_added": "10.0"
             },
-            "webview_android": [
-              {
-                "version_added": "71"
-              },
-              {
-                "version_added": "53",
-                "prefix": "webkit"
-              }
-            ]
+            "webview_android": {
+              "version_added": "71"
+            }
           },
           "status": {
             "experimental": false,
@@ -482,7 +457,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -553,10 +528,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
So, here we saw quite early version numbers, probably to fix https://github.com/mdn/browser-compat-data/issues/3504.
I've left those early versions for the Document part here.

For the ShadowRoot part, I've temporarily added a root compat data object api.ShadowRoot to this file, so the consistency checker would complain (it currently doesn't, I filed https://github.com/mdn/browser-compat-data/issues/9044). I've then bumped the versions up to the basic support of ShadowRoot for all features of ShadowRoot.

I've removed the documentorshadowroot feature from ShadowRoot. It makes no sense with the new mixin approach, imo.

It would be cool if some automation could actually verify the version numbers here, since I want to focus on demixing instead of on researching the correct data for two interfaces. (cc @foolip)