### PR TITLE
api.HTMLCanvasElement.getContext.powerPreference works on macOS only

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -314,10 +314,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "63"
+                "version_added": "63",
+                "partial_implementation": true,
+                "notes": "Firefox respects the GPU hint on macOS only."
               },
               "firefox_android": {
-                "version_added": "63"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -344,7 +344,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This is a substitute to the stalled PR #7667. The feature was only ever implemented in Firefox on macOS. I did some checking and it has not been implemented in Chromium or WebKit, so I set the experimental flag to `true` while I was here.

https://bugzilla.mozilla.org/show_bug.cgi?id=1349799
https://bugzilla.mozilla.org/show_bug.cgi?id=1496459

Closes #7667.
