### PR TITLE
Add Safari data for ARIA attributes

### DIFF
--- a/api/_mixins/ARIAMixin__Element.json
+++ b/api/_mixins/ARIAMixin__Element.json
@@ -30,10 +30,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -78,10 +78,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -126,10 +126,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -174,10 +174,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -222,10 +222,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -270,10 +270,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -318,10 +318,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -366,10 +366,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -462,10 +462,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -510,10 +510,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -558,10 +558,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -606,10 +606,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -654,10 +654,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -702,10 +702,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -750,10 +750,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -798,10 +798,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -846,10 +846,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -894,10 +894,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -942,10 +942,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -990,10 +990,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1038,10 +1038,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1086,10 +1086,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1134,10 +1134,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1182,10 +1182,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1230,10 +1230,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1278,10 +1278,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1326,10 +1326,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1374,10 +1374,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1422,10 +1422,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1470,10 +1470,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1518,10 +1518,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1566,10 +1566,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1614,10 +1614,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1662,10 +1662,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1710,10 +1710,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1758,10 +1758,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -1806,10 +1806,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
These changes were produced by mdn-bcd-collector v2.0.1:
$ npm run update-bcd ../mdn-bcd-results/ -- --browser=safari --browser=safari_ios

Follow-up to https://github.com/mdn/browser-compat-data/pull/9067.