### PR TITLE
Desktop Safari adds date/time input support in v14.1

### DIFF
--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -33,8 +33,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/119175'>bug 119175</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": "5"

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -34,8 +34,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": true

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -33,8 +33,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": true


### PR DESCRIPTION
[Webkit feature status](https://webkit.org/status/#feature-date-and-time-input-types) says `date`, `datetime-local`, and `time` input is supported [as of October 2020](https://bugs.webkit.org/attachment.cgi?id=412182&action=diff), but no release seems to have included that support yet. Technology preview releases have included support since [at least TP 114](https://webkit.org/blog/11300/release-notes-for-safari-technology-preview-114/) which should be included in the next version: 15. [CanIUse agrees](https://caniuse.com/input-datetime) that support is present in current tech previews, though lacking `week` and `month` support.