### PR TITLE
Add Edge versions for api.MediaQueryList.onchange

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -303,7 +303,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onchange` member of the `MediaQueryList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaQueryList/onchange
