### PR TITLE
Add Edge versions for Path2D API

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -11,7 +11,7 @@
             "version_added": "36"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "31"
@@ -59,7 +59,7 @@
               "version_added": "36"
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "14",
               "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
             },
             "firefox": {
@@ -108,7 +108,7 @@
               "version_added": "68"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "34"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Path2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Path2D
