### PR TITLE
Update the note of `Element: paste event` and `DragEvent`

### DIFF
--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -20,7 +20,8 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "10"
+            "version_added": "9",
+            "notes": "Before Internet Explorer 10, <code>DragEvent</code> is exposed in standards mode but not quirks mode."
           },
           "opera": {
             "version_added": "12"
@@ -68,7 +69,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "12"
@@ -116,7 +117,9 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "The value is always <code>null</code>."
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -6207,7 +6207,8 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "8",
+              "notes": "Before Internet Explorer 11, copying files does not trigger the <code>paste</code> event."
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
There are two things I have tested and confirmed:

1. You can also listen to the `paste` event by running the following sinppet under IE8, but it won't trigger when pasting files like screenshot of other applications below IE10:

    ```html
    <body id="test" contenteditable>area</body>
    <script type="text/javascript">
    window.onload = function () {
        document.getElementById('test').attachEvent('onpaste', function (e) {
            console.log(e.type); // => print out "paste" when pasting text
        });
    };
    </script>
    ```

2. IE9 standard mode has implemented `DragEvent` but not in quirks mode.
3. `DragEvent` is an `Object` under IE9/10/11 and it is not a constructor at all:

    ```js
    ({}).toString.call(DragEvent); // => [object DragEvent] under IE9/10/11, [object Function] under Chrome
    ```

4. `DragEvent` under IE9/10/11 has no `dataTransfer`:

    ```html
    <body id="test" contenteditable>area</body>
    <script type="text/javascript">
    window.onload = function () {
        document.getElementById('test').addEventListener('paste', function (e) {
            console.log(e.dataTransfer); // => null under IE9/10/11
        });
    };
    </script>
    ```