### PR TITLE
Add Edge versions for OES_element_index_uint API

### DIFF
--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "24"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `OES_element_index_uint` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_element_index_uint
