### PR TITLE
Update focus-visible for Edge

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -36,16 +36,21 @@
                 ]
               }
             ],
-            "edge": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": [
               {
                 "version_added": "85"

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -37,7 +37,7 @@
               }
             ],
             "edge": {
-              "version_added": "79",
+              "version_added": "86",
               "flags": [
                 {
                   "name": "#enable-experimental-web-platform-features",


### PR DESCRIPTION
This PR updates `focus-visible` for Edge as referenced in issue #9167
