### PR TITLE
adding color-mix()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -196,7 +196,7 @@
         },
         "color-mix": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color_mix()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix()",
             "description": "<code>color-mix()</code>",
             "support": {
               "chrome": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -197,7 +197,7 @@
         "color-mix": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color_mix()",
-            "description": "<code>color_mix()</code>",
+            "description": "<code>color-mix()</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -194,7 +194,7 @@
             }
           }
         },
-        "color_mix": {
+        "color-mix": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color_mix()",
             "description": "<code>color_mix()</code>",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -52,7 +52,7 @@
         },
         "alpha": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#rgba()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/rgba()",
             "description": "Alpha color values (<code>rgba()</code>, <code>hsla()</code>)",
             "support": {
               "chrome": {
@@ -194,6 +194,69 @@
             }
           }
         },
+        "color_mix": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color_mix()",
+            "description": "<code>color_mix()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.color-mix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.color-mix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "currentcolor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#currentColor",
@@ -293,7 +356,7 @@
         },
         "hsl": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#hsl()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/hsl()",
             "description": "HSL color values (<code>hsl()</code>)",
             "support": {
               "chrome": {
@@ -536,7 +599,7 @@
         },
         "rgb_functional_notation": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#rgb()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/rgb()",
             "description": "RGB functional notation (<code>rgb()</code>)",
             "support": {
               "chrome": {


### PR DESCRIPTION
CSS Color Level 5 has the `color-mix()` functional notation, which has been implemented behind a pref in Firefox 88 so I'll document it as part of the work I'm doing to improve the docs on these functions.

Spec: https://www.w3.org/TR/css-color-5/#colormix
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1695376

It is also in Safari TP: https://webkit.org/blog/11577/release-notes-for-safari-technology-preview-122/

I also fixed a couple of the URLs to other color functional notations which now have their own pages as part of this work.
