### PR TITLE
Remove incorrect prefixed support statements for Web Audio API

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -22,31 +22,17 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "15",
-              "prefix": "webkit"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "14",
-              "prefix": "webkit"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -114,8 +100,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createAnalyser",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -134,31 +119,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -179,8 +150,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBiquadFilter",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -199,31 +169,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -244,8 +200,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -264,31 +219,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -309,8 +250,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBufferSource",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -329,31 +269,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -374,8 +300,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelMerger",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -394,31 +319,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -439,8 +350,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createChannelSplitter",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -459,31 +369,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -552,8 +448,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createConvolver",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -572,31 +467,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -617,8 +498,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDelay",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -637,31 +517,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -682,8 +548,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createDynamicsCompressor",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -702,31 +567,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -747,8 +598,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createGain",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -767,31 +617,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -862,8 +698,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createOscillator",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -882,31 +717,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -927,8 +748,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPanner",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -947,31 +767,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -997,11 +803,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "57"
-              },
-              {
-                "version_added": "10",
-                "prefix": "webkit"
+                "version_added": "10"
               }
             ],
             "chrome_android": [
@@ -1010,11 +812,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "57"
-              },
-              {
-                "version_added": "33",
-                "prefix": "webkit"
+                "version_added": "33"
               }
             ],
             "edge": {
@@ -1031,31 +829,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": [
               {
@@ -1063,10 +847,6 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "7.0"
-              },
-              {
-                "prefix": "webkit",
                 "version_added": "2.0"
               }
             ],
@@ -1076,11 +856,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "57"
-              },
-              {
-                "version_added": "4.4.3",
-                "prefix": "webkit"
+                "version_added": "4.4.3"
               }
             ]
           },
@@ -1144,8 +920,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createScriptProcessor",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1164,31 +939,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1259,8 +1020,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createWaveShaper",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1279,31 +1039,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1324,8 +1070,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1344,31 +1089,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1389,8 +1120,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1409,31 +1139,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1504,8 +1220,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1524,31 +1239,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1569,8 +1270,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/listener",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1587,31 +1287,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1658,12 +1344,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "9",
-              "prefix": "webkit"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9",
-              "prefix": "webkit"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1684,8 +1368,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
           "support": {
             "chrome": {
-              "version_added": "10",
-              "prefix": "webkit"
+              "version_added": "10"
             },
             "chrome_android": {
               "version_added": "33"
@@ -1704,31 +1387,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -1775,12 +1444,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "9",
-              "prefix": "webkit"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9",
-              "prefix": "webkit"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -5,8 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode",
         "support": {
           "chrome": {
-            "version_added": "14",
-            "prefix": "webkit"
+            "version_added": "14"
           },
           "chrome_android": {
             "version_added": true
@@ -23,38 +22,23 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "15",
-              "prefix": "webkit"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "14",
-              "prefix": "webkit"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": true
           },
           "webview_android": {
-            "version_added": "≤37",
-            "prefix": "webkit"
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
These methods have never themselves been prefixed, they have merely been
accessed via the prefixed webkitAudioContext interface.