### PR TITLE
Add Edge versions for DeviceLightEvent API

### DIFF
--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "13",
             "version_removed": "79"
           },
           "firefox": [


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `DeviceLightEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceLightEvent
