### PR TITLE
Add Edge versions for CSSPropertyRule API

### DIFF
--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -11,7 +11,7 @@
             "version_added": "78"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "85"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "85"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "85"
             },
             "firefox": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "85"
             },
             "firefox": {
               "version_added": false
@@ -202,7 +202,7 @@
               "version_added": "78"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "85"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CSSPropertyRule` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSPropertyRule
