### PR TITLE
Add notes about FF preferences that overridde CSS prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1285,7 +1285,11 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "67"
+                "version_added": "67",
+                "notes": [
+                  "The feature can be overridden by Firefox preference <code>privacy.resistFingerprinting</code>. Set to <code>true</code> to always return <code>light</code>.",
+                  "The feature can be overridden by Firefox numeric preference <code>ui.systemUsesDarkTheme</code>. Set to <code>0</code> for <code>light</code>, <code>1</code> for <code>dark</code>, <code>2</code> for <code>no-preference</code> (in versions that support it). Any other value causes Firefox to return <code>light</code>."
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
The [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media query has a Firefox specific note up the top about preference over-rides for this feature. That note should be in the BCD. 

![image](https://user-images.githubusercontent.com/5368500/109437882-840de000-7a7b-11eb-8ab0-209009ab1181.png)

This follows on from discussion in https://github.com/mdn/content/pull/2562#discussion_r580196154
