### PR TITLE
Note Safari bug resolving CSS variables and url()

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -83,10 +83,12 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "9.1"
+              "version_added": "9.1",
+              "notes": "Shorthand property values containing <code>url()</code> and a CSS variable resolve the <code>url()</code> relative to the document root instead of the stylesheet. See <a href='https://webkit.org/b/198512'>bug 198512</a>."
             },
             "safari_ios": {
-              "version_added": "9.3"
+              "version_added": "9.3",
+              "notes": "Shorthand property values containing <code>url()</code> and a CSS variable resolve the <code>url()</code> relative to the document root instead of the stylesheet. See <a href='https://webkit.org/b/198512'>bug 198512</a>."
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
In certain circumstances, Safari will incorrectly resolve `url()` values relative to the document instead of the stylesheet. It's a bit of an edge case, but there's two WebKit bugs and a BCD issue about it (#9075), so I figured that justified a note.

See for details about the bug itself and the fix: https://trac.webkit.org/changeset/267951/webkit

Fixes #9075