### PR TITLE
Update api.Navigator.share for Chrome 89

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2547,7 +2547,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/share",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89"
             },
             "chrome_android": {
               "version_added": "61"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -435,7 +435,7 @@
             "chrome": {
               "version_added": "89",
               "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1144920'>bug 1144920</a>."
+              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "75"
@@ -2551,7 +2551,7 @@
             "chrome": {
               "version_added": "89",
               "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1144920'>bug 1144920</a>."
+              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "61"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -433,7 +433,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/canShare",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "89",
+              "partial_implementation": true,
+              "notes": "Not supported on macOS, see <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "75"
@@ -2547,7 +2549,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/share",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "89",
+              "partial_implementation": true,
+              "notes": "Not supported on macOS, see <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "61"


### PR DESCRIPTION
The link to the feature provided is at: https://www.chromestatus.com/feature/5668769141620736.

Fixes #9396.