### PR TITLE
Mark week input as unsupported for Safari

### DIFF
--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -38,7 +38,8 @@
                 "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
The linked bug and WebKit platform status report this as unsupported:

https://bugs.webkit.org/show_bug.cgi?id=200416
https://webkit.org/status/#feature-date-and-time-input-types

Related to #9172
