### PR TITLE
FF87 removes the non-standard caption-side values

### DIFF
--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -62,10 +62,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "87"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "87"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/2502

The non-standard values of `caption-side` are being removed. I don't know what the policy is with something which is now in no browsers, but did have support?