### PR TITLE
Add Edge versions for MediaKeyMessageEvent API

### DIFF
--- a/api/MediaKeyMessageEvent.json
+++ b/api/MediaKeyMessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "13"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaKeyMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaKeyMessageEvent
