### PR TITLE
Update Safari versions for InputEvent API (#8912)

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -125,10 +125,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -173,10 +173,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
Fixes #8912
Adds versions of Safari / Safari iOS for api.InputEvent.InputEvent, api.InputEvent.data, api.InputEvent.dataTransfer.
Versions obtained from <https://webkit.org/blog/7358/enhanced-editing-with-input-events/>.