### PR TITLE
Mirror javascript.builtins.String.matchAll for Samsung Internet

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1498,7 +1498,7 @@
                 "version_added": "13"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "11.0"
               },
               "webview_android": {
                 "version_added": "73"


### PR DESCRIPTION
This fills in an obvious discrepancy for a well-supported feature. Fixes #9196.