### PR TITLE
Add Edge versions for MediaError API

### DIFF
--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -113,7 +113,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaError
