### PR TITLE
Document getTransports availability in Chrome as of v74

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -245,7 +245,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
           "support": {
             "chrome": {
-              "version_added": 74
+              "version_added": "74"
             },
             "chrome_android": {
               "version_added": 74

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": 74
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": 74
             },
             "edge": {
               "version_added": false

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -248,7 +248,7 @@
               "version_added": "74"
             },
             "chrome_android": {
-              "version_added": 74
+              "version_added": "74"
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
Per https://web-confluence.appspot.com/#!/catalog?releases=%5B%22Chrome_73.0.3683.86_Windows_10.0%22,%22Chrome_74.0.3729.108_Windows_10.0%22%5D&q=%22Attestatio%22
part of #6922


