### PR TITLE
Add spec URLs for newly-added CSS @property descriptors

### DIFF
--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -53,6 +53,7 @@
           "__compat": {
             "description": "<code>inherits</code> descriptor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property/inherits",
+            "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#inherits-descriptor",
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -102,6 +103,7 @@
           "__compat": {
             "description": "<code>initial-value</code> descriptor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property/initial-value",
+            "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor",
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -151,6 +153,7 @@
           "__compat": {
             "description": "<code>syntax</code> descriptor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property/syntax",
+            "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#the-syntax-descriptor",
             "support": {
               "chrome": {
                 "version_added": "85"


### PR DESCRIPTION
This change adds spec URLs for the CSS @property `inherits`, `initial-value`, and `syntax` descriptors.