### PR TITLE
Add entries for webkitOfflineAudioContext

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -4,12 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext",
         "support": {
-          "chrome": {
-            "version_added": "14"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "35"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "57",
+              "prefix": "webkit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "35"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "57",
+              "prefix": "webkit"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -22,24 +36,54 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "15"
-          },
-          "opera_android": {
-            "version_added": "14"
-          },
+          "opera": [
+            {
+              "version_added": "22"
+            },
+            {
+              "version_added": "15",
+              "version_removed": "44",
+              "prefix": "webkit"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "22"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "43",
+              "prefix": "webkit"
+            }
+          ],
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "6",
+            "prefix": "webkit"
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": "≤37"
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "3.0"
+            },
+            {
+              "version_added": "1.5",
+              "version_removed": "7.0",
+              "prefix": "webkit"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "4.4.3"
+            },
+            {
+              "version_added": "≤37",
+              "version_removed": "57",
+              "prefix": "webkit"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -52,14 +96,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/OfflineAudioContext",
           "description": "<code>OfflineAudioContext()</code> constructor",
           "support": {
-            "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
-            },
-            "chrome_android": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
-            },
+            "chrome": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -72,26 +128,54 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "43",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6",
+              "prefix": "webkit"
             },
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "Before Samsung Internet 7.0, the default values were not supported."
-            },
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "7.0",
+                "prefix": "webkit"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4.3"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "57",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -154,10 +238,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/complete_event",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -184,7 +268,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -250,10 +334,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/oncomplete",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -280,7 +364,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -346,10 +430,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/startRendering",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -376,7 +460,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
In addition to not representing prefixed support, much of the existing
data claimed support that was earlier than it really was.

Chrome versions for webkitOfflineAudioContext and OfflineAudioContext were
found with two mdn-bcd-collector tests:
https://mdn-bcd-collector.appspot.com/tests/api/webkitOfflineAudioContext
https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioContext/OfflineAudioContext

Other Chromium data was mirrored.

Safari 14 does not support the unprefixed constructor, that should be
coming in Safari 14.1.

Support for webkitOfflineAudioContext was confirmed in iOS 7, and so
assumed to have been introduced in iOS 6, matching webkitAudioContext.