### PR TITLE
Add Edge versions for MediaStream API

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -95,7 +95,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "44"
@@ -389,7 +389,7 @@
               "notes": "Deprecated in Chrome 52."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -746,7 +746,7 @@
               "notes": "Deprecated in Chrome 45."
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -798,7 +798,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": null
@@ -894,7 +894,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaStream` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStream
