### PR TITLE
Update api.Console.trace for Firefox 6

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1468,10 +1468,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "ie": {
               "version_added": "11"


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6 `console.trace()` is added in Firefox 6.

Fixes #9119.