### PR TITLE
Remove the api.Window.layoutShift entry

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3443,55 +3443,6 @@
           }
         }
       },
-      "layoutShift": {
-        "__compat": {
-          "description": "<code>languagechange</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/layoutShift",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "80"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/length",


### PR DESCRIPTION
This was added in https://github.com/mdn/browser-compat-data/pull/6090
but there is no `layoutShift` global property, nor any "layoutshift"
event. There is a `LayoutShift` interface, but that's already covered in
LayoutShift.json.