### PR TITLE
Remove 3 PasswordCredential attributes which were unshipped

### DIFF
--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -96,54 +96,6 @@
           }
         }
       },
-      "additionalData": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/additionalData",
-          "support": {
-            "chrome": {
-              "version_added": "51"
-            },
-            "chrome_android": {
-              "version_added": "51"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "38"
-            },
-            "opera_android": {
-              "version_added": "41"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "51"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "iconURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/iconURL",
@@ -189,54 +141,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "idName": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/idName",
-          "support": {
-            "chrome": {
-              "version_added": "51"
-            },
-            "chrome_android": {
-              "version_added": "51"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "38"
-            },
-            "opera_android": {
-              "version_added": "41"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "51"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": true
           }
         }
       },
@@ -333,54 +237,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "passwordName": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PasswordCredential/passwordName",
-          "support": {
-            "chrome": {
-              "version_added": "51"
-            },
-            "chrome_android": {
-              "version_added": "51"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "38"
-            },
-            "opera_android": {
-              "version_added": "41"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "51"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
These were removed in Chromium M64:
https://storage.googleapis.com/chromium-find-releases-static/57b.html#57b2dc23b962feeadd2dcf60a399c9f38d2087e3

That removal reached stable more than 2 years ago, for example Samsung
Internet 9.0 with M67 was released on 2018-09-15.