### PR TITLE
Rename SVGFECompositeElement.in back to in1

### DIFF
--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -47,7 +47,7 @@
           "deprecated": false
         }
       },
-      "in": {
+      "in1": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
Inexplicably, the interface uses `in1` for the corresponding element's `in` attribute.

Fixes #9337.