### PR TITLE
Update support for DataTransfer.items for Safari

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -418,7 +418,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -415,7 +415,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Was reported in #9200 as supported in Safari 14. Found https://trac.webkit.org/changeset/222376/webkit showing that it was enabled in Safari (it says something about iOS, but I don't think iOS actually fires the drag and drop events) circa 2017. [Tested](https://gist.github.com/ddbeck/9b05cc6915c565eba89317d3eef1c678) to confirm that it landed in Safari 11.1 and not earlier.

Fixes #9200.
