### PR TITLE
Update <a> ping attribute

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -152,8 +152,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -457,7 +457,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": true,

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -487,7 +487,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "6"

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -471,6 +471,7 @@
               },
               "firefox_android": {
                 "version_added": true,
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -489,10 +489,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -502,7 +502,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -544,6 +544,7 @@
               },
               "firefox_android": {
                 "version_added": true,
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -560,7 +560,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "6"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -522,63 +522,63 @@
         },
         "ping": {
           "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "79"
-                },
-                "firefox": {
-                  "version_added": true,
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "browser.send_pings",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": true,
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "browser.send_pings",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "6"
-                },
-                "safari_ios": {
-                  "version_added": "6"
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": {
-                  "version_added": true
-                }
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "referrerpolicy": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -530,7 +530,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": true,

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -520,6 +520,67 @@
             }
           }
         },
+        "ping": {
+          "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "browser.send_pings",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "browser.send_pings",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": "6"
+                },
+                "safari_ios": {
+                  "version_added": "6"
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+          }
+        },
         "referrerpolicy": {
           "__compat": {
             "support": {

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -200,8 +200,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "≤18",
-                "version_removed": "79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61",

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -204,10 +204,25 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": "61"
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": "61"
+                "version_added": "61",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.send_pings",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Tested by clicking a link with `ping` set to a server running locally and inspecting the requests. First works in Safari 6 (both platforms).

Fixes #9219.