### PR TITLE
Mark <content> and <shadow> elements as removed in Chromium

### DIFF
--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -5,13 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement",
         "support": {
           "chrome": {
-            "version_added": "35"
+            "version_added": "35",
+            "version_removed": "89"
           },
           "chrome_android": {
-            "version_added": "37"
+            "version_added": "37",
+            "version_removed": "89"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79",
+            "version_removed": "89"
           },
           "firefox": {
             "version_added": "28",
@@ -25,7 +28,8 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "26"
+            "version_added": "26",
+            "version_removed": "75"
           },
           "opera_android": {
             "version_added": "26"
@@ -40,7 +44,8 @@
             "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": "37",
+            "version_removed": "89"
           }
         },
         "status": {
@@ -54,13 +59,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/getDistributedNodes",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79",
+              "version_removed": "89"
             },
             "firefox": {
               "version_added": "28",
@@ -74,7 +82,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "75"
             },
             "opera_android": {
               "version_added": "26"
@@ -89,7 +98,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             }
           },
           "status": {
@@ -104,13 +114,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLContentElement/select",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79",
+              "version_removed": "89"
             },
             "firefox": {
               "version_added": "28",
@@ -124,7 +137,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "75"
             },
             "opera_android": {
               "version_added": "26"
@@ -139,7 +153,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             }
           },
           "status": {

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -5,13 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement",
         "support": {
           "chrome": {
-            "version_added": "35"
+            "version_added": "35",
+            "version_removed": "89"
           },
           "chrome_android": {
-            "version_added": "35"
+            "version_added": "35",
+            "version_removed": "89"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "79",
+            "version_removed": "89"
           },
           "firefox": {
             "version_added": "29",
@@ -25,7 +28,8 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "26"
+            "version_added": "26",
+            "version_removed": "75"
           },
           "opera_android": {
             "version_added": null
@@ -40,7 +44,8 @@
             "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": "37",
+            "version_removed": "89"
           }
         },
         "status": {
@@ -54,13 +59,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLShadowElement/getDistributedNodes",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "89"
             },
             "firefox": {
               "version_added": false
@@ -72,7 +80,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "75"
             },
             "opera_android": {
               "version_added": null
@@ -87,7 +96,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             }
           },
           "status": {

--- a/html/elements/content.json
+++ b/html/elements/content.json
@@ -6,13 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/content",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "89"
             },
             "firefox": {
               "version_added": "33",
@@ -40,7 +43,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "75"
             },
             "opera_android": {
               "version_added": null
@@ -55,7 +59,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             }
           },
           "status": {

--- a/html/elements/shadow.json
+++ b/html/elements/shadow.json
@@ -6,13 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/shadow",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "89"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "89"
             },
             "firefox": {
               "version_added": "33",
@@ -40,7 +43,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "75"
             },
             "opera_android": {
               "version_added": null
@@ -55,7 +59,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "89"
             }
           },
           "status": {


### PR DESCRIPTION
The chrome, chrome_android and edge fixes for the interfaces were made
by mdn-bcd-collector, the rest was inferred.

Commit which removed this, confirming M89:
https://storage.googleapis.com/chromium-find-releases-static/e9a.html#e9aef1ba859e5942b9e8f5396380008b4443f69d

There are no releases of Opera Android or Samsung Internet using M89
yet, so those must be left as they are.