### PR TITLE
Fix descriptions and Safari versions for canvas Path2D overloads

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -382,9 +382,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -414,7 +414,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "8"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"
@@ -1005,7 +1005,7 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -1023,9 +1023,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "37"
@@ -1052,10 +1052,10 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"
@@ -1457,9 +1457,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -1486,10 +1486,10 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"
@@ -2291,9 +2291,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -2401,9 +2401,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -2430,10 +2430,10 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"
@@ -3685,9 +3685,9 @@
             "deprecated": false
           }
         },
-        "Path_parameter": {
+        "path_parameter": {
           "__compat": {
-            "description": "<code>Path</code> parameter",
+            "description": "<code>Path2D</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -3714,10 +3714,10 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"


### PR DESCRIPTION
The type was incorrectly described as Path. Rather than changing the
IDs, just lowercase them, as this is much more typical in BCD, and the
name of the argument is also path, although this is not observable.

Safari version archeology:

5 of these were around when isPointInPath/isPointInStroke were added and
were most likely shipped together with Path2D:
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl?rev=165927

See however https://github.com/mdn/browser-compat-data/issues/9423 about
the challenge of distinguishing Safari 6.1 and 7. 7 is used because
that's the version used for Path2D itself.

drawFocusIfNeeded is different, it was added at WebKit trunk 538.35.0:
https://trac.webkit.org/changeset/168476/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=168476

The Path2D overload was added at WebKit trunk 601.1.1:
https://trac.webkit.org/changeset/173652/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=173652

Both are after Safari 7 was released, so that can't be right. The
likely versions are instead inferred from the WebKit trunk version.