### PR TITLE
Add Intl.NumberFormat Unified API support in Safari 14.1

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -145,10 +145,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"
@@ -196,10 +196,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"
@@ -247,10 +247,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"
@@ -298,10 +298,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"
@@ -349,10 +349,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"
@@ -400,10 +400,10 @@
                     "version_added": "55"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "samsunginternet_android": {
                     "version_added": "12.0"


### PR DESCRIPTION
[Intl.NumberFormat Unified API](https://github.com/tc39/proposal-unified-intl-numberformat) is Supported in Safari 14.1.

Examples for testing could be found here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat

Safari 14.1 is available for Apple Developers program members

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
