### PR TITLE
Set Attr and related APIs as supported since Safari 1

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -82,7 +82,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -185,7 +185,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -288,7 +288,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/Element.json
+++ b/api/Element.json
@@ -29,7 +29,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "1.3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -1297,7 +1297,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1821,7 +1821,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -3818,7 +3818,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -3914,7 +3914,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -3962,7 +3962,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -4012,7 +4012,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -4219,7 +4219,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3",
+              "version_added": "1",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari_ios": {
@@ -4329,7 +4329,7 @@
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari": {
-              "version_added": "1.3",
+              "version_added": "1",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari_ios": {
@@ -4429,7 +4429,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -4477,7 +4477,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -4527,7 +4527,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -4663,7 +4663,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -6495,7 +6495,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -6543,7 +6543,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -6591,7 +6591,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7290,7 +7290,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7526,7 +7526,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7720,7 +7720,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7817,7 +7817,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7915,7 +7915,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -7963,7 +7963,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -8013,7 +8013,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -8061,7 +8061,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -8458,7 +8458,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
The difference between Safari 1 and 1.3 is of course not important, but
some assumption has to be made to fix localName/namespaceURI/prefix:
https://github.com/mdn/browser-compat-data/pull/9561

Based on current Web IDL, the set of related APIs are:
- Document.createAttribute
- Document.createAttributeNS
- Element.attributes (a NamedNodeMap)
- Element.getAttributeNode
- Element.getAttributeNodeNS
- Element.setAttributeNode
- Element.setAttributeNodeNS
- Element.removeAttributeNode
- NamedNodeMap and all of its members

All can be found in the bindings of the revision tagged Safari 85:
https://trac.webkit.org/browser/webkit/trunk/WebCore/khtml/ecma/kjs_dom.lut.h?rev=4552

The only complication is Attr.localName/namespaceURI/prefix, which was
then on Node, but judging by the implementation they probably worked:
https://trac.webkit.org/browser/webkit/trunk/WebCore/khtml/dom/dom_node.cpp?rev=4552

Because some Element.* entries were set to 1, api.Element itself was
also set to 1, and the following non-Attr-related features also
confirmed to be in kjs_dom.lut.h above:
- Element.getAttribute
- Element.getAttributeNS
- Element.getElementsByTagName
- Element.getElementsByTagNameNS
- Element.hasAttribute
- Element.hasAttributeNS
- Element.hasAttributes (on Node)
- Element.removeAttribute
- Element.removeAttributeNS
- Element.scrollLeft (on Node)
- Element.scrollTop (on Node)
- Element.scrollHeight (on Node)
- Element.scrollWidth (on Node)
- Element.setAttribute
- Element.setAttributeNS
- Element.tagName

Finally, Element.className and id were here:
https://trac.webkit.org/browser/webkit/trunk/WebCore/khtml/ecma/kjs_html.lut.h?rev=4552