### PR TITLE
Rewrite Path2D EdgeHTML-only note (and change Path2D status)

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -139,7 +139,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -60,7 +60,7 @@
             },
             "edge": {
               "version_added": "14",
-              "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
+              "notes": "Before Edge 79, the constructor for <code>Path2D</code> objects does not support invocation with a string consisting of SVG path data."
             },
             "firefox": {
               "version_added": "31"


### PR DESCRIPTION
Fixes #9291. Specifically:

- There was an old EdgeHTML note about the `Path2D()` constructor, which didn't identify itself as such.
- Path2D is not plausibly experimental