### PR TITLE
Update APIs shipped in Safari 12.1 / iOS 12.2

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -554,10 +554,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -222,10 +222,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -622,10 +622,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/Request.json
+++ b/api/Request.json
@@ -1531,10 +1531,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
These changes were produced by mdn-bcd-collector v2.0.1:
$ npm run update-bcd ../mdn-bcd-results/ -- --browser=safari --added=12.1
$ npm run update-bcd ../mdn-bcd-results/ -- --browser=safari_ios --added=12.2

(Not all resulting changes are included, only ones that formed a pair.)