### PR TITLE
Remove form.requestAutocomplete() entry

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -672,54 +672,6 @@
           }
         }
       },
-      "requestAutocomplete": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestAutocomplete",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "requestSubmit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit",


### PR DESCRIPTION
This was once shipped in Chrome, but was removed in Chrome 52:
https://storage.googleapis.com/chromium-find-releases-static/e62.html#e62c2a4c85f206833cb058932cfe62b3c347c685
https://groups.google.com/a/chromium.org/g/blink-dev/c/O9_XnDQh3Yk/m/SI9yuUpjAwAJ