### PR TITLE
Mark Intl.NumberFormat support partial in Safari

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -164,6 +164,60 @@
                 }
               }
             },
+            "currencyDisplay": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "77"
+                  },
+                  "chrome_android": {
+                    "version_added": "77"
+                  },
+                  "edge": {
+                    "version_added": "79"
+                  },
+                  "firefox": {
+                    "version_added": "78"
+                  },
+                  "firefox_android": {
+                    "version_added": "79"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "12.11.0"
+                  },
+                  "opera": {
+                    "version_added": "64"
+                  },
+                  "opera_android": {
+                    "version_added": "55"
+                  },
+                  "safari": {
+                    "version_added": "10",
+                    "partial_implementation": true,
+                    "notes": "Doesn't support <code>currencyDisplay: 'narrowSymbol'</code>."
+                  },
+                  "safari_ios": {
+                    "version_added": "10",
+                    "partial_implementation": true,
+                    "notes": "Doesn't support <code>currencyDisplay: 'narrowSymbol'</code>."
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "12.0"
+                  },
+                  "webview_android": {
+                    "version_added": "77"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "currencySign": {
               "__compat": {
                 "description": "<code>currencySign</code> option",

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -166,6 +166,7 @@
             },
             "currencyDisplay": {
               "__compat": {
+                "description": "<code>currencyDisplay</code> option",
                 "support": {
                   "chrome": {
                     "version_added": "77"


### PR DESCRIPTION
Code examination of https://trac.webkit.org/changeset/266031/webkit indicates that support for `currencyDisplay: 'narrowSymbol'` wasn’t added to WebKit until 2020-08-22 — and didn’t make it into Safari 14 (confirmed by testing), released 2020-09-16.