### PR TITLE
PerformanceObserver.supportedEntryTypes in Firefox

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -256,7 +256,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -228,7 +228,7 @@
               "version_added": "68"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -225,7 +225,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "68"
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
Bugzilla says v66: https://bugzilla.mozilla.org/show_bug.cgi?id=1512225
but I tested on BrowserStack that it's available only in v68
