### PR TITLE
Update api.DataTransferItemList.add Edge support

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -107,8 +107,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "50"


### PR DESCRIPTION
A fix for Issue #9211 api.DataTransferItemList.add - Incorrect compatibility data for Microsoft Edge.
Tested on Windows 7 x64 using Microsoft Edge 88.0.705.74 (Official build) (64-bit) on the built-in example on MDN page for this documentation entry.

MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add