### PR TITLE
Remove irrelevant flags in Chromium for Authenticator* APIs

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -4,22 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse",
         "support": {
-          "chrome": [
-            {
-              "version_added": "67"
-            },
-            {
-              "version_added": "65",
-              "notes": "Only supports USB U2F tokens.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "value_to_set": "Enabled",
-                  "name": "Web Authentication API"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "67"
+          },
           "chrome_android": {
             "version_added": "70"
           },
@@ -66,22 +53,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/authenticatorData",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },
@@ -129,22 +103,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/signature",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },
@@ -192,22 +153,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse/userHandle",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -4,22 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse",
         "support": {
-          "chrome": [
-            {
-              "version_added": "67"
-            },
-            {
-              "version_added": "65",
-              "notes": "Only supports USB U2F tokens.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "value_to_set": "Enabled",
-                  "name": "Web Authentication API"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "67"
+          },
           "chrome_android": {
             "version_added": "70"
           },
@@ -66,22 +53,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/attestationObject",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -4,22 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse",
         "support": {
-          "chrome": [
-            {
-              "version_added": "67"
-            },
-            {
-              "version_added": "65",
-              "notes": "Only supports USB U2F tokens.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "value_to_set": "Enabled",
-                  "name": "Web Authentication API"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "67"
+          },
           "chrome_android": {
             "version_added": "70"
           },
@@ -66,22 +53,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse/clientDataJSON",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Authenticator*` APIs as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
