### PR TITLE
Add Edge versions for Cache API

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -13,7 +13,7 @@
             "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "16"
           },
           "firefox": {
             "version_added": "39",
@@ -428,7 +428,7 @@
               "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Cache` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Cache
