### PR TITLE
Add Edge versions for CSSTransition API

### DIFF
--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -11,7 +11,7 @@
             "version_added": "78"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "84"
           },
           "firefox": {
             "version_added": "75"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CSSTransition` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v1.3.3).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSTransition
