### PR TITLE
Testing shows SVG <set> works on FF desktop/android

### DIFF
--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -15,13 +15,13 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -61,13 +61,13 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -52,40 +52,40 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -6,40 +6,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/set",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -76,10 +76,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/3231

There is a test example on this page for set and "to" attribute: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/set s
This works on current FF desktop and android variants. Does not work on current IE11. I can't find any docs on when this was introduced in FF so I set to true. 

