### PR TITLE
Remove WebAuthn support for WebView

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -40,7 +40,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -189,7 +189,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -40,7 +40,7 @@
             "version_added": "10.0"
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -89,7 +89,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -40,7 +40,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -53,7 +53,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {
@@ -304,7 +304,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
I wondered about this while mirroring some data in #9504. It turns out that WebView does not expose some WebAuthn interfaces:

https://source.chromium.org/chromium/chromium/src/+/master:android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt;l=114-118
https://storage.googleapis.com/chromium-find-releases-static/d06.html#d065fd5bdb8aff53f022d6771bc9578e9f7bdd97