### PR TITLE
updating link matching behavior for :link, :visited, :any-link

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -8,7 +8,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "65"
+                "version_added": "65",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               {
                 "prefix": "-webkit-",
@@ -17,7 +18,8 @@
             ],
             "chrome_android": [
               {
-                "version_added": "65"
+                "version_added": "65",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               {
                 "prefix": "-webkit-",
@@ -35,7 +37,8 @@
             ],
             "firefox": [
               {
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               {
                 "version_added": "1",
@@ -45,7 +48,8 @@
             ],
             "firefox_android": [
               {
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               {
                 "version_added": "4",
@@ -76,7 +80,8 @@
             ],
             "safari": [
               {
-                "version_added": "9"
+                "version_added": "9",
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
               },
               {
                 "version_added": "3",
@@ -90,7 +95,8 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9"
+                "version_added": "9",
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
               },
               {
                 "prefix": "-webkit-",
@@ -108,7 +114,8 @@
             ],
             "webview_android": [
               {
-                "version_added": "65"
+                "version_added": "65",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               {
                 "prefix": "-webkit-",

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -7,19 +7,23 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:link",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "ie": {
               "version_added": "3"
@@ -31,16 +35,19 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3.2",
+              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1.5"
+              "version_added": "1.5",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             }
           },
           "status": {

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -7,19 +7,23 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:visited",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From version 87 Firefox stops matching <code>&lt;link&gt;</code> elements with link pseudo-classes."
             },
             "ie": {
               "version_added": "4"
@@ -31,76 +35,25 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4",
+              "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "not_match_link": {
-          "__compat": {
-            "description": "<code>:visited</code> privacy: selector does not match <code>&lt;link&gt;</code> elements",
-            "support": {
-              "chrome": {
-                "version_added": "1",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              },
-              "chrome_android": {
-                "version_added": "18",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "70"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "15",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              },
-              "opera_android": {
-                "version_added": "14",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              },
-              "safari": {
-                "version_added": "12"
-              },
-              "safari_ios": {
-                "version_added": "12"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              },
-              "webview_android": {
-                "version_added": "4.4",
-                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         },
         "privacy_measures": {


### PR DESCRIPTION
I am working on https://github.com/mdn/content/issues/2506 the discussion there explains why I am making these changes.

Of the three pseudo-classes `:visited` had a separate subsection about this, I've removed that and updated all three to add notes explaining current status.
