### PR TITLE
api.Notification.data - Some browsers does support feature

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -15,7 +15,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "44"
+            "version_added": true
           },
           "edge": {
             "version_added": "14"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -15,7 +15,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": false
+            "version_added": "44"
           },
           "edge": {
             "version_added": "14"
@@ -331,10 +331,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Notification/data",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "edge": {
               "version_added": "16"
@@ -349,10 +349,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Cf. issue https://github.com/mdn/browser-compat-data/issues/8946

-> the data feature in Notification.json needs to be updated to show that it was added in Chrome 44, Chrome for Android 44, Opera 31, and Opera for Android 32.

Official documentation listing the availability of this feature for these browsers : https://chromestatus.com/feature/5736434757533696 (but it seems that Android WebView still does not support Notifications : https://bugs.chromium.org/p/chromium/issues/detail?id=551446)