### PR TITLE
Mark MerchantValidationEvent shipped in Safari 11.1 / iOS 11.3

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -45,10 +45,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -95,10 +95,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -146,10 +146,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -196,10 +196,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -246,10 +246,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This was renamed from ApplePayMerchantValidationEvent here:
https://github.com/WebKit/WebKit/commit/7678653a3cb439d11074cbe8c5b7d47aa31d1905

Because of `conditional=PAYMENT_REQUEST` the timing of the commit can't
be used to infer when this was shipped, but we can say it has to be at
the same time as `onmerchantvalidation`, added in the same commit.

That was in Safari 11.1 / iOS 11.3.

However, due to `NoInterfaceObject` the interface object and constructor
wasn't exposed then, that happened later, here:
https://github.com/WebKit/WebKit/commit/90a5b4d7316500b38d277d8bca709b33d6ec027e

The `methodName` attribute was also added later:
https://github.com/WebKit/WebKit/commit/51510fef62223398b8ea0aa505a64456e5e121ba

Both changes were in Safari 12.1 / iOS 12.2.

This was informed by results from mdn-bcd-collector and is consistent
with those results, but not everything can be inferred from the results
alone.