### PR TITLE
Mirror Firefox desktop data to Android for the Animation API

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -182,7 +182,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -566,7 +566,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -712,7 +712,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -963,7 +963,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -1011,7 +1011,7 @@
               "version_added": "75"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -1156,14 +1156,8 @@
               "notes": "Currently only the getter is supported"
             },
             "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.timelines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "79",
+              "notes": "Currently only the getter is supported"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The note about readonly timeline is still true:
https://github.com/mozilla/gecko-dev/blob/491c8096b5dfdb328b2135895062e16e1e36d708/dom/webidl/Animation.webidl#L27-L32

mdn-bcd-collector results confirm support for all of these in Firefox
for Android 86, except remove_filling_animation which has not test, but
is safe to assume matches Firefox for Windows.

Follow-up to https://github.com/mdn/browser-compat-data/pull/9192.