### PR TITLE
Mirror Response.ok for Android browsers

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -564,7 +564,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "edge": {
               "version_added": "14"
@@ -584,7 +584,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -624,10 +624,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #9309.

Using https://mdn-bcd-collector.appspot.com/tests/api/Response/ok, I confirmed that the unflagged desktop data is correct for Chrome and Firefox and that the feature is available in the current Android versions of Chrome and Firefox. This seemed good enough to me to mirror this data.