### PR TITLE
Add note about Firefox Nightly-only for top_level await

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -80,7 +80,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "85",
+                "version_added": false,
+                "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1681046'>bug 1681046</a>.",
                 "flags": [
                   {
                     "type": "preference",
@@ -89,7 +90,8 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "85",
+                "version_added": false,
+                "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1681046'>bug 1681046</a>.",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
Just like https://github.com/mdn/browser-compat-data/pull/8682 , top-level await is nightly-only on Firefox.
So made the `version_added` field `false`, and added note that points the bug to enable it.

  * bug to enable on non-Nightly : https://bugzilla.mozilla.org/show_bug.cgi?id=1681046
  * code that uses the mentioned pref only on Nightly: https://searchfox.org/mozilla-central/rev/e84baf5c730abd453be5d50dcb0aba1e743bac47/js/xpconnect/src/XPCJSContext.cpp#1028-1032

