### PR TITLE
Fix Chromium versions for CSSPropertyRule (enabled in M85)

### DIFF
--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule",
         "support": {
           "chrome": {
-            "version_added": "78"
+            "version_added": "85"
           },
           "chrome_android": {
-            "version_added": "78"
+            "version_added": "85"
           },
           "edge": {
             "version_added": "85"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "71"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "12.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "78"
+            "version_added": "85"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/inherits",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "edge": {
               "version_added": "85"
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "78"
+              "version_added": "85"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/initialValue",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "edge": {
               "version_added": "85"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "78"
+              "version_added": "85"
             }
           },
           "status": {
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/name",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "edge": {
               "version_added": "85"
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "78"
+              "version_added": "85"
             }
           },
           "status": {
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/syntax",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": "85"
             },
             "edge": {
               "version_added": "85"
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "78"
+              "version_added": "85"
             }
           },
           "status": {


### PR DESCRIPTION
This interface is for the @property rule, and was shipped in Chrome 85:
https://www.chromestatus.com/feature/5193698449031168
https://storage.googleapis.com/chromium-find-releases-static/9ab.html#9abf13eb1926e80fddd30a505c4370499433e236

There's no Samsung Internet release based on M85 yet.

The original data came from https://github.com/mdn/browser-compat-data/pull/6278.