### PR TITLE
Fix the capitalization of two SVG API entries

### DIFF
--- a/api/SVGTests.json
+++ b/api/SVGTests.json
@@ -47,7 +47,7 @@
           "deprecated": false
         }
       },
-      "hasextension": {
+      "hasExtension": {
         "__compat": {
           "support": {
             "chrome": {

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -47,7 +47,7 @@
           "deprecated": false
         }
       },
-      "viewtarget": {
+      "viewTarget": {
         "__compat": {
           "support": {
             "chrome": {


### PR DESCRIPTION
These were in older versions of SVG:
https://www.w3.org/TR/SVG11/types.html#InterfaceSVGTests
https://www.w3.org/TR/SVG11/linking.html#InterfaceSVGViewElement