### PR TITLE
Add Edge versions for Clients API

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -11,7 +11,7 @@
             "version_added": "40"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -108,7 +108,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",
@@ -159,7 +159,7 @@
               "notes": "<code>Client</code> objects returned in most recent focus order."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "17",
               "notes": "<code>Client</code> objects returned in most recent focus order."
             },
             "firefox": [
@@ -307,18 +307,10 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               {
-                "version_added": "≤79",
-                "notes": "Can only open URLs on the same origin."
-              },
-              {
-                "version_added": "≤79",
-                "notes": "Can open any URL. "
-              },
-              {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Clients` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Clients
