### PR TITLE
api.EventTarget.addEventListener.options - add signal option

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -533,19 +533,19 @@
               "description": "<code>signal</code> option",
               "support": {
                 "chrome": {
-                  "version_added": "89"
+                  "version_added": "90"
                 },
                 "chrome_android": {
-                  "version_added": "89"
+                  "version_added": "90"
                 },
                 "edge": {
-                  "version_added": "89"
+                  "version_added": "90"
                 },
                 "firefox": {
                   "version_added": "86"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "86"
                 },
                 "ie": {
                   "version_added": false
@@ -554,7 +554,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "74"
+                  "version_added": "76"
                 },
                 "opera_android": {
                   "version_added": false
@@ -569,7 +569,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": "89"
+                  "version_added": "90"
                 }
               },
               "status": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -527,6 +527,57 @@
                 "deprecated": false
               }
             }
+          },
+          "signal": {
+            "__compat": {
+              "description": "<code>signal</code> option",
+              "support": {
+                "chrome": {
+                  "version_added": "89"
+                },
+                "chrome_android": {
+                  "version_added": "89"
+                },
+                "edge": {
+                  "version_added": "89"
+                },
+                "firefox": {
+                  "version_added": "86"
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "74"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "89"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Fixes #9555
@ddbeck Comments inline. 

Further, I just called this subfeature `signal`. There is a bit of a mess of naming, and I guess that will impact ordering. I was wondering if perhaps we should rename according to a patter. So perhaps option_signal, option_passive, option_once. Then the passive option exceptiosn could be option_passive_default_etc. I will leave unchanged unless you decide renaming is sensible.