### PR TITLE
feImage note: doesn't work with doc fragments on Firefox

### DIFF
--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -62,7 +62,7 @@
               },
               "firefox": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "firefox_android": {
                 "version_added": true,

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -66,7 +66,7 @@
               },
               "firefox_android": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -159,7 +159,7 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "firefox_android": {
                 "version_added": true,

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -156,10 +156,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -62,11 +62,11 @@
               },
               "firefox": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "firefox_android": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true
@@ -159,11 +159,11 @@
               },
               "firefox": {
                 "version_added": "4",
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "firefox_android": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -61,10 +61,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986 '>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -163,7 +163,7 @@
               },
               "firefox_android": {
                 "version_added": true,
-                "notes": "Document fragments (including references to fragments in current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
+                "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
Firefox does not support document fragments in `feImage` - as per bug https://bugzilla.mozilla.org/show_bug.cgi?id=455986

What this means is that you can reference a png, svg or other document from an external source, but not a fragment - e.g. a path or circle you define in the doc. It's an irritating limitation.