### PR TITLE
html.elements.video: Fix crossorigin support for Firefox

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -272,7 +272,7 @@
                   "version_added": "12",
                   "version_removed": "74",
                   "partial_implementation": true,
-                  "notes": "See Bugzilla <a href='https://bugzil.la/1532722'>bug 1532722</a>."
+                  "notes": "With <code>crossorigin=\"use-credentials\"</code>, cookies aren't sent during seek. See <a href='https://bugzil.la/1532722'>bug 1532722</a>."
                 }
               ],
               "firefox_android": [
@@ -283,7 +283,7 @@
                   "version_added": "14",
                   "version_removed": "79",
                   "partial_implementation": true,
-                  "notes": "See Bugzilla <a href='https://bugzil.la/1532722'>bug 1532722</a>."
+                  "notes": "With <code>crossorigin=\"use-credentials\"</code>, cookies aren't sent during seek. See <a href='https://bugzil.la/1532722'>bug 1532722</a>."
                 }
               ],
               "ie": {

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -264,12 +264,28 @@
               "edge": {
                 "version_added": "≤18"
               },
-              "firefox": {
-                "version_added": "12"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox": [
+                {
+                  "version_added": "74"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "74",
+                  "partial_implementation": true,
+                  "notes": "See Bugzilla <a href='https://bugzil.la/1532722'>bug 1532722</a>."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "See Bugzilla <a href='https://bugzil.la/1532722'>bug 1532722</a>."
+                }
+              ],
               "ie": {
                 "version_added": null
               },


### PR DESCRIPTION
Due to [Bugzilla bug 1532722](https://bugzilla.mozilla.org/show_bug.cgi?id=1532722), full support for the crossorigin attribute only became available with Firefox 74 and Firefox Android 79. See #9038.

This PR:

* Sets full implementation to 74 for Firefox and 79 for Firefox Android.
* Sets partial implementation to [12, 74) for Firefox and [14, 79) for Firefox Android.
* Adds a note linking to the appropriate Bugzilla report.

Guidance on what to change in the video.json file was provided by @ddbeck. Npm `test` and `lint` showed no errors. I have read and agree to the project's contribution guidelines and code of conduct.