### PR TITLE
Remove spread in destructuring

### DIFF
--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -128,57 +128,6 @@
             }
           }
         },
-        "spread_in_destructuring": {
-          "__compat": {
-            "description": "Spread in destructuring",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": {
-                "version_added": "49"
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": "34"
-              },
-              "firefox_android": {
-                "version_added": "34"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "6.0.0"
-              },
-              "opera": {
-                "version_added": "37"
-              },
-              "opera_android": {
-                "version_added": "37"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "spread_in_object_literals": {
           "__compat": {
             "description": "Spread in object literals",


### PR DESCRIPTION
Hi there,

The goal of this PR is to remove "spread in destructuring" from the spread syntax compatibility table as mentioned in this [issue](https://github.com/mdn/browser-compat-data/issues/9457).

Supporting information:
On the object literal [proposal](https://github.com/tc39/proposal-object-rest-spread) it's mentioned:

> rest elements for array destructuring assignment
> rest properties for object destructuring assignment 

Destructuring is rest and not spread.

The error message when the rest element also hints at being rest and not spread destructuring:

![image](https://user-images.githubusercontent.com/2487710/111206534-c6c9cf00-85c8-11eb-8e4a-ca9ba0468924.png)

Hope this helps.
