### PR TITLE
Edge89 Release

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -112,19 +112,26 @@
         "88": {
           "release_date": "2021-01-21",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-88070550-january-21",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
-          "status": "beta",
+          "release_date": "2021-03-04",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-89077445-march-4",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "89"
         },
         "90": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "90"
+        },
+        "91": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "91"
         }
       }
     }


### PR DESCRIPTION
Edge 89 is released -- this PR updates the browser data accordingly.

Refs:
- https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-89077445-march-4
