### PR TITLE
Add Edge versions for BroadcastChannel API

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -11,7 +11,7 @@
             "version_added": "54"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "38"
@@ -56,7 +56,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -101,7 +101,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -238,7 +238,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -283,7 +283,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -328,7 +328,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"
@@ -373,7 +373,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `BroadcastChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BroadcastChannel
