### PR TITLE
Revise notes for historic window.close() behavior

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1173,15 +1173,16 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Before Edge 79, scripts can close windows that weren't opened by the same script."
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Starting in Firefox 46.0.1, <code>Window.close()</code> can no longer close windows that weren't opened by the same script. This is a security precaution."
+              "notes": "Before Firefox 46, scripts can close windows that weren't opened by the same script."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Starting in Firefox 46.0.1, <code>Window.close()</code> can no longer close windows that weren't opened by the same script. This is a security precaution."
+              "notes": "Before Firefox 46, scripts can close windows that weren't opened by the same script."
             },
             "ie": {
               "version_added": "4"


### PR DESCRIPTION
Fixes #9270. There's some additional oddities about the way browsers do and do not allow `window.close()` to work with respect to document history, but as a practical matter, it doesn't really come up. These notes should cover it, but I'm putting these links here as a record in case it ever comes up again:

https://bugs.chromium.org/p/chromium/issues/detail?id=6773
https://bugs.chromium.org/p/chromium/issues/detail?id=1170131

Related fix to content: https://github.com/mdn/content/pull/3236
