### PR TITLE
Set explicit version for api.SharedWorker.SharedWorker.name_option

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -162,7 +162,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"


### PR DESCRIPTION
This PR changes the ranged value for `api.SharedWorker.SharedWorker.name_option` to an explicit version ("≤79" to "79").  Because the `SharedWorker` API wasn't around in EdgeHTML versions, it makes no sense to mark this as "potentially in EdgeHTML versions".

Part of work for #8969.
