### PR TITLE
Update stop-opacity for Safari iOS and remove duplications (#9402)

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2210,54 +2210,6 @@
             }
           }
         },
-        "stop-opacity": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-opacity",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "stroke": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke",

--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -144,6 +144,7 @@
         },
         "stop-opacity": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-opacity",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -172,9 +172,15 @@
               "safari": {
                 "version_added": "3"
               },
-              "safari_ios": {
-                "version_added": "3"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "3",
+                  "version_removed": "11"
+                },
+                {
+                  "version_added": "14"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "1.0"
               },


### PR DESCRIPTION
# Summary of changes
* Updated Safari iOS' entry for `stop-opacity` to show missing support between versions 11 and 14.
* Removed duplication of data for `stop-opacity` in svg.attributes.presentation following this discussion: #9402

Details on testing and verification of support information can also be found in that issue.

Tests and lints passed with no issues.
Although, when running `npm install` the package-lock.json file was modified a bunch, which I since had to unstage before committing. Not sure what the right way to deal with that is, but either way updating dependencies is outside the scope of this PR

Related issue: #9402