### PR TITLE
Remove html.elements.script.version_parameter entry

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -641,56 +641,6 @@
                 "deprecated": false
               }
             }
-          },
-          "version_parameter": {
-            "__compat": {
-              "description": "The <code>version</code> parameter of the <code>type</code> attribute",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": true,
-                  "version_removed": "59"
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "version_removed": "59"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": false
-              }
-            }
           }
         }
       }


### PR DESCRIPTION
Firefox 59 was released 2018-03-13, so this can be removed:
https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features