### PR TITLE
Add Edge versions for AudioParam API

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -58,7 +58,7 @@
               "version_added": "68"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -358,7 +358,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -406,7 +406,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `AudioParam` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioParam
