### PR TITLE
Re-sort Firefox MediaDevices.enumerateDevices support statements

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -111,6 +111,9 @@
             },
             "firefox": [
               {
+                "version_added": "39"
+              },
+              {
                 "version_added": "63",
                 "flags": [
                   {
@@ -120,13 +123,13 @@
                   }
                 ],
                 "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included if the <code>media.setsinkid.enabled</code> preference is enabled."
-              },
-              {
-                "version_added": "39"
               }
             ],
             "firefox_android": [
               {
+                "version_added": "39"
+              },
+              {
                 "version_added": "63",
                 "flags": [
                   {
@@ -136,9 +139,6 @@
                   }
                 ],
                 "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included if the <code>media.setsinkid.enabled</code> preference is enabled."
-              },
-              {
-                "version_added": "39"
               }
             ],
             "ie": {


### PR DESCRIPTION
The current sort makes this feature appear unsupported on Firefox.

I noticed this problem in the course of triaging #9053. I'm not sure if this is the right fix, exactly. The other support statement is about what values are returned by this method, rather than the method in general. It's possible that it should be made a note of the now-top support statement. Either way, I assume that showing support since 39 is preferable than suggesting this feature is behind a flag.
