### PR TITLE
Add a note of CSSStyleDeclaration's @@iterator

### DIFF
--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -544,6 +544,54 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/@@iterator",
+          "support": {
+            "chrome": {
+              "version_added": "51"
+            },
+            "chrome_android": {
+              "version_added": "51"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "36"
+            },
+            "firefox_android": {
+              "version_added": "36"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "51"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
I have confirmed that:

1. `CSSStyleDeclaration` has no `@@iterator` under all IEs as they don't support `Symbol`.
2. Chrome has implemented `CSSStyleDeclaration[Symbol.iterator]` since 51. Under 50 and below, we have to transform it into Array by calling `Array.from()` before iteration.
3. Firefox has implemented with `Symbol.iterator` at the same time since 36.
4. Opera has implemented with `Symbol.iterator` at the same time since 30.

Feel free to update the `null` value of other browsers when ensuring the version added or nonexistent feature.  
