### PR TITLE
Add Edge versions for api.ImageData.ImageData

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "29"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ImageData` member of the `ImageData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageData/ImageData
