### PR TITLE
Update Edge versions for AnimationTimeline API

### DIFF
--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "84"
           },
           "firefox": [
             {
@@ -101,7 +101,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "84"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `AnimationTimeline` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationTimeline
