### PR TITLE
Add release notes for 2021-02-18 / v3.1.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,7 +55,7 @@ February 18, 2021
 
 **Statistics**
 
-- 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits (https://github.com/mdn/browser-compat-data/compare/v3.1.0...v3.1.1)
+- 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits ([`v3.1.0...v3.1.1`](https://github.com/mdn/browser-compat-data/compare/v3.1.0...v3.1.1))
 - 12,975 total features
 - 759 total contributors
 - 3,240 total stargazers

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,9 +56,9 @@ February 18, 2021
 **Statistics**
 
 - 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits (https://github.com/mdn/browser-compat-data/compare/v3.1.0...v3.1.1)
-- 12975 total features
+- 12,975 total features
 - 759 total contributors
-- 3240 total stargazers
+- 3,240 total stargazers
 
 ## [v3.1.0](https://github.com/mdn/browser-compat-data/releases/tag/v3.1.0)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,10 +97,10 @@ February 11, 2021
 
 **Statistics**
 
-- 13 contributors have changed 77 files with 4,861 additions and 3,150 deletions in 58 commits ([`v3.0.6...v3.1.0`](https://github.com/mdn/browser-compat-data/compare/v3.0.6...v3.1.0))
-- 12,975 total features
-- 759 total contributors
-- 3,240 total stargazers
+- 10 contributors have changed 49 files with 1,534 additions and 644 deletions in 37 commits ([`v3.0.6...v3.1.0`](https://github.com/mdn/browser-compat-data/compare/v3.0.6...v3.1.0))
+- 12,972 total features
+- 758 total contributors
+- 3,234 total stargazers
 
 ## [v3.0.6](https://github.com/mdn/browser-compat-data/releases/tag/v3.0.6)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,41 @@
 # Release notes
 
+## [v3.1.1](https://github.com/mdn/browser-compat-data/releases/tag/v3.1.1)
+
+**Notable changes**
+
+- The following mixin features have been migrated to their exposed interfaces:
+
+  | Former mixin (old)                                | Exposed interface (new)                                                          |
+  | ------------------------------------------------- | -------------------------------------------------------------------------------- |
+  | `api.DocumentOrShadowRoot`                        | (removed)                                                                        |
+  | `api.DocumentOrShadowRoot.activeElement`          | `api.Document.activeElement`<br>`api.ShadowRoot.activeElement`                   |
+  | `api.DocumentOrShadowRoot.adoptedStyleSheets`     | `api.Document.adoptedStyleSheets`<br>`api.ShadowRoot.adoptedStyleSheets`         |
+  | `api.DocumentOrShadowRoot.caretPositionFromPoint` | `api.Document.caretPositionFromPoint`<br>`api.ShadowRoot.caretPositionFromPoint` |
+  | `api.DocumentOrShadowRoot.elementFromPoint`       | `api.Document.elementFromPoint`<br>`api.ShadowRoot.elementFromPoint`             |
+  | `api.DocumentOrShadowRoot.elementsFromPoint`      | `api.Document.elementsFromPoint`<br>`api.ShadowRoot.elementsFromPoint`           |
+  | `api.DocumentOrShadowRoot.fullscreenElement`      | `api.Document.fullscreenElement`<br>`api.ShadowRoot.fullscreenElement`           |
+  | `api.DocumentOrShadowRoot.getSelection`           | `api.Document.getSelection`<br>`api.ShadowRoot.getSelection`                     |
+  | `api.DocumentOrShadowRoot.pointerLockElement`     | `api.Document.pointerLockElement`<br>`api.ShadowRoot.pointerLockElement`         |
+  | `api.DocumentOrShadowRoot.styleSheets`            | `api.Document.styleSheets`<br>`api.ShadowRoot.styleSheets`                       |
+  | `api.ShadowRoot.documentorshadowroot`             | (removed)                                                                        |
+
+* The following never-supported features were removed as irrelevant:
+
+  - `api.Window.clipboardchange_event` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
+  - `api.Window.getAttention` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
+  - `api.Window.getAttentionWithCycleCount` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
+  - `svg.elements.textPath.method` ([#6959](https://github.com/mdn/browser-compat-data/pull/6959))
+
+* The subfeatures of `api.Element.getBoundingClientRect` (`height`, `width`, `x`, and `y`) were removed because they duplicated the subfeatures of `api.DOMRectReadOnly`. ([#9061](https://github.com/mdn/browser-compat-data/pull/9061))
+
+**Statistics**
+
+- 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits (https://github.com/mdn/browser-compat-data/compare/v3.1.0...HEAD)
+- 12975 total features
+- 759 total contributors
+- 3240 total stargazers
+
 ## [v3.1.0](https://github.com/mdn/browser-compat-data/releases/tag/v3.1.0)
 
 February 11, 2021

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,30 +4,52 @@
 
 **Notable changes**
 
-- The following mixin features have been migrated to their exposed interfaces:
+- `css.properties.grid-template-rows.masonry` feature was moved from its previously erroneous entry as `css.properties.masonry`. ([#9078](https://github.com/mdn/browser-compat-data/pull/9078))
 
-  | Former mixin (old)                                | Exposed interface (new)                                                          |
-  | ------------------------------------------------- | -------------------------------------------------------------------------------- |
-  | `api.DocumentOrShadowRoot`                        | (removed)                                                                        |
-  | `api.DocumentOrShadowRoot.activeElement`          | `api.Document.activeElement`<br>`api.ShadowRoot.activeElement`                   |
-  | `api.DocumentOrShadowRoot.adoptedStyleSheets`     | `api.Document.adoptedStyleSheets`<br>`api.ShadowRoot.adoptedStyleSheets`         |
-  | `api.DocumentOrShadowRoot.caretPositionFromPoint` | `api.Document.caretPositionFromPoint`<br>`api.ShadowRoot.caretPositionFromPoint` |
-  | `api.DocumentOrShadowRoot.elementFromPoint`       | `api.Document.elementFromPoint`<br>`api.ShadowRoot.elementFromPoint`             |
-  | `api.DocumentOrShadowRoot.elementsFromPoint`      | `api.Document.elementsFromPoint`<br>`api.ShadowRoot.elementsFromPoint`           |
-  | `api.DocumentOrShadowRoot.fullscreenElement`      | `api.Document.fullscreenElement`<br>`api.ShadowRoot.fullscreenElement`           |
-  | `api.DocumentOrShadowRoot.getSelection`           | `api.Document.getSelection`<br>`api.ShadowRoot.getSelection`                     |
-  | `api.DocumentOrShadowRoot.pointerLockElement`     | `api.Document.pointerLockElement`<br>`api.ShadowRoot.pointerLockElement`         |
-  | `api.DocumentOrShadowRoot.styleSheets`            | `api.Document.styleSheets`<br>`api.ShadowRoot.styleSheets`                       |
-  | `api.ShadowRoot.documentorshadowroot`             | (removed)                                                                        |
+- The following mixin features have been migrated to their exposed interfaces (or deduplicated, where the exposed interface data already existed):
 
-* The following never-supported features were removed as irrelevant:
+  | Former mixin (old)                                           | Exposed interface (new)                                                                                             |
+  | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+  | `api.DocumentFragment.methods`                               | (removed, duplicate)                                                                                                |
+  | `api.DocumentFragment.properties`                            | (removed, duplicate)                                                                                                |
+  | `api.DocumentOrShadowRoot.activeElement`                     | `api.Document.activeElement`<br>`api.ShadowRoot.activeElement`                                                      |
+  | `api.DocumentOrShadowRoot.adoptedStyleSheets`                | `api.Document.adoptedStyleSheets`<br>`api.ShadowRoot.adoptedStyleSheets`                                            |
+  | `api.DocumentOrShadowRoot.caretPositionFromPoint`            | `api.Document.caretPositionFromPoint`<br>`api.ShadowRoot.caretPositionFromPoint`                                    |
+  | `api.DocumentOrShadowRoot.elementFromPoint`                  | `api.Document.elementFromPoint`<br>`api.ShadowRoot.elementFromPoint`                                                |
+  | `api.DocumentOrShadowRoot.elementsFromPoint`                 | `api.Document.elementsFromPoint`<br>`api.ShadowRoot.elementsFromPoint`                                              |
+  | `api.DocumentOrShadowRoot.fullscreenElement`                 | `api.Document.fullscreenElement`<br>`api.ShadowRoot.fullscreenElement`                                              |
+  | `api.DocumentOrShadowRoot.getSelection`                      | `api.Document.getSelection`<br>`api.ShadowRoot.getSelection`                                                        |
+  | `api.DocumentOrShadowRoot.pointerLockElement`                | `api.Document.pointerLockElement`<br>`api.ShadowRoot.pointerLockElement`                                            |
+  | `api.DocumentOrShadowRoot.styleSheets`                       | `api.Document.styleSheets`<br>`api.ShadowRoot.styleSheets`                                                          |
+  | `api.DocumentOrShadowRoot`                                   | (removed)                                                                                                           |
+  | `api.ParentNode.append`                                      | `api.Document.append` <br> `api.DocumentFragment.append` <br> `api.Element.append`                                  |
+  | `api.ParentNode.childElementCount.document_documentfragment` | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.childElementCount`                           | `api.Document.childElementCount` <br> `api.DocumentFragment.childElementCount` <br> `api.Element.childElementCount` |
+  | `api.ParentNode.children.document_documentfragment`          | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.children.svgelement`                         | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.children`                                    | `api.Document.children` <br> `api.DocumentFragment.children` <br> `api.Element.children`                            |
+  | `api.ParentNode.document_documentfragment`                   | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.firstElementChild.document_documentfragment` | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.firstElementChild`                           | `api.Document.firstElementChild` <br> `api.DocumentFragment.firstElementChild` <br> `api.Element.firstElementChild` |
+  | `api.ParentNode.lastElementChild.document_documentfragment`  | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.lastElementChild`                            | `api.Document.lastElementChild` <br> `api.DocumentFragment.lastElementChild` <br> `api.Element.lastElementChild`    |
+  | `api.ParentNode.prepend`                                     | `api.Document.prepend` <br> `api.DocumentFragment.prepend` <br> `api.Element.prepend`                               |
+  | `api.ParentNode.querySelector`                               | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.querySelectorAll`                            | (removed, duplicate)                                                                                                |
+  | `api.ParentNode.replaceChildren`                             | `api.Document.replaceChildren` <br> `api.DocumentFragment.replaceChildren` <br> `api.Element.replaceChildren`       |
+  | `api.ParentNode`                                             | (removed)                                                                                                           |
+  | `api.ShadowRoot.documentorshadowroot`                        | (removed, duplicate)                                                                                                |
+
+  See [#9045](https://github.com/mdn/browser-compat-data/pull/9045) and [#9064](https://github.com/mdn/browser-compat-data/pull/9064) for details.
+
+- The following never-supported features were removed as irrelevant:
 
   - `api.Window.clipboardchange_event` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
   - `api.Window.getAttention` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
   - `api.Window.getAttentionWithCycleCount` ([#6942](https://github.com/mdn/browser-compat-data/pull/6942))
   - `svg.elements.textPath.method` ([#6959](https://github.com/mdn/browser-compat-data/pull/6959))
 
-* The subfeatures of `api.Element.getBoundingClientRect` (`height`, `width`, `x`, and `y`) were removed because they duplicated the subfeatures of `api.DOMRectReadOnly`. ([#9061](https://github.com/mdn/browser-compat-data/pull/9061))
+- The subfeatures of `api.Element.getBoundingClientRect` (`height`, `width`, `x`, and `y`) were removed because they duplicated the subfeatures of `api.DOMRectReadOnly`. ([#9061](https://github.com/mdn/browser-compat-data/pull/9061))
 
 **Statistics**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,7 +53,7 @@
 
 **Statistics**
 
-- 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits (https://github.com/mdn/browser-compat-data/compare/v3.1.0...HEAD)
+- 13 contributors have changed 77 files with 4,859 additions and 3,148 deletions in 57 commits (https://github.com/mdn/browser-compat-data/compare/v3.1.0...v3.1.1)
 - 12975 total features
 - 759 total contributors
 - 3240 total stargazers

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## [v3.1.1](https://github.com/mdn/browser-compat-data/releases/tag/v3.1.1)
 
+February 18, 2021
+
 **Notable changes**
 
 - `css.properties.grid-template-rows.masonry` feature was moved from its previously erroneous entry as `css.properties.masonry`. ([#9078](https://github.com/mdn/browser-compat-data/pull/9078))

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,10 +97,10 @@ February 11, 2021
 
 **Statistics**
 
-- 10 contributors have changed 49 files with 1,534 additions and 644 deletions in 37 commits ([`v3.0.6...v3.1.0`](https://github.com/mdn/browser-compat-data/compare/v3.0.6...v3.1.0))
-- 12,972 total features
-- 758 total contributors
-- 3,234 total stargazers
+- 13 contributors have changed 77 files with 4,861 additions and 3,150 deletions in 58 commits ([`v3.0.6...v3.1.0`](https://github.com/mdn/browser-compat-data/compare/v3.0.6...v3.1.0))
+- 12,975 total features
+- 759 total contributors
+- 3,240 total stargazers
 
 ## [v3.0.6](https://github.com/mdn/browser-compat-data/releases/tag/v3.0.6)
 


### PR DESCRIPTION
Testing out running release notes out of the Git-tracked file, instead of GitHub directly. I'll probably self-merge this, but I expect to be able to collaborate on release notes draft PRs in the future. 🎉