### PR TITLE
Mirror Safari -> Safari iOS for HTMLElement, HTMLLIElement, ImageData

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1326,7 +1326,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLLIElement.json
+++ b/api/HTMLLIElement.json
@@ -80,7 +80,7 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -32,7 +32,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -128,7 +128,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -176,7 +176,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -224,7 +224,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR performs some mirroring of Safari to Safari iOS versions for three APIs (`HTMLElement`, `HTMLLIElement`, and `ImageData`).
