### PR TITLE
SameSite: Add schemeful, corrections, statuses for Android browsers

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -406,6 +406,96 @@
               }
             }
           },
+          "schemeful": {
+            "__compat": {
+              "description": "Schemeful",
+              "support": {
+                "chrome": {
+                  "version_added": "86",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#schemeful-same-site",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                },
+                "chrome_android": {
+                  "version_added": "86",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#schemeful-same-site",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                },
+                "edge": {
+                  "version_added": "86",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#schemeful-same-site",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                },
+                "firefox": {
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.schemeful",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.schemeful",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "72",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#schemeful-same-site",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "secure_context_required": {
             "__compat": {
               "description": "Secure context required",

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -284,7 +284,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "67"
+                  "version_added": "71"
                 },
                 "opera_android": {
                   "version_added": false
@@ -526,7 +526,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "67"
+                  "version_added": "71"
                 },
                 "opera_android": {
                   "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -278,7 +278,14 @@
                   ]
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.laxByDefault",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "ie": {
                   "version_added": false
@@ -287,7 +294,7 @@
                   "version_added": "71"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "60"
                 },
                 "safari": {
                   "version_added": false
@@ -520,7 +527,14 @@
                   ]
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.noneRequiresSecure",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "ie": {
                   "version_added": false
@@ -529,7 +543,7 @@
                   "version_added": "71"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "60"
                 },
                 "safari": {
                   "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -415,7 +415,7 @@
           },
           "schemeful": {
             "__compat": {
-              "description": "Schemeful",
+              "description": "URL scheme-aware (\"schemeful\")",
               "support": {
                 "chrome": {
                   "version_added": "86",

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -265,7 +265,7 @@
                   "version_added": "80"
                 },
                 "edge": {
-                  "version_added": "80"
+                  "version_added": "86"
                 },
                 "firefox": {
                   "version_added": "69",
@@ -507,7 +507,7 @@
                   "version_added": "80"
                 },
                 "edge": {
-                  "version_added": "80"
+                  "version_added": "86"
                 },
                 "firefox": {
                   "version_added": "69",


### PR DESCRIPTION
- [x] Summarize your changes
  1. Added `schemeful` SameSite subfeature
  2. Corrected `Lax_default` `secure_context_required` statuses for Chromium-based browsers
  3. Added `Lax_default` `secure_context_required` statuses for some Android browsers
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
  1. → 38ab4be
    - Flag added in Chrome 86: [issue 1102429](https://bugs.chromium.org/p/chromium/issues/detail?id=1102429), [diff between Chromium 85 and 86](https://chromium.googlesource.com/chromium/src/+log/85.0.4183.127..86.0.4240.75?pretty=fuller&n=10000)
    - Flag added in Firefox 79: [bug 1638358](https://bugzilla.mozilla.org/show_bug.cgi?id=1638358)
    - Opera 72 is based on Chromium 86: [release notes](https://blogs.opera.com/desktop/2020/08/opera-72-developer/)
    - Opera for Android 61 is based on Chromium 86: [Google Play (Internet Archive)](https://web.archive.org/web/20201217224819/https://play.google.com/store/apps/details?id=com.opera.browser), [APKMirror](https://www.apkmirror.com/apk/opera-software-asa/opera/opera-61-2-3076-56749-release/)
  2. → 8832444 edfe37c
    - Flags in the Chromium source code were changed in 85
      - The enforcements were [rolled out to Chrome 80+](https://www.chromium.org/updates/same-site) but in an out-of-bounds manner
      - [Diff between Chromium 84 and 85](https://chromium.googlesource.com/chromium/src/+log/84.0.4147.135..85.0.4183.83?n=10000)
      - Revised Chrome Platform Status for [`Lax_default`](https://www.chromestatus.com/feature/5088147346030592) and [`secure_context_required`](https://www.chromestatus.com/feature/5633521622188032)
    - The enforcements are coming to Edge 86: [Microsoft Edge documentation](https://docs.microsoft.com/en-us/microsoft-edge/web-platform/site-impacting-changes)
    - Opera 71 is based on Chromium 85: [release notes](https://blogs.opera.com/desktop/2020/06/opera-71-developer/)
  3. → 9c02380
    - There is no Firefox for Android 69 ~ 78 due to Fenix transition: [Firefox version history](https://en.wikipedia.org/wiki/Firefox_version_history)
    - Opera for Android 60 is based on Chromium 85: [Google Play (Internet Archive)](https://web.archive.org/web/20201022152655/https://play.google.com/store/apps/details?id=com.opera.browser), [APKMirror](https://www.apkmirror.com/apk/opera-software-asa/opera/opera-60-3-3004-55692-release/)
- [x] Data: if you tested something, describe how you tested with details like browser and version
  All the changes were manually tested with the corresponding versions on macOS and Android Virtual Device with Developer Tools. It was a doozy.
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
  https://github.com/Fyrd/caniuse/pull/5794