### PR TITLE
Add Edge versions for CacheStorage API

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -13,7 +13,7 @@
             "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "16"
           },
           "firefox": {
             "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CacheStorage` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CacheStorage
