### PR TITLE
Add separate entries from BaseAudioContext before it existed

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -4,12 +4,28 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext",
         "support": {
-          "chrome": {
-            "version_added": true
-          },
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "56",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "56",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
           "edge": [
             {
               "version_added": "79"
@@ -18,36 +34,88 @@
               "version_added": "12",
               "version_removed": "79",
               "partial_implementation": true,
-              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> interface."
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
             }
           ],
-          "firefox": {
-            "version_added": "53"
-          },
-          "firefox_android": {
-            "version_added": "53"
-          },
+          "firefox": [
+            {
+              "version_added": "53"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "53",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "53"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "53",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "15"
-          },
-          "opera_android": {
-            "version_added": "14"
-          },
+          "opera": [
+            {
+              "version_added": "43"
+            },
+            {
+              "version_added": "15",
+              "version_removed": "43",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "43"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "43",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "6.0"
+            },
+            {
+              "version_added": "1.0",
+              "version_removed": "6.0",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "≤37",
+              "version_removed": "56",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -117,12 +185,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -167,12 +233,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -217,12 +281,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -267,12 +329,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -317,12 +377,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -367,12 +425,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -417,10 +473,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "ie": {
               "version_added": false
@@ -465,12 +521,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -515,12 +569,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -565,12 +617,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -615,12 +665,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -665,12 +713,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 50."
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 50."
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -715,12 +761,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -765,12 +809,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -827,12 +869,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -937,12 +977,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -987,12 +1025,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 37."
+              "version_added": "37"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 37."
+              "version_added": "37"
             },
             "ie": {
               "version_added": false
@@ -1037,12 +1073,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1087,12 +1121,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1137,12 +1169,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1186,12 +1216,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "53",
-                "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 36."
+                "version_added": "36"
               },
               "firefox_android": {
-                "version_added": "53",
-                "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 36."
+                "version_added": "36"
               },
               "ie": {
                 "version_added": false
@@ -1237,12 +1265,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1287,10 +1313,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1335,12 +1361,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 40."
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 40."
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -1385,12 +1409,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 25."
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -1435,12 +1457,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 40."
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "53",
-              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 40."
+              "version_added": "40"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Chrome 56 came from mdn-bcd-collector:
https://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext

A lot of the Firefox subfeatures needed updating, and almost all of it
was confirmed by mdn-bcd-collector results. The "promise_syntax" is the
notable exception, where the version in the notes was trusted.