### PR TITLE
Add <form rel> initial compat data

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -473,6 +473,53 @@
             }
           }
         },
+        "rel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "target": {
           "__compat": {
             "support": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
    Adding `<form rel>` compat data as per the revised spec: https://github.com/whatwg/html/pull/4332.
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
    - Mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1509346
    - Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=931209
    - WebKit: https://bugs.webkit.org/show_bug.cgi?id=194398
- [x] Data: if you tested something, describe how you tested with details like browser and version
    - No browser has implemented this feature as far as I know.
    - Tested with Firefox 85, Chrome 88, Safari 14, and IE 11.
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
    Fell into this rabbit hole while preparing https://github.com/mdn/content/pull/2236. Should follow up there once this data is available.
