### PR TITLE
Replace ranged Edge ≤79 versions with 79 for Web Bluetooth

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -131,11 +131,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -146,7 +146,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -309,11 +309,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -324,7 +324,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -411,11 +411,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -426,7 +426,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -513,11 +513,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -528,7 +528,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -131,11 +131,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -146,7 +146,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -233,11 +233,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -248,7 +248,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -335,11 +335,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -350,7 +350,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -437,11 +437,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -452,7 +452,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -539,11 +539,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -554,7 +554,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -641,11 +641,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -656,7 +656,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -743,11 +743,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -758,7 +758,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -845,11 +845,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -860,7 +860,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -947,11 +947,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -962,7 +962,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -202,7 +202,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -298,7 +298,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -346,7 +346,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -131,11 +131,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -146,7 +146,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -233,11 +233,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -248,7 +248,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -335,11 +335,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -350,7 +350,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -437,11 +437,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -452,7 +452,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -539,11 +539,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -554,7 +554,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -641,11 +641,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -656,7 +656,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -743,11 +743,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -758,7 +758,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -845,11 +845,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -860,7 +860,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -947,11 +947,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -962,7 +962,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -1049,11 +1049,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -1064,7 +1064,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -131,11 +131,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -146,7 +146,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -233,11 +233,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -248,7 +248,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -335,11 +335,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -350,7 +350,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -437,11 +437,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -452,7 +452,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -539,11 +539,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -554,7 +554,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -131,11 +131,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -146,7 +146,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -233,11 +233,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -248,7 +248,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -335,11 +335,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -350,7 +350,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -437,11 +437,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -452,7 +452,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -539,11 +539,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -554,7 +554,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -641,11 +641,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -656,7 +656,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -30,11 +30,11 @@
           },
           "edge": [
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "macOS only."
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Linux and versions of Windows earlier than 10.",
               "flags": [
                 {
@@ -45,7 +45,7 @@
               ]
             },
             {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Windows 10."
             }
           ],
@@ -197,11 +197,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -212,7 +212,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -395,11 +395,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -410,7 +410,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],
@@ -545,11 +545,11 @@
             },
             "edge": [
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "macOS only."
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Linux and versions of Windows earlier than 10.",
                 "flags": [
                   {
@@ -560,7 +560,7 @@
                 ]
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "Windows 10."
               }
             ],


### PR DESCRIPTION
These APIs were not supported in EdgeHTML. This is a simple
search-replace and leaves many issues with the data.