### PR TITLE
Updates api.ResizeObserver in Firefox for Android v79

### DIFF
--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -17,7 +17,7 @@
             "version_added": "69"
           },
           "firefox_android": {
-            "version_added": "85"
+            "version_added": "79"
           },
           "ie": {
             "version_added": false

--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -65,7 +65,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -17,7 +17,7 @@
             "version_added": "69"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "85"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
Hi guys!

Regarding issue #9261 all the methods of the `api.ResizeObserver` feature are working on Firefox version for Android 85.

However, I was unable to perform a test on previous versions to see if there is a version before 85 that was already working.

Could someone tell me what would be the best way to test with older mobile browsers on a desktop?

Fixes #9261.