### PR TITLE
Remove flag data for the Body mixin

### DIFF
--- a/api/Body.json
+++ b/api/Body.json
@@ -4,71 +4,27 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body",
         "support": {
-          "chrome": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "42"
+          },
           "chrome_android": {
             "version_added": "42"
           },
           "edge": {
             "version_added": "≤18"
           },
-          "firefox": [
-            {
-              "version_added": "39"
-            },
-            {
-              "version_added": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.fetch.enabled"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "39"
+          },
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "29"
+          },
+          "opera_android": {
+            "version_added": "29"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -92,74 +48,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/arrayBuffer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -184,74 +96,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/blob",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -285,46 +153,12 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
             "ie": {
               "version_added": false
             },
@@ -358,74 +192,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/bodyUsed",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -459,20 +249,9 @@
             "edge": {
               "version_added": "≤79"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -513,74 +292,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/json",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -605,74 +340,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/text",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },


### PR DESCRIPTION
This flag data can be removed under the irrelevant flag data guideline:
https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-flag-data

The relevant release dates:
 * Chrome 42, 2015-04-14
 * Firefox 39, 2015-07-02
 * Firefox 65, 2019-01-29
 * Opera 29, 2015-04-28