### PR TITLE
Fix isPointInPath Path Parameter support info for Safari

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2320,7 +2320,7 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": null

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2323,7 +2323,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"


### PR DESCRIPTION
This Pull Request is the continuation of and closes #9353.
I changed Safari isPointInPath Path Parameter support info from false to "7", as suggested by @foolip in the original Pull Request #9353.
