### PR TITLE
Move "masonry" under "grid-template-rows" so it is treated as a value rather than a property

### DIFF
--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -224,6 +224,62 @@
             }
           }
         },
+        "masonry": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Masonry",
+            "description": "<code>masonry</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid-template-masonry-value.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "minmax": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax()",
@@ -534,62 +590,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        }
-      },
-      "masonry": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Masonry",
-          "description": "<code>masonry</code>",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid-template-masonry-value.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Currently the "masonry" value of `grid-template-rows` appears as a sibling of `grid-template-rows` rather than a child. As a result it is interpreted on caniuse (and perhaps other places) as its own property, rather than a value.

This PR moves it as a child of `grid-template-rows` to correct this issue.