### PR TITLE
Add Edge versions for api.Range.Range

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -61,7 +61,7 @@
               "version_added": "29"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "24"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Range` member of the `Range` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Range/Range
