### PR TITLE
details for the different types in URLSearchParams.constructor

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -181,7 +181,7 @@
                 "version_added": "17"
               },
               "firefox": {
-                "version_added": "53"
+                "version_added": "54"
               },
               "firefox_android": {
                 "version_added": "54"
@@ -196,7 +196,7 @@
                 "version_added": "48"
               },
               "opera_android": {
-                "version_added": "48"
+                "version_added": "45"
               },
               "safari": {
                 "version_added": "11"
@@ -259,7 +259,7 @@
                 "version_added": "7.2"
               },
               "webview_android": {
-                "version_added": "61"
+                "version_added": "58"
               }
             },
             "status": {

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -167,57 +167,6 @@
             }
           }
         },
-        "sequence": {
-          "__compat": {
-            "description": "sequence for <code>init</code> object",
-            "support": {
-              "chrome": {
-                "version_added": "58"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": {
-                "version_added": "17"
-              },
-              "firefox": {
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "version_added": "53"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "7.10.0"
-              },
-              "opera": {
-                "version_added": "45"
-              },
-              "opera_android": {
-                "version_added": "45"
-              },
-              "safari": {
-                "version_added": "11"
-              },
-              "safari_ios": {
-                "version_added": "11"
-              },
-              "samsunginternet_android": {
-                "version_added": "7.2"
-              },
-              "webview_android": {
-                "version_added": "61"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "record": {
           "__compat": {
             "description": "record for <code>init</code> object",
@@ -257,6 +206,57 @@
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sequence": {
+          "__compat": {
+            "description": "sequence for <code>init</code> object",
+            "support": {
+              "chrome": {
+                "version_added": "58"
+              },
+              "chrome_android": {
+                "version_added": "58"
+              },
+              "edge": {
+                "version_added": "17"
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "7.10.0"
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "7.2"
               },
               "webview_android": {
                 "version_added": "61"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -247,7 +247,7 @@
                 "version_added": "45"
               },
               "opera_android": {
-                "version_added": "45"
+                "version_added": "43"
               },
               "safari": {
                 "version_added": "11"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -116,9 +116,111 @@
             "deprecated": false
           }
         },
-        "USVString_sequence": {
+        "USVString": {
           "__compat": {
-            "description": "<code>USVString</code> or sequence for <code>init</code> object",
+            "description": "<code>USVString</code> for <code>init</code> object",
+            "support": {
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
+              "edge": {
+                "version_added": "17"
+              },
+              "firefox": {
+                "version_added": "29"
+              },
+              "firefox_android": {
+                "version_added": "29"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "7.5.0"
+              },
+              "opera": {
+                "version_added": "36"
+              },
+              "opera_android": {
+                "version_added": "36"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "49"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sequence": {
+          "__compat": {
+            "description": "sequence for <code>init</code> object",
+            "support": {
+              "chrome": {
+                "version_added": "58"
+              },
+              "chrome_android": {
+                "version_added": "58"
+              },
+              "edge": {
+                "version_added": "17"
+              },
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "7.10.0"
+              },
+              "opera": {
+                "version_added": "45"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "7.2"
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "record": {
+          "__compat": {
+            "description": "record for <code>init</code> object",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -133,32 +235,25 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": "54"
               },
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.10.0"
-                },
-                {
-                  "version_added": "7.5.0",
-                  "partial_implementation": true,
-                  "notes": "Only string as <code>init</code> object supported."
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.10.0"
+              },
               "opera": {
                 "version_added": "48"
               },
               "opera_android": {
-                "version_added": "45"
+                "version_added": "48"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
fixes : #8829

In short : 

`URLSearchParams.constructor` supports multiple types of init args.
Support for each type was added in different versions for most browser engines.

This change is intended to make it more clear which browsers support which init types.

_I am not yet used to all the naming conventions here so any feedback is super welcome!_