### PR TITLE
fix unhandledrejection_event / onunhandledrejection edge compatibility

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -10041,7 +10041,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -688,7 +688,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
The current data says it's available in <= 79.  this conflicts with caniuse (https://caniuse.com/?search=unhandledrejection) as well as not making much sense and also conflicting with my own testing - I verified it's available in Edge 88; and it's also been in Chrome for a while.  As 79 is the first Edge based on the same code base as Chrome, it seems far more likely that Edge >=79 is the correct range of Edge versions with support - or certainly more correct than the <=79 range.

My test in edge was basically
```
window.addEventListener("unhandledrejection", (e) => console.log("unhandled rejection handler fired"));
Promise.reject("error")
```
The catch is that the rejected promise needs to be executed in the web page - if you reject a promise in the console, it doesn't trigger the unhandledrejection handler.  The exception handler however can be set in the console.

and then saw the text console.log'ed
