### PR TITLE
feature_policy not supported in FF74 (still behind preference)

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -14,21 +14,16 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.featurePolicy.header.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": "65",
               "flags": [
@@ -250,21 +245,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -368,21 +358,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -435,21 +420,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "67",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "67",
                 "flags": [
@@ -502,21 +482,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -569,21 +544,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -636,22 +606,17 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74",
-                  "notes": "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "notes": "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -704,21 +669,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1068,21 +1028,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1135,21 +1090,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1285,21 +1235,16 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "74"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1868,11 +1813,25 @@
               },
               "firefox": {
                 "version_added": "81",
-                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
+                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": "81",
-                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
+                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
The Feature-Policy HTTP header was not enabled in FF74 as indicated by BCD - it is still behind a preference. 

This header has been renamed in the spec to Permissions-Policy. This has not rolled out to FF. Should the change be made in BCD now? If so we should presumably track which browsers have made the change too. BUT, can we do that as a second PR?

Note
- #9264 indicates it was briefly enabled by default in nightly, but we don't track that level in BCD

Fixes #9264
