### PR TITLE
Deprecate BluetoothRemoteGATTCharacteristic.writeValue

### DIFF
--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -1115,9 +1115,9 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
See https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
See https://github.com/WebBluetoothCG/web-bluetooth/issues/238

Related: https://github.com/mdn/content/issues/3382