### PR TITLE
Update forced-colors Chrome version status

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -672,7 +672,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -611,9 +611,22 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/forced-colors",
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#forced-colors",
             "support": {
-              "chrome": {
-                "version_added": "89"
-              },
+              "chrome": [
+                {
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#forced-colors",
+                      "value_to_set": "Enabled"
+                    }
+                  ],
+                  "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+                },
+                {
+                  "version_added": "89"
+                }
+              ],
               "chrome_android": {
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
@@ -659,7 +672,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -613,6 +613,9 @@
             "support": {
               "chrome": [
                 {
+                  "version_added": "89"
+                },
+                {
                   "version_added": "79",
                   "flags": [
                     {
@@ -622,9 +625,6 @@
                     }
                   ],
                   "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
-                },
-                {
-                  "version_added": "89"
                 }
               ],
               "chrome_android": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -612,15 +612,7 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#forced-colors",
             "support": {
               "chrome": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#forced-colors",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+                "version_added": "89"
               },
               "chrome_android": {
                 "version_added": false,
@@ -667,7 +659,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust",
           "support": {
             "chrome": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "forced-colors",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "89"
             },
             "chrome_android": {
               "version_added": false
@@ -52,7 +45,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -5,9 +5,21 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust",
           "support": {
-            "chrome": {
-              "version_added": "89"
-            },
+            "chrome": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "forced-colors",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "89"
+              }
+            ],
             "chrome_android": {
               "version_added": false
             },

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -7,6 +7,9 @@
           "support": {
             "chrome": [
               {
+                "version_added": "89"
+              },
+              {
                 "version_added": "79",
                 "flags": [
                   {
@@ -15,9 +18,6 @@
                     "value_to_set": "enabled"
                   }
                 ]
-              },
-              {
-                "version_added": "89"
               }
             ],
             "chrome_android": {


### PR DESCRIPTION
Forced colors mode is shipping in Chrome 89. Updating the version information to reflect this.

See: 
https://chromium.googlesource.com/chromium/src/+/0b1c596b6732f6bc9d440b12af53d3c74aa3c4ac
https://www.chromestatus.com/feature/5757293075365888#details
https://blog.chromium.org/2021/01/chrome-89-beta-advanced-hardware.html

I'm also working on a PR to update the MDN docs for these CSS features.
