### PR TITLE
Add notes about selectstart event handling on Safari iOS

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10814,9 +10814,7 @@
             "safari_ios": {
               "version_added": false,
               "partial_implementation": true,
-              "notes": [
-                "The <code>selectstart</code> event never fires and never invokes this handler."
-              ]
+              "notes": "The <code>selectstart</code> event never fires and never invokes this handler."
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -10812,9 +10812,7 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false,
-              "partial_implementation": true,
-              "notes": "The <code>selectstart</code> event never fires and never invokes this handler."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -10812,7 +10812,11 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false,
+              "partial_implementation": true,
+              "notes": [
+                "The <code>selectstart</code> event never fires and never invokes this handler."
+              ]
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4210,9 +4210,7 @@
             "safari_ios": {
               "version_added": "1",
               "partial_implementation": true,
-              "notes": [
-                "The <code>selectstart</code> event never fires and never invokes this handler."
-              ]
+              "notes": "The <code>selectstart</code> event never fires and never invokes this handler."
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4208,7 +4208,11 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": [
+                "The <code>selectstart</code> event never fires and never invokes this handler."
+              ]
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Add notes about `selectstart` event never firing on Safari iOS

Related issues: fixes https://github.com/mdn/browser-compat-data/issues/9143 and fixes https://github.com/mdn/browser-compat-data/issues/9144
