### PR TITLE
HTTP Referrer-Policy - change to default

### DIFF
--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -15,10 +15,20 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "50",
+              "notes": [
+                "Firefox version 87 and later have a default <code>Referrer-Policy</code> of <code>strict-origin-when-cross-origin</code>. This default can be changed using the preference <code>network.http.referer.userControlPolicy</code>, where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>.",
+                "Firefox versions 59 to 86 have a default <code>Referrer-Policy</code> of <code>3 = no-referrer-when-downgrade (default)</code>. This default can be change using the preference <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks), where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade (default)</code>.",
+                "Firefox versions 53 to 58 allow the default <code>Referrer-Policy</code> to be set using the preference <code>network.http.referer.userControlPolicy</code>, where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade (default)</code>."
+              ]
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "50",
+              "notes": [
+                "Firefox version 87 and later have a default <code>Referrer-Policy</code> of <code>strict-origin-when-cross-origin</code>. This default can be changed using the preference <code>network.http.referer.userControlPolicy</code>, where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>.",
+                "Firefox versions 59 to 86 have a default <code>Referrer-Policy</code> of <code>3 = no-referrer-when-downgrade (default)</code>. This default can be change using the preference <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks), where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade (default)</code>.",
+                "Firefox versions 53 to 58 allow the default <code>Referrer-Policy</code> to be set using the preference <code>network.http.referer.userControlPolicy</code>, where <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade (default)</code>."
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The **default** HTTP `Referrer-Policy` changed from `no-referrer-when-downgrade` to `strict-origin-when-cross-origin` in  Firefox 87 (https://bugzilla.mozilla.org/show_bug.cgi?id=1589074) as a result of this spec change: https://github.com/whatwg/fetch/pull/1066. The change will also affect chrome and others.

In addition, the MDN page has [some notes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#browser_compatibility) about setting the default which I understand we'd now include in BCD (reproduced below):

![image](https://user-images.githubusercontent.com/5368500/109460122-3b264d80-7ab4-11eb-8a5c-2c95b8b4892e.png)

This first draft just puts all of these things as notes . What I THINK needs to happen is that we have a new subfeature to indicate the version at which `strict-origin-when-cross-origin` is used as the default. So if this is false or unknown the assumption is that the default is  `no-referrer-when-downgrade`. Does that make sense?  The other notes from the box above would then be re-worked without all the detail about the "default default" :-)

Does that make sense? If so, any suggestions for the feature name and description?

@ddbeck Your advice appreciated.

Note, this impacts FF content update: https://github.com/mdn/content/issues/2516