### PR TITLE
Remove irrelevant flag data and mixin notes for WindowOrWorkerGlobalScope

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -67,10 +67,6 @@
               {
                 "version_added": "27",
                 "notes": "<code>atob()</code> ignores all space characters in the argument to comply with the latest HTML5 spec (see <a href='https://bugzil.la/711180'>bug 711180</a>)."
-              },
-              {
-                "version_added": "57",
-                "notes": "<code>atob()</code> now defined on <code><A href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
               }
             ],
             "firefox_android": [
@@ -80,10 +76,6 @@
               {
                 "version_added": "27",
                 "notes": "<code>atob()</code> ignores all space characters in the argument to comply with the latest HTML5 spec (see <a href='https://bugzil.la/711180'>bug 711180</a>)."
-              },
-              {
-                "version_added": "57",
-                "notes": "<code>atob()</code> now defined on <code><A href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
               }
             ],
             "ie": {
@@ -128,24 +120,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>btoa()</code> now defined on <code><A href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>atob()</code> now defined on <code><A href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -188,24 +168,12 @@
             "edge": {
               "version_added": "≤79"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>caches</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>caches</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": "42"
+            },
             "ie": {
               "version_added": false
             },
@@ -248,24 +216,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>clearInterval()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>clearInterval()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": "4",
               "notes": "From Internet Explorer 4 through 8, <code>clearInterval</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
@@ -314,24 +270,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>clearTimeout()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>clearTimeout()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": "4",
               "notes": "From Internet Explorer 4 through 8, <code>clearTimeout</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
@@ -380,15 +324,9 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "52",
-                "notes": "<code>createImageBitmap()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              },
-              {
-                "version_added": "42"
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": true
             },
@@ -629,73 +567,21 @@
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enable"
-                  }
-                ]
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>fetch()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enable"
-                  }
-                ]
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>fetch()</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -938,21 +824,11 @@
               {
                 "version_added": "10",
                 "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>indexedDB</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>indexedDB</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "22"
+            },
             "ie": {
               "version_added": "10",
               "partial_implementation": true
@@ -1191,24 +1067,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": "4"
             },
@@ -1310,24 +1174,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "52",
-                "notes": "<code>setInterval</code> now defined on <code><a href='https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope'>WindowOrWorkerGlobalScope</a></code> mixin."
-              }
-            ],
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": "4"
             },


### PR DESCRIPTION
The flag data can be removed under the irrelevant flag data guideline:
https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-flag-data

The notes say "now defined on WindowOrWorkerGlobalScope mixin" which
does not communicate any information. If some of these things were
previously not exposed in workers (or window) then that should be noted
directly.