### PR TITLE
Add Edge versions for Client API

### DIFF
--- a/api/Client.json
+++ b/api/Client.json
@@ -108,7 +108,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -157,7 +157,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -206,7 +206,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "54"
@@ -254,7 +254,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Client` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Client
