### PR TITLE
Use relative paths in markdown files

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,7 +10,7 @@ _Everyone_ who is involved in any form with the project must abide by the projec
 
 ### Users
 
-Users are community members who have a need for the project. They are typically consumers of the compat data (see [data consumers](https://github.com/mdn/browser-compat-data#projects-using-the-data)). Anyone can be a User; there are no special requirements and the data is licensed under [CC0](LICENSE). Common User contributions include evangelizing the project (e.g., display a link on a website and raise awareness through word-of-mouth), informing developers of strengths and weaknesses from a new user perspective, or providing moral support (a “thank you” goes a long way).
+Users are community members who have a need for the project. They are typically consumers of the compat data (see [data consumers](README.md#projects-using-the-data)). Anyone can be a User; there are no special requirements and the data is licensed under [CC0](LICENSE). Common User contributions include evangelizing the project (e.g., display a link on a website and raise awareness through word-of-mouth), informing developers of strengths and weaknesses from a new user perspective, or providing moral support (a “thank you” goes a long way).
 
 Users who continue to engage with the project and its community will often become more and more involved. Such Users may find themselves becoming [Contributors](#Contributors), as described in the next section.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,11 +6,11 @@
 
 ### Community members
 
-_Everyone_ who is involved in any form with the project must abide by the project’s [Contribution Guidelines](https://github.com/mdn/browser-compat-data/blob/master/CODE_OF_CONDUCT.md) and Commit Access Guidelines. Everyone is expected to be respectful of fellow community members and to work collaboratively respective of the Code of Conduct (CPG). Consequences for not adhering to these Guidelines are listed in their respective documents.
+_Everyone_ who is involved in any form with the project must abide by the project’s [Contribution Guidelines](CODE_OF_CONDUCT.md) and Commit Access Guidelines. Everyone is expected to be respectful of fellow community members and to work collaboratively respective of the Code of Conduct (CPG). Consequences for not adhering to these Guidelines are listed in their respective documents.
 
 ### Users
 
-Users are community members who have a need for the project. They are typically consumers of the compat data (see [data consumers](https://github.com/mdn/browser-compat-data#projects-using-the-data)). Anyone can be a User; there are no special requirements and the data is licensed under [CC0](https://github.com/mdn/browser-compat-data/blob/master/LICENSE). Common User contributions include evangelizing the project (e.g., display a link on a website and raise awareness through word-of-mouth), informing developers of strengths and weaknesses from a new user perspective, or providing moral support (a “thank you” goes a long way).
+Users are community members who have a need for the project. They are typically consumers of the compat data (see [data consumers](https://github.com/mdn/browser-compat-data#projects-using-the-data)). Anyone can be a User; there are no special requirements and the data is licensed under [CC0](LICENSE). Common User contributions include evangelizing the project (e.g., display a link on a website and raise awareness through word-of-mouth), informing developers of strengths and weaknesses from a new user perspective, or providing moral support (a “thank you” goes a long way).
 
 Users who continue to engage with the project and its community will often become more and more involved. Such Users may find themselves becoming [Contributors](#Contributors), as described in the next section.
 
@@ -126,7 +126,7 @@ If an agenda item cannot reach a consensus, an owner can call for either a closi
 ## Licensing
 
 Please note that this project is made available using the
-[CC0 license](https://github.com/mdn/browser-compat-data/blob/master/LICENSE),
+[CC0 license](LICENSE),
 so anyone contributing should only submit data if they know they have the right to submit it under CC0. If you're not sure about that, just ask.
 
 ## Project Meetings

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This data can be used in documentation, to build compatibility tables listing
 browser support for APIs. For example:
 [Browser support for WebExtension APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs).
 
-Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
+Read how this project is [governed](GOVERNANCE.md).
 
 Chat on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org).
 
@@ -34,21 +34,21 @@ bcd.css.properties.background;
 
 The `@mdn/browser-compat-data` package contains a tree of objects, with support and browser data objects at their leaves. There are over 12,000 features in the dataset; this documentation highlights significant portions, but many others exist at various levels of the tree.
 
-The definitive description of the format used to represent individual features and browsers is the [schema definitions](https://github.com/mdn/browser-compat-data/blob/master/schemas/).
+The definitive description of the format used to represent individual features and browsers is the [schema definitions](schemas/).
 
 Apart from the explicitly documented objects below, feature-level support data may change at any time. See [_Semantic versioning policy_](#Semantic-versioning-policy) for details.
 
 The package contains the following top-level objects:
 
-### [`api`](https://github.com/mdn/browser-compat-data/tree/master/api)
+### [`api`](api)
 
 Data for [Web API](https://developer.mozilla.org/en-US/docs/Web/API) features.
 
-### [`browsers`](https://github.com/mdn/browser-compat-data/tree/master/browsers)
+### [`browsers`](browsers)
 
-Data for browser and engine releases. See the [browser schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers-schema.md) for details.
+Data for browser and engine releases. See the [browser schema](schemas/browsers-schema.md) for details.
 
-### [`css`](https://github.com/mdn/browser-compat-data/tree/master/css)
+### [`css`](css)
 
 Data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) features, including:
 
@@ -57,7 +57,7 @@ Data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) features, inclu
 - `selectors` - selectors (such as basic selectors, combinators, or pseudo elements)
 - `types` - types for rule values
 
-### [`html`](https://github.com/mdn/browser-compat-data/tree/master/html)
+### [`html`](html)
 
 Data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) features, including:
 
@@ -65,7 +65,7 @@ Data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) features, inc
 - `global_attributes` - Global attributes
 - `manifest` - Web App manifest keys
 
-### [`http`](https://github.com/mdn/browser-compat-data/tree/master/http)
+### [`http`](http)
 
 Data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) features, including:
 
@@ -73,7 +73,7 @@ Data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) features, inc
 - `methods` - Request methods
 - `status` - Status codes
 
-### [`javascript`](https://github.com/mdn/browser-compat-data/tree/master/javascript)
+### [`javascript`](javascript)
 
 Data for JavaScript language features, including:
 
@@ -84,35 +84,35 @@ Data for JavaScript language features, including:
 - `operators` - Mathematical and logical operators
 - `statements` - Language statements and expressions
 
-### [`mathml`](https://github.com/mdn/browser-compat-data/tree/master/mathml)
+### [`mathml`](mathml)
 
 Data for [MathML](https://developer.mozilla.org/en-US/docs/Web/MathML) features, including:
 
 - `elements` - Elements
 
-### [`svg`](https://github.com/mdn/browser-compat-data/tree/master/svg)
+### [`svg`](svg)
 
 Data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) features, including:
 
 - `attributes` - Attributes
 - `elements` - Elements
 
-### [`webdriver`](https://github.com/mdn/browser-compat-data/tree/master/webdriver)
+### [`webdriver`](webdriver)
 
 Data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) features.
 
-### [`webextensions`](https://github.com/mdn/browser-compat-data/tree/master/webextensions)
+### [`webextensions`](webextensions)
 
 Data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) features, including:
 
 - `api` - WebExtension-specific APIs
 - `manifest` - `manifest.json` keys
 
-### [`xpath`](https://github.com/mdn/browser-compat-data/tree/master/xpath)
+### [`xpath`](xpath)
 
 Data for [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) features.
 
-### [`xslt`](https://github.com/mdn/browser-compat-data/tree/master/xslt)
+### [`xslt`](xslt)
 
 Data for [XSLT](https://developer.mozilla.org/en-US/docs/Web/XSLT) features.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -129,7 +129,7 @@ March 4, 2021
   - `mathml.elements.mtd.groupalign`
   - `mathml.elements.mtr.groupalign`
 
-- The following constants have been removed, under the recently-adopted [_Constants_ guideline](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#constants) ([#9195](https://github.com/mdn/browser-compat-data/pull/9195)):
+- The following constants have been removed, under the recently-adopted [_Constants_ guideline](docs/data-guidelines.md#constants) ([#9195](https://github.com/mdn/browser-compat-data/pull/9195)):
 
   - `api.KeyboardEvent.DOM_KEY_LOCATION_LEFT`
   - `api.KeyboardEvent.DOM_KEY_LOCATION_NUMPAD`
@@ -209,7 +209,7 @@ February 11, 2021
 
 **Notable changes**
 
-- We've adopted [a new data guideline for interface mixins](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#mixins). From v3.1.0, new data for [interface mixins](https://heycam.github.io/webidl/#idl-interface-mixins) will be represented as subfeatures of their exposed interfaces, instead of fictitious mixin interfaces.
+- We've adopted [a new data guideline for interface mixins](docs/data-guidelines.md#mixins). From v3.1.0, new data for [interface mixins](https://heycam.github.io/webidl/#idl-interface-mixins) will be represented as subfeatures of their exposed interfaces, instead of fictitious mixin interfaces.
 
   For example, `HTMLHyperlinkElementUtils` attributes are now represented on `HTMLAnchorElement` and `HTMLAreaElement` directly.
 
@@ -251,7 +251,7 @@ February 4, 2021
 
 **Notable changes**
 
-- `api.WEBGL_color_buffer_float.RGB32F_EXT`, a constant, was removed following the [_Constants_ data guideline](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#constants) ([#8934](https://github.com/mdn/browser-compat-data/pull/8934))
+- `api.WEBGL_color_buffer_float.RGB32F_EXT`, a constant, was removed following the [_Constants_ data guideline](docs/data-guidelines.md#constants) ([#8934](https://github.com/mdn/browser-compat-data/pull/8934))
 
 **Statistics**
 
@@ -359,7 +359,7 @@ Review the changes below for details.
 - Node.js versions `0.10` and `0.12` were replaced by their full SemVer values, `0.10.0` and `0.12.0`, respectively. ([#7491](https://github.com/mdn/browser-compat-data/issues/7491), [#7492](https://github.com/mdn/browser-compat-data/issues/7492))
 - Many high-level namespaces in the package were [documented](https://github.com/mdn/browser-compat-data#package-contents) and [a formal Semantic Versioning policy was introduced](https://github.com/mdn/browser-compat-data#semantic-versioning-policy). ([#7615](https://github.com/mdn/browser-compat-data/issues/7615))
 - Data in `javascript` requires version number data; the `javascript` data no longer contains any `null` or `true` values. ([#7607](https://github.com/mdn/browser-compat-data/issues/7607))
-- [_Addition of browsers_](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#addition-of-browsers) and [_Removal of browsers_](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-browsers) data guidelines were adopted to document requirements to add or remove a browser or engine from package. ([#7244](https://github.com/mdn/browser-compat-data/issues/7244))
+- [_Addition of browsers_](docs/data-guidelines.md#addition-of-browsers) and [_Removal of browsers_](docs/data-guidelines.md#removal-of-browsers) data guidelines were adopted to document requirements to add or remove a browser or engine from package. ([#7244](https://github.com/mdn/browser-compat-data/issues/7244))
 - The following features were removed as irrelevant:
   - `api.HTMLAnchorElement.media` ([#7538](https://github.com/mdn/browser-compat-data/issues/7538))
   - `api.HTMLAreaElement.hreflang` ([#7539](https://github.com/mdn/browser-compat-data/issues/7539))
@@ -413,7 +413,7 @@ November 19, 2020
 **Notable changes**
 
 - Internet Explorer version `"≤6"` is now an accepted value, to reflect testing limitations for older versions ([#7337](https://github.com/mdn/browser-compat-data/issues/7337))
-- The following features were [removed as irrelevant](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features):
+- The following features were [removed as irrelevant](docs/data-guidelines.md#removal-of-irrelevant-features):
   - `api.MediaQueryListListener` ([#7210](https://github.com/mdn/browser-compat-data/issues/7210))
   - `api.IDBVersionChangeRequest.setVersion` ([#6934](https://github.com/mdn/browser-compat-data/issues/6934))
   - `api.IDBVersionChangeRequest` ([#7411](https://github.com/mdn/browser-compat-data/issues/7411))
@@ -924,7 +924,7 @@ May 28, 2020
 
 **Notable changes**
 
-- The following [irrelevant features](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features) have been removed:
+- The following [irrelevant features](docs/data-guidelines.md#removal-of-irrelevant-features) have been removed:
   - `javascript.builtins.String.quote` ([#6207](https://github.com/mdn/browser-compat-data/issues/6207))
   - `javascript.builtins.String.replace.flags` ([#6206](https://github.com/mdn/browser-compat-data/issues/6206))
   - `api.LocalFileSystem` and `api.LocalFileSystemSync` ([#6163](https://github.com/mdn/browser-compat-data/issues/6163))
@@ -942,12 +942,12 @@ May 21, 2020
 
 **Notable changes**
 
-- The following [irrelevant features](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#removal-of-irrelevant-features) have been removed:
+- The following [irrelevant features](docs/data-guidelines.md#removal-of-irrelevant-features) have been removed:
   - `javascript.builtins.Date.toLocaleFormat` ([#6183](https://github.com/mdn/browser-compat-data/issues/6183))
   - `javascript.builtins.String.match.flags` ([#6184](https://github.com/mdn/browser-compat-data/issues/6184))
   - `javascript.statements.try_catch.conditional_clauses` ([#6192](https://github.com/mdn/browser-compat-data/issues/6192))
 - `javascript.statements.default.exports` has moved to `javascript.statements.exports.default` (see [#5869](https://github.com/mdn/browser-compat-data/issues/5869)).
-- A new guideline for how [Permissions API permissions data](https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#permissions-api-permissions-permissionname_permission) is stored has been accepted and the descriptions have been fixed, see https://github.com/mdn/browser-compat-data/pull/6156.
+- A new guideline for how [Permissions API permissions data](docs/data-guidelines.md#permissions-api-permissions-permissionname_permission) is stored has been accepted and the descriptions have been fixed, see https://github.com/mdn/browser-compat-data/pull/6156.
 
 **Statistics**
 
@@ -1688,7 +1688,7 @@ March 28, 2019
 
 **Notable changes**
 
-- [`matches` objects](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#the-matches-object) have been added to the schema.(https://github.com/mdn/browser-compat-data/pull/3631)
+- [`matches` objects](schemas/compat-data-schema.md#the-matches-object) have been added to the schema.(https://github.com/mdn/browser-compat-data/pull/3631)
 
 **Statistics**
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ The repository is made available under the terms the [Creative Commons CC0 Publi
 
 There are many ways you can help improve this repository! For example:
 
-- **Add new compat data**: familiarize yourself with the [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json) and read the [schema docs](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) and [data guidelines](data-guidelines.md) to add new files.
+- **Add new compat data**: familiarize yourself with the [schema](../schemas/compat-data.schema.json) and read the [schema docs](../schemas/compat-data-schema.md) and [data guidelines](data-guidelines.md) to add new files.
 - **Fix existing compat data**: maybe a browser now supports a certain feature. Yay! If you open a PR to fix a browser's data, it would be most helpful if you include a link to a bug report or similar so that we can double-check the good news.
 - **Fix a bug:** we have a list of [issues](https://github.com/mdn/browser-compat-data/issues),
   or maybe you found your own.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -205,7 +205,7 @@ This versioning scheme came at [Apple's request, in #2006](https://github.com/md
 
 ## Addition of browsers
 
-BCD's [owners](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md) may choose to adopt a new browser or engine. To add a new browser to BCD, we need evidence of (in decreasing order of importance):
+BCD's [owners](../GOVERNANCE.md) may choose to adopt a new browser or engine. To add a new browser to BCD, we need evidence of (in decreasing order of importance):
 
 - a compelling downstream-consumer story (e.g., MDN or caniuse express an interest, or someone is planning to do something with the data that might plausibly grow BCD's reach)
 - reviewers (e.g., two or more people with interest and ability to test data relating to new and existing releases, or at least one reviewer acting on behalf of the vendor)
@@ -216,7 +216,7 @@ This decision was proposed in [#7238](https://github.com/mdn/browser-compat-data
 
 ## Removal of browsers
 
-To maintain data quality, BCD's [owners](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md) may choose to remove a browser or engine from the project. To remove a browser from BCD, we need habitual (six months or more) evidence of (in decreasing order of importance):
+To maintain data quality, BCD's [owners](../GOVERNANCE.md) may choose to remove a browser or engine from the project. To remove a browser from BCD, we need habitual (six months or more) evidence of (in decreasing order of importance):
 
 - negative/neutral downstream-consumer interest in the browser's data (e.g., MDN and caniuse don't object to removal)
 - poor data coverage with negative trends (e.g., our data for the browser covers only a few features, with limited/flat growth in more data being added for it, or few features with real version numbers rather than just `null` or `true`, etc.)
@@ -250,7 +250,7 @@ This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-dat
 
 ## Initial versions for browsers
 
-The schema docs list [initial versions](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#initial-versions) for BCD browsers. These are the earliest possible version numbers allowed to be used.
+The schema docs list [initial versions](../schemas/compat-data-schema.md#initial-versions) for BCD browsers. These are the earliest possible version numbers allowed to be used.
 
 If the table indicates an initial version of "1" and an information source says a feature was implemented in a (beta) version "0.8", record the initial version number "1" for it. In other words, a lower version number is always elevated to a browser's initial version number.
 
@@ -268,7 +268,7 @@ Members of this mixin are available to `HTMLAnchorElement` and `HTMLAreaElement`
 
 1. For smaller mixins, add members of `HTMLHyperlinkElementUtils` directly to the `api/HTMLAnchorElement.json` and `api/HTMLAreaElement.json` files as if they were regular members of these interfaces.
 
-2. For larger mixins, create a file in the `api/_mixins/` folder and indicate for which interface they are using file names like: `HTMLHyperlinkElementUtils__HTMLAnchorElement.json` and `HTMLHyperlinkElementUtils__HTMLAreaElement.json`.  
+2. For larger mixins, create a file in the `api/_mixins/` folder and indicate for which interface they are using file names like: `HTMLHyperlinkElementUtils__HTMLAnchorElement.json` and `HTMLHyperlinkElementUtils__HTMLAreaElement.json`.
    In these files, expose the data under the correct tree. For `HTMLHyperlinkElementUtils__HTMLAnchorElement.json`, the file needs to start like this:
 
    ```

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -14,11 +14,11 @@ A good migration starts with a clear description of the changes to be made, with
 
 Next, create a migration script and tests for that script.
 
-Put migration scripts in the [`/scripts/migrations/`](https://github.com/mdn/browser-compat-data/tree/master/scripts/migrations) directory. Name the scripts in the pattern `###-<description>.js` where `###` is the sequential number of the migration and `<description>` is a short name for the migration. For example, the first migration was `001-sort-features.js`.
+Put migration scripts in the [`/scripts/migrations/`](../scripts/migrations) directory. Name the scripts in the pattern `###-<description>.js` where `###` is the sequential number of the migration and `<description>` is a short name for the migration. For example, the first migration was `001-sort-features.js`.
 
 The script must be accompanied by one or more tests that demonstrate that the migration makes the changes described and doesn’t introduce other, unrelated changes. Typically, tests in the `/scripts/migrations/` directory are named in the form `###-<description>.test.js`.
 
-When the script and tests are ready, open a pull request. To be accepted, the PR must be reviewed and approved by at least one [project owner](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md#owners).
+When the script and tests are ready, open a pull request. To be accepted, the PR must be reviewed and approved by at least one [project owner](../GOVERNANCE.md#owners).
 
 ## Step 3: Migrate
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,11 +2,11 @@
 
 ## Code style
 
-The JSON files should be formatted according to the [.editorconfig](https://github.com/mdn/browser-compat-data/blob/master/.editorconfig) file.
+The JSON files should be formatted according to the [.editorconfig](../.editorconfig) file.
 
 ## Validating the data
 
-All data in the repo must conform to the schema. The formal feature data schema is defined in [`compat-data.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json); see [`compat-data-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) for more info. The browser data schema is defined in [`browsers.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers.schema.json); see [`browsers-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers-schema.md) for more info.
+All data in the repo must conform to the schema. The formal feature data schema is defined in [`compat-data.schema.json`](../schemas/compat-data.schema.json); see [`compat-data-schema.md`](../schemas/compat-data-schema.md) for more info. The browser data schema is defined in [`browsers.schema.json`](../schemas/browsers.schema.json); see [`browsers-schema.md`](../schemas/browsers-schema.md) for more info.
 
 You can use `npm test` to validate data against the schema. You might need to install the `devDependencies` using `npm install`.
 The JSON data is validated against the schema using [`ajv`](http://epoberezkin.github.io/ajv/).
@@ -19,7 +19,7 @@ To see how changes will affect the statistics of real (either `false` or a versi
 
 To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`.
 
-The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).
+The browser may be any single browser defined in the [`browsers/` folder](../browsers/).
 
 The folder may be omitted or set to `all` to search through all data folders, or a comma-separated list of folders to search through.
 

--- a/docs/using-confluence.md
+++ b/docs/using-confluence.md
@@ -57,7 +57,7 @@ Although it is a useful and, to date, the most automated source of web platform 
 
 ## Only Web Platform APIs are available
 
-Web Platform APIs generally refer to features you would use in JavaScript that are not JavaScript itself. You can only use Confluence to verify data in the repo's [api/](https://github.com/mdn/browser-compat-data/tree/master/api) directory.
+Web Platform APIs generally refer to features you would use in JavaScript that are not JavaScript itself. You can only use Confluence to verify data in the repo's [api/](../api) directory.
 
 ## Only prototype-exposed interfaces are available
 

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -1,10 +1,10 @@
 # The browser JSON schema
 
-This document helps you to understand the structure of the [browser JSON](https://github.com/mdn/browser-compat-data/tree/master/browsers) files.
+This document helps you to understand the structure of the [browser JSON](../browsers) files.
 
 #### Browser identifiers
 
-The currently accepted browser identifiers are [defined in the compat-data schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#browser-identifiers). They are re-used for the browser data scheme. No other identifiers are allowed and the file names should also use the browser identifiers.
+The currently accepted browser identifiers are [defined in the compat-data schema](compat-data-schema.md#browser-identifiers). They are re-used for the browser data scheme. No other identifiers are allowed and the file names should also use the browser identifiers.
 
 For example, for the browser identifier `firefox`, the file name is `firefox.json`.
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -10,27 +10,27 @@ Compatibility data is organized in top-level directories for each broad area cov
 `javascript`, and `webextensions`. Inside each of these directories is one or more
 JSON files containing the compatibility data.
 
-- [api/](https://github.com/mdn/browser-compat-data/tree/master/api) contains data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API) interface.
+- [api/](../api) contains data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API) interface.
 
-- [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors, and at-rules.
+- [css/](../css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors, and at-rules.
 
-- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes, and global attributes.
+- [html/](../html) contains data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes, and global attributes.
 
-- [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses, and methods.
+- [http/](../http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses, and methods.
 
-- [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.
+- [javascript/](../javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.
 
-- [mathml/](https://github.com/mdn/browser-compat-data/tree/master/mathml) contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML) elements, attributes, and global attributes.
+- [mathml/](../mathml) contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML) elements, attributes, and global attributes.
 
-- [svg/](https://github.com/mdn/browser-compat-data/tree/master/svg) contains data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements, attributes, and global attributes.
+- [svg/](../svg) contains data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements, attributes, and global attributes.
 
-- [webdriver/](https://github.com/mdn/browser-compat-data/tree/master/webdriver) contains data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
+- [webdriver/](../webdriver) contains data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
 
-- [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
+- [webextensions/](../webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
 
-- [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
+- [xpath/](../xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
 
-- [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.
+- [xslt/](../xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.
 
 ### File and folder breakdown
 


### PR DESCRIPTION
Removes one blocker in #6292.

This also makes it much easier to navigate within IDEs.