### PR TITLE
Update text-underline-offset.json

### DIFF
--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "73"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Opera already supports text-underline-offset 

https://live.browserstack.com/dashboard#os=OS+X&os_version=Catalina&browser=Opera&browser_version=73.0&zoom_to_fit=true&full_screen=true&url=www.google.com&speed=1

tested locally and using the code pen from CSS tricks in Opera on Windows (BrowserStack) and locally with Opera on Mac:
https://css-tricks.com/almanac/properties/t/text-underline-offset/