### PR TITLE
Link to Firefox bug for lazy-loading iframes

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -533,10 +533,12 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1622090'>bug 1622090</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1622090'>bug 1622090</a>."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Fixes #9416. Chrome implements it and Safari seems headed that way, so this helps answer what Firefox is up to.