### PR TITLE
Clear-Site-Data header: secure context is standard compliant

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -338,7 +338,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
As discussed in https://github.com/mdn/browser-compat-data/pull/8785#issuecomment-793650145 there is a strong implication that the `Clear-Site-Data` requiring a secure context is required by the standard. This flips the status so that standard is true.