### PR TITLE
Add Edge versions for MediaElementAudioSourceNode API

### DIFF
--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"
@@ -61,7 +61,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaElementAudioSourceNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaElementAudioSourceNode
