### PR TITLE
Add note about CSS caret-color behavior on iOS

### DIFF
--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -33,7 +33,9 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "While the property is recognized, implementation is incomplete. The color of the caret does not always match the color set for the element in focus. See <a href='https://webkit.org/b/177489'>bug 177489</a>."
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
Fixes #9142, which attempts to describe the odd, buggy behavior of `caret-color` on iOS.
