### PR TITLE
Firefox 86 is released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -616,27 +616,28 @@
         "85": {
           "release_date": "2021-01-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/85",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-04-20",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "88"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -483,27 +483,28 @@
         "85": {
           "release_date": "2021-01-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/85",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-04-20",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "88"
         },


### PR DESCRIPTION
Firefox 86 is released -- this PR updates the browser data accordingly.

Refs:
- https://www.mozilla.org/en-US/firefox/86.0/releasenotes/
- https://www.mozilla.org/en-US/firefox/87.0beta/releasenotes/
- https://www.mozilla.org/en-US/firefox/88.0a1/releasenotes/