### PR TITLE
Add safelisted cors header subfeature

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -90,7 +90,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -48,6 +48,54 @@
             "deprecated": false
           }
         },
+        "cors_response_safelist": {
+          "__compat": {
+            "description": "CORS-safelisted response header",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "immutable": {
           "__compat": {
             "description": "<code>immutable</code>",

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -48,54 +48,6 @@
             "deprecated": false
           }
         },
-        "cors_response_safelist": {
-          "__compat": {
-            "description": "CORS-safelisted response header",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "immutable": {
           "__compat": {
             "description": "<code>immutable</code>",

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -90,7 +90,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -47,6 +47,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "cors_response_safelist": {
+          "__compat": {
+            "description": "CORS-safelisted response header",
+            "support": {
+              "chrome": {
+                "version_added": "76"
+              },
+              "chrome_android": {
+                "version_added": "76"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "87"
+              },
+              "firefox_android": {
+                "version_added": "87"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "63"
+              },
+              "opera_android": {
+                "version_added": "54"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "76"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #9300 

@ddbeck As we discussed in #9300 this is update adds subfeature for "CORS response header safelist" for two response headers as a test (on completion this will cover [all the headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header)

The `Content-Length` update is the interesting one, which adds the browser versions at which the header joined the list. The linked item covers the versioning discussion except for Safari. I have marked that as `false` because it is still in the technology preview: https://developer.apple.com/safari/technology-preview/release-notes/

The `Cache-Control` is what all the other ones will look like. Essentially it just copies the version info from the parent - my assumption being that the header and the safelist came at the same time. This is reasonable, because most of these headers just say `true` for version anyway.

If you're OK with the approach/text I will roll out to the other headers in the list.

