### PR TITLE
Mirror Web Audio API shipping in Firefox 25 to Android (was 26)

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -257,7 +257,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -305,7 +305,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -353,7 +353,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -401,7 +401,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -449,7 +449,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -497,7 +497,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -119,7 +119,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -359,7 +359,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -407,7 +407,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -118,7 +118,7 @@
               "notes": "Firefox currently handles the value <code>null</code> incorrectly. Instead of producing a node that generates a single channel of silence, the node becomes unusable and will be ignored if you attempt to connect it to anything."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "notes": "Firefox currently handles the value <code>null</code> incorrectly. Instead of producing a node that generates a single channel of silence, the node becomes unusable and will be ignored if you attempt to connect it to anything."
             },
             "ie": {
@@ -215,7 +215,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -407,7 +407,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -455,7 +455,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -31,7 +31,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -131,7 +131,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -417,7 +417,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -465,7 +465,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -513,7 +513,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -64,7 +64,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -68,7 +68,7 @@
               "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "version_removed": "63"
             },
             "ie": {
@@ -421,7 +421,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -469,7 +469,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -521,7 +521,7 @@
               "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "version_removed": "63"
             },
             "ie": {

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -64,7 +64,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -160,7 +160,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -208,7 +208,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -256,7 +256,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -304,7 +304,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -448,7 +448,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -496,7 +496,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -160,7 +160,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -208,7 +208,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -260,7 +260,7 @@
               "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "partial_implementation": true,
               "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
@@ -314,7 +314,7 @@
               "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "partial_implementation": true,
               "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
@@ -460,7 +460,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -508,7 +508,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -556,7 +556,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -605,7 +605,7 @@
               "notes": "Prior to Firefox 69, <code>value</code> did not take into account scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "notes": "Firefox for Android does not currently take into account scheduled or gradiated changes to the parameter's value; only the initial value or the most recent explicitly set value is returned."
             },
             "ie": {

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -122,7 +122,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -172,7 +172,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -222,7 +222,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -272,7 +272,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -322,7 +322,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -372,7 +372,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -470,7 +470,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -520,7 +520,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -570,7 +570,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -620,7 +620,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -720,7 +720,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -770,7 +770,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -832,7 +832,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -942,7 +942,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -1042,7 +1042,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -1092,7 +1092,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -1142,7 +1142,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -1242,7 +1242,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false
@@ -1390,7 +1390,7 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
             },
             "ie": {
               "version_added": false

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -119,7 +119,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -359,7 +359,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -19,7 +19,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -161,7 +161,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -313,7 +313,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -361,7 +361,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -166,7 +166,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -358,7 +358,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -261,7 +261,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -310,7 +310,7 @@
               "notes": "Before Firefox 30, the <code>when</code> parameter was not optional."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "notes": "Before Firefox 30, the <code>when</code> parameter was not optional."
             },
             "ie": {
@@ -360,7 +360,7 @@
               "notes": "Before Firefox 30, the <code>when</code> parameter was not optional."
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "notes": "Before Firefox 30, the <code>when</code> parameter was not optional."
             },
             "ie": {
@@ -409,7 +409,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -261,7 +261,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -309,7 +309,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -501,7 +501,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -693,7 +693,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -741,7 +741,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -789,7 +789,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -837,7 +837,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -889,7 +889,7 @@
               "version_removed": "63"
             },
             "firefox_android": {
-              "version_added": "26",
+              "version_added": "25",
               "version_removed": "63"
             },
             "ie": {

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -17,7 +17,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The existing data is inconsistent, with AudioScheduledSourceNode and
already ScriptProcessorNode marked as shipping in Firefox Android 25.

What actually happened is hard to tell from release notes and bug:
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/25
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/26
https://bugzilla.mozilla.org/show_bug.cgi?id=885505

This is made consistent because when updating existing data and notes in
BaseAudioContext, one has to assume one or the other. The difference
between 25 and 26 no longer matters, so just say 25.