### PR TITLE
Add Edge versions for RTCIceCandidate API

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "22"
@@ -59,7 +59,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "22",
@@ -212,7 +212,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -260,7 +260,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -308,7 +308,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -356,7 +356,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -404,7 +404,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -452,7 +452,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -500,7 +500,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -644,7 +644,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -740,7 +740,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -788,7 +788,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "67"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCIceCandidate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidate
