### PR TITLE
Add Edge versions for AudioListener API

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -115,7 +115,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -165,7 +165,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -215,7 +215,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -265,7 +265,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -315,7 +315,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -365,7 +365,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -568,7 +568,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -618,7 +618,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -668,7 +668,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `AudioListener` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioListener
