### PR TITLE
Add Edge versions for MediaStreamTrackEvent API

### DIFF
--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -59,7 +59,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaStreamTrackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamTrackEvent
