### PR TITLE
Revert "Mark ConstantSourceNode as shipped in Edge 79 (not earlier)"

### DIFF
--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": "52",
@@ -61,7 +61,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "52"


### PR DESCRIPTION
Reverts mdn/browser-compat-data#9278