### PR TITLE
Add Edge versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "notes": "From Firefox 78 this function does nothing, as the specification requires.",
@@ -107,7 +107,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
