### PR TITLE
Update SVGGeometryElement's isPointIn* Edge / Firefox data

### DIFF
--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -158,13 +158,13 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -206,13 +206,13 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
It's a coincidence that it's "79" for both.

Edge 79 is suggested by mdn-bcd-collector, because these weren't in Edge
18.

mdn-bcd-collector also confirms support in current Firefox for Android,
and then the Firefox data was mirrored, assuming concurrent shipping.