### PR TITLE
Remove irrelevant flags in Firefox for AnimationTimeline API

### DIFF
--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -13,55 +13,19 @@
           "edge": {
             "version_added": "≤79"
           },
-          "firefox": [
-            {
-              "version_added": "75"
-            },
-            {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.timelines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "48",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.timelines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "48",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "75"
+          },
+          "firefox_android": {
+            "version_added": "63",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.animations-api.timelines.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "ie": {
             "version_added": false
           },
@@ -103,55 +67,19 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "75"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.timelines.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.timelines.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.timelines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `AnimationTimeline` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
