### PR TITLE
Add Edge versions for MediaCapabilities API

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -11,7 +11,7 @@
             "version_added": "66"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "63"
@@ -58,7 +58,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaCapabilities` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaCapabilities
