### PR TITLE
Fix IE data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "4"
+            "version_added": "5"
           },
           "opera": {
             "version_added": "8"
@@ -4048,7 +4048,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "9.5"
@@ -4907,7 +4907,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"
@@ -5022,7 +5022,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": "4",
+              "version_added": "5",
               "notes": [
                 "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a <code>&lt;table&gt;</code>, <code>&lt;tbody&gt;</code>, <code>&lt;thead&gt;</code>, or <code>&lt;tr&gt;</code> element.",
                 "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
@@ -6189,7 +6189,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": "5"
             },
             "opera": {
               "version_added": "8"


### PR DESCRIPTION
This PR fixes the Element API data for Internet Explorer.  Previously, the API was listed as supported since IE 4 (apparently, by my doing).  However, so far I haven't found a single way to obtain an Element instance in IE 4, whether through variables or methods.

I believe that when I initially set IE to "4" for this API, I must have made a typo on my document and not realized it to be so.  The data for the modified subfeatures also came from the initial wiki page migration, so I'm less likely to trust its data.
