### PR TITLE
Show removal of runtime flag for module support in Node.js

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1619,6 +1619,7 @@
               },
               {
                 "version_added": "12.0.0",
+                "version_removed": "13.2.0",
                 "flags": [
                   {
                     "name": "--experimental-modules",
@@ -1629,6 +1630,7 @@
               },
               {
                 "version_added": "8.5.0",
+                "version_removed": "12.0.0",
                 "flags": [
                   {
                     "name": "--experimental-modules",


### PR DESCRIPTION
This makes it a bit more explicit how the support has changed over time.

Fixes #9460.
