### PR TITLE
Update Edge versions for CustomEvent API

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"
@@ -167,7 +167,7 @@
               }
             ],
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `CustomEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CustomEvent
