### PR TITLE
Remove entries representing indexed property getters

### DIFF
--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -48,54 +48,6 @@
           "deprecated": false
         }
       },
-      "CSSNumericValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/CSSNumericValue",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/entries",

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -48,54 +48,6 @@
           "deprecated": false
         }
       },
-      "CSSUnparsedSegment": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/CSSUnparsedSegment",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "CSSUnparsedValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/CSSUnparsedValue",

--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -48,56 +48,6 @@
           "deprecated": false
         }
       },
-      "DataTransferItem": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/DataTransferItem",
-          "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface:datatransferitem",
-          "description": "<code>DataTransferItemList[]</code>",
-          "support": {
-            "chrome": {
-              "version_added": "13"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "12"
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "6"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "add": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add",

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -56,56 +56,6 @@
           "deprecated": false
         }
       },
-      "SourceBuffer": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/SourceBuffer",
-          "spec_url": "https://w3c.github.io/media-source/#dfn-sourcebufferlist-getter",
-          "support": {
-            "chrome": {
-              "version_added": "45"
-            },
-            "chrome_android": {
-              "version_added": "45"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "42"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "11",
-              "notes": "Only works on Windows 8+."
-            },
-            "opera": {
-              "version_added": "32"
-            },
-            "opera_android": {
-              "version_added": "32"
-            },
-            "safari": {
-              "version_added": "8"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "45"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/length",

--- a/api/TrackDefaultList.json
+++ b/api/TrackDefaultList.json
@@ -47,54 +47,6 @@
           "deprecated": true
         }
       },
-      "TrackDefault": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrackDefaultList/TrackDefault",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "≤18"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "TrackDefaultList": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrackDefaultList/TrackDefaultList",


### PR DESCRIPTION
These are curious, because the ability to access the members of these
Array-like interfaces is the whole point of them. There are many
interfaces like this, but only these few have entries for [].

These pages exist and will need to be removed:
https://developer.mozilla.org/docs/Web/API/DataTransferItemList/DataTransferItem
https://developer.mozilla.org/docs/Web/API/SourceBufferList/SourceBuffer
https://developer.mozilla.org/docs/Web/API/TrackDefaultList/TrackDefault

These pages do not exist:
https://developer.mozilla.org/docs/Web/API/CSSNumericArray/CSSNumericValue
https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/CSSUnparsedSegment

The interface pages do exist and show that support is largely identical
to the parent feature:
https://developer.mozilla.org/docs/Web/API/CSSNumericArray#Browser_compatibility
https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue#Browser_compatibility
https://developer.mozilla.org/docs/Web/API/DataTransferItemList#Browser_compatibility
https://developer.mozilla.org/docs/Web/API/SourceBufferList#Browser_compatibility
https://developer.mozilla.org/docs/Web/API/TrackDefaultList#Browser_compatibility

The exception is SourceBufferList, but that must be an error in the data.