### PR TITLE
Remove the api.Window.OverconstrainedError entry

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -96,54 +96,6 @@
           }
         }
       },
-      "OverconstrainedError": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/OverconstrainedError",
-          "support": {
-            "chrome": {
-              "version_added": "63"
-            },
-            "chrome_android": {
-              "version_added": "63"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "63"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "afterprint_event": {
         "__compat": {
           "description": "<code>afterprint</code> event",


### PR DESCRIPTION
There's already an api.OverconstrainedError entry with subfeatures. The
compat data for that either matches or is more precise than that being
removed here.

The reason this entry is here is probably because `OverconstrainedError`
was originally not defined using Web IDL but with some spec prose
decribing the interface object.