### PR TITLE
Add Edge versions for MediaQueryListEvent API

### DIFF
--- a/api/MediaQueryListEvent.json
+++ b/api/MediaQueryListEvent.json
@@ -11,7 +11,7 @@
             "version_added": "39"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "55"
@@ -59,7 +59,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -107,7 +107,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -155,7 +155,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaQueryListEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaQueryListEvent
