### PR TITLE
Link Chromium/WebKit bugs for grid animations and subgrid

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -128,17 +128,19 @@
         },
         "animation": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns",
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "firefox": {
                 "version_added": "66"
@@ -150,22 +152,28 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/204580'>bug 204580</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/204580'>bug 204580</a>."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               }
             },
             "status": {
@@ -480,13 +488,16 @@
             "description": "<code>subgrid</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "firefox": [
                 {
@@ -511,22 +522,28 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               }
             },
             "status": {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -128,17 +128,19 @@
         },
         "animation": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows",
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "firefox": {
                 "version_added": "66"
@@ -150,22 +152,28 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/204580'>bug 204580</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/204580'>bug 204580</a>."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
               }
             },
             "status": {
@@ -536,13 +544,16 @@
             "description": "<code>subgrid</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "firefox": [
                 {
@@ -567,22 +578,28 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/618969'>bug 618969</a>."
               }
             },
             "status": {


### PR DESCRIPTION
Also remove the MDN URL pointing to the parent feature. When on that
page, following the link and ending up on the same page is a confusing
experience.