### PR TITLE
Add Edge versions for BaseAudioContext API

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -17,7 +17,8 @@
             {
               "version_added": "12",
               "version_removed": "79",
-              "note": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> interface."
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> interface."
             }
           ],
           "firefox": {

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "53"
@@ -121,7 +121,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -186,7 +186,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -251,7 +251,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -316,7 +316,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -381,7 +381,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -446,7 +446,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -559,7 +559,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -624,7 +624,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -689,7 +689,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -754,7 +754,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -818,7 +818,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "53",
@@ -869,7 +869,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -934,7 +934,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1018,7 +1018,7 @@
               }
             ],
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1101,7 +1101,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false
@@ -1151,7 +1151,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1215,7 +1215,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1266,7 +1266,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1331,7 +1331,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1396,7 +1396,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1511,7 +1511,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1576,7 +1576,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53"
@@ -1638,7 +1638,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "53",
@@ -1691,7 +1691,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53",
@@ -1755,7 +1755,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "53",

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "53"
@@ -121,7 +121,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -186,7 +186,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -251,7 +251,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -316,7 +316,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -381,7 +381,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -446,7 +446,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -510,7 +510,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -559,7 +559,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -624,7 +624,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -689,7 +689,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -754,7 +754,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -818,7 +818,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -869,7 +869,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -934,7 +934,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1018,7 +1018,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1101,7 +1101,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "≤18"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1151,7 +1151,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1215,7 +1215,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1266,7 +1266,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1331,7 +1331,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1396,7 +1396,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1511,7 +1511,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1576,7 +1576,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -1638,7 +1638,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1691,7 +1691,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1755,7 +1755,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -10,9 +10,16 @@
           "chrome_android": {
             "version_added": true
           },
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79",
+              "note": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> interface."
+            }
+          ],
           "firefox": {
             "version_added": "53"
           },


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `BaseAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext
