### PR TITLE
Mirror optional_chaining from Chrome to Samsung Internet, Opera Android

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -80,7 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": "13.1"
@@ -89,7 +89,7 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "webview_android": {
               "version_added": "80"


### PR DESCRIPTION
This is a significant feature that's more widely supported than the data lets on at the moment. Fixes #9146.