### PR TITLE
Add Edge versions for MediaKeyStatusMap API

### DIFF
--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "13"
           },
           "firefox": {
             "version_added": "38"
@@ -393,7 +393,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "45"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaKeyStatusMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaKeyStatusMap
