### PR TITLE
api.Navigator.share - Note Firefox for Android's lack of text sharing support

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2513,7 +2513,7 @@
             "firefox_android": {
               "version_added": "79",
               "partial_implementation": true,
-              "notes": "Firefox does not support sharing files."
+              "notes": "Firefox does not support sharing files or text."
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2513,7 +2513,7 @@
             "firefox_android": {
               "version_added": "79",
               "partial_implementation": true,
-              "notes": "Firefox does not support sharing files or text."
+              "notes": "Firefox for Android does not support sharing files or text."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #9252
