### PR TITLE
Update Firefox Clipboard API support

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -103,6 +103,7 @@
               {
                 "version_added": "63",
                 "version_removed": "87",
+                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
@@ -110,7 +111,10 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
+                "notes": [
+                  "This method returns a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
+                  "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+                ]
               }
             ],
             "firefox_android": [
@@ -128,6 +132,7 @@
               {
                 "version_added": "63",
                 "version_removed": "87",
+                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
@@ -135,7 +140,10 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
+                "notes": [
+                  "This method returns a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
+                  "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+                ]
               }
             ],
             "ie": {
@@ -255,6 +263,7 @@
               },
               {
                 "version_added": "63",
+                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
@@ -262,7 +271,10 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
+                "notes": [
+                  "This method accepts a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
+                  "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+                ]
               }
             ],
             "firefox_android": [
@@ -279,6 +291,7 @@
               },
               {
                 "version_added": "63",
+                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
@@ -286,7 +299,10 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
+                "notes": [
+                  "This method accepts a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
+                  "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+                ]
               }
             ],
             "ie": {

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -88,28 +88,56 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.dataTransfer",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
-            },
-            "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.dataTransfer",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
-            },
+            "firefox": [
+              {
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.clipboardItem",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+              },
+              {
+                "version_added": "63",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.dataTransfer",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.clipboardItem",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
+              },
+              {
+                "version_added": "63",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.dataTransfer",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Currently works just like <code>readText()</code>; non-text content is not currently supported."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -213,28 +241,54 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.dataTransfer",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
-            },
-            "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.dataTransfer",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
-            },
+            "firefox": [
+              {
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.clipboardItem",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.dataTransfer",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.clipboardItem",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.dataTransfer",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Currently works exactly like <code>writeText()</code>, including the availability limitations currently imposed by Firefox."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -14,10 +14,24 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "87",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.events.asyncClipboard.clipboardItem",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "87",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.events.asyncClipboard.clipboardItem",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
             "version_added": false
@@ -62,10 +76,24 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -110,10 +138,24 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -157,10 +199,24 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -205,10 +261,24 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "87",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.events.asyncClipboard.clipboardItem",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
- ClipboardItem is now implemented behind a pref.
- clipboard.read and clipboad.write are also behind the same pref.
- clipboard.write now supports more types, not just text.
- Chrome's implementation of clipboard.read is marked as partial, so maybe Firefox's should be as well? Sadly the spec here is a very bad state. By the same token clipboard.write could be marked as partial... 
- It's also interesting to note that the previous implementation of read/write used DataTransfer, which was completely different from the specified ClipboardItem.

https://bugzilla.mozilla.org/show_bug.cgi?id=1619947
https://bugzilla.mozilla.org/show_bug.cgi?id=1689886

The last bug hasn't been merged yet, so waiting on that.
