### PR TITLE
Add Edge versions for ChannelSplitterNode API

### DIFF
--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -13,7 +13,7 @@
             "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ChannelSplitterNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ChannelSplitterNode
