### PR TITLE
Added data for RegExp.prototype.hasIndices

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -471,7 +471,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -426,6 +426,57 @@
             }
           }
         },
+        "hasIndices": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
+            "support": {
+              "chrome": {
+                "version_added": "91"
+              },
+              "chrome_android": {
+                "version_added": "91"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "88"
+              },
+              "firefox_android": {
+                "version_added": "88"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "ignoreCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase",
@@ -526,57 +577,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "hasIndices": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
-            "support": {
-              "chrome": {
-                "version_added": "91"
-              },
-              "chrome_android": {
-                "version_added": "91"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "88"
-              },
-              "firefox_android": {
-                "version_added": "88"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -529,6 +529,57 @@
             }
           }
         },
+        "hasIndices": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
+            "support": {
+              "chrome": {
+                "version_added": "91"
+              },
+              "chrome_android": {
+                "version_added": "91"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "88"
+              },
+              "firefox_android": {
+                "version_added": "88"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "input": {
           "__compat": {
             "description": "<code>RegExp.input</code> (<code>$_</code>)",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -431,13 +431,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
             "support": {
               "chrome": {
-                "version_added": "91"
+                "version_added": "90"
               },
               "chrome_android": {
-                "version_added": "91"
+                "version_added": "90"
               },
               "edge": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox": {
                 "version_added": "88"
@@ -467,7 +467,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "90"
               }
             },
             "status": {


### PR DESCRIPTION
This patch adds compatibility data for the [recently introduced `RegExp.prototype.hasIndices`](https://github.com/tc39/proposal-regexp-match-indices) property.

It got implemented in Firefox 88 as of [bug 1519483](https://bugzilla.mozilla.org/show_bug.cgi?id=1519483) and in Chrome as of [issue 9548](https://bugs.chromium.org/p/v8/issues/detail?id=9548), which should be 91. Though the [platform status](https://www.chromestatus.com/features/6558676666023936) says "In developer trial (Behind a flag)", which confuses me a little bit because it's not needed to turn on any flag.

I've tested this in Firefox Nightly 88.0a1 (2021-03-17), in Chrome 91.0.4450.0. I've also tried Firefox DevEdition 87.0b9 (64-bit) and Chrome 89.0.4389.90 where it is _not_ implemented.

Note that I _didn't_ test the feature in Chrome 88. It might be that it's already added in that version. I also did _not_ test it in other browsers but I assume it's not implemented there yet as the feature is pretty new. The feature just landed in V8 last month, so Chromium based browsers probably didn't pick it up yet. Therefore I've set everything to `false`. I could also set the ones where support is unclear to `null`, instead.

Sebastian