### PR TITLE
Add Edge versions for Headers API

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -33,7 +33,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": [
             {
@@ -135,20 +135,9 @@
                 ]
               }
             ],
-            "edge": [
-              {
-                "version_added": "≤79"
-              },
-              {
-                "version_added": "≤79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "14"
+            },
             "firefox": [
               {
                 "version_added": "39"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Headers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Headers
