### PR TITLE
Update api.RTCRtpTransceiver.stop for Chrome 88

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -342,10 +342,10 @@
           "description": "<code>stop()</code>",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "88"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "88"
             },
             "edge": {
               "version_added": false
@@ -375,7 +375,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "88"
             }
           },
           "status": {

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -348,7 +348,7 @@
               "version_added": "88"
             },
             "edge": {
-              "version_added": false
+              "version_added": "88"
             },
             "firefox": {
               "version_added": "59"
@@ -360,7 +360,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "74"
             },
             "opera_android": {
               "version_added": false

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -360,7 +360,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "74"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Fixes #9253.