### PR TITLE
Deprecate CSP plugin-types directive

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -842,8 +842,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -812,8 +812,7 @@
                   "version_added": "15"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1045899'>bug 1045899</a>."
+                  "version_added": false
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
https://github.com/w3c/webappsec-csp/commit/e9895ed (https://github.com/w3c/webappsec-csp/issues/394) completely removed the `plugin-types` directive from the CSP spec. So this patch marks it `deprecated:true` and `standard_track:false`.