### PR TITLE
Mark ShadowRoot.getSelection as not supported in Firefox or Safari and as non-standard

### DIFF
--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -338,38 +338,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -380,10 +354,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -394,7 +368,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Prompted by https://github.com/mdn/browser-compat-data/pull/9431 and
confirmed by mdn-bcd-collector results.