### PR TITLE
Fix isPointInPath Path Parameter support info

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2320,7 +2320,7 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
                 "version_added": null


### PR DESCRIPTION
I changed Safari's `version_added` from **false** to **"10"** in accordance to #9328.