### PR TITLE
Add Chrome 89 release information.

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -609,12 +609,14 @@
         "88": {
           "release_date": "2021-01-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop_19.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
-          "status": "beta",
+          "release_date": "2021-03-02",
+          "release_notes": "https://chromereleases.googleblog.com/2021/03/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "89"
         },

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -446,17 +446,19 @@
         "88": {
           "release_date": "2021-01-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/01/chrome-for-android-update_19.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
-          "status": "beta",
+          "release_date": "2021-03-02",
+          "release_notes": "https://chromereleases.googleblog.com/2021/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "89"
         },
         "90": {
-          "status": "beta",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "90"
         }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -437,12 +437,14 @@
         "88": {
           "release_date": "2021-01-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/01/chrome-for-android-update_19.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
-          "status": "beta",
+          "release_date": "2021-03-02",
+          "release_notes": "https://chromereleases.googleblog.com/2021/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "89"
         },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2021/03/stable-channel-update-for-desktop.html
https://chromereleases.googleblog.com/2021/03/chrome-for-android-update.html