### PR TITLE
Update CSS blend-mode spec URL to latest spec

### DIFF
--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>&lt;blend-mode&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/blend-mode",
-          "spec_url": "https://drafts.fxtf.org/compositing-1/#ltblendmodegt",
+          "spec_url": "https://drafts.fxtf.org/compositing/#ltblendmodegt",
           "support": {
             "chrome": {
               "version_added": "35"


### PR DESCRIPTION
https://drafts.fxtf.org/compositing/#ltblendmodegt has the same information and is the current spec, so let’s use that rather than the https://drafts.fxtf.org/compositing-1/#ltblendmodegt (outdated) spec.