### PR TITLE
Add Edge versions for ExtendableMessageEvent API

### DIFF
--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "45",
@@ -60,7 +60,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",
@@ -109,7 +109,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",
@@ -207,7 +207,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "firefox": {
               "version_added": false
@@ -255,7 +255,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",
@@ -304,7 +304,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ExtendableMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ExtendableMessageEvent
