### PR TITLE
Remove the api.PaymentManager.requestPermission entry

### DIFF
--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -142,55 +142,6 @@
           }
         }
       },
-      "requestPermission": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/requestPermission",
-          "description": "<code>requestPermission()</code>",
-          "support": {
-            "chrome": {
-              "version_added": "70"
-            },
-            "chrome_android": {
-              "version_added": "70"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "57"
-            },
-            "opera_android": {
-              "version_added": "49"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "userHint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentManager/userHint",


### PR DESCRIPTION
This was added in https://github.com/mdn/browser-compat-data/pull/1978,
but was actually never shipped. It was removed from the spec in
https://github.com/w3c/payment-handler/pull/277 and has never been
present in Chromium's payment_manager.idl.