### PR TITLE
Adding BCD background-attachment:fixed and local data

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -48,6 +48,54 @@
             "deprecated": false
           }
         },
+        "fixed": {
+          "__compat": {
+            "description": "<code>fixed</code>",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "local": {
           "__compat": {
             "description": "<code>local</code>",
@@ -77,7 +125,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "5"
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": "4.2"


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/2242
Adding BCD value for background-attachment: fixed because they are not present in the table. 
Setting Safari version for Background-attachment: local and background-attachment: fixed as false because they don't work on Safari 14, as described in https://github.com/mdn/content/issues/2242
