### PR TITLE
Add Edge versions for RTCSessionDescription API

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "prefix": "moz",
@@ -60,7 +60,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "prefix": "moz",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCSessionDescription` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCSessionDescription
