### PR TITLE
Add Edge versions for RTCPeerConnection API

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "22"
@@ -89,7 +89,7 @@
               "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "22"
@@ -355,7 +355,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -795,7 +795,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -945,7 +945,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -1167,7 +1167,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -1466,7 +1466,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -1578,7 +1578,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -2570,7 +2570,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -3306,7 +3306,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -3481,7 +3481,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -3543,7 +3543,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -3785,7 +3785,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -3932,7 +3932,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCPeerConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection
