### PR TITLE
Fix sort of api.PushEvent features for Edge

### DIFF
--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -12,6 +12,10 @@
           },
           "edge": [
             {
+              "version_added": "17"
+            },
+            {
+              "version_removed": "17",
               "version_added": "16",
               "flags": [
                 {
@@ -19,9 +23,6 @@
                   "name": "Enable service workers"
                 }
               ]
-            },
-            {
-              "version_added": "17"
             }
           ],
           "firefox": {
@@ -79,6 +80,10 @@
             },
             "edge": [
               {
+                "version_added": "17"
+              },
+              {
+                "version_removed": "17",
                 "version_added": "16",
                 "flags": [
                   {
@@ -86,9 +91,6 @@
                     "name": "Enable service workers"
                   }
                 ]
-              },
-              {
-                "version_added": "17"
               }
             ],
             "firefox": {
@@ -145,6 +147,10 @@
             },
             "edge": [
               {
+                "version_added": "17"
+              },
+              {
+                "version_removed": "17",
                 "version_added": "16",
                 "flags": [
                   {
@@ -152,9 +158,6 @@
                     "name": "Enable service workers"
                   }
                 ]
-              },
-              {
-                "version_added": "17"
               }
             ],
             "firefox": {


### PR DESCRIPTION
This will put the most relevant entry first, so it shows as supported in the MDN table. It also terminates the flag, since that's definitely no longer a thing in Chromium.

Fixes #9234.