### PR TITLE
Update Safari support info for unicode-bidi

### DIFF
--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -119,16 +119,20 @@
               "opera_android": {
                 "version_added": "35"
               },
-              "safari": {
+              "safari": [{
+                "version_added": "11"
+              }, {
                 "prefix": "-webkit-",
                 "version_added": "6",
                 "notes": "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47)."
-              },
-              "safari_ios": {
+              }],
+              "safari_ios": [{
+                "version_added": "11"
+              }, {
                 "prefix": "-webkit-",
                 "version_added": "6",
                 "notes": "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47)."
-              },
+              }],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
@@ -185,12 +189,18 @@
               "opera_android": {
                 "version_added": "35"
               },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari": [{
+                "version_added": "11"
+              }, {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }],
+              "safari_ios": [{
+                "version_added": "11"
+              }, {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
@@ -255,12 +265,18 @@
               "opera_android": {
                 "version_added": "35"
               },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari": [{
+                "version_added": "11"
+              }, {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }],
+              "safari_ios": [{
+                "version_added": "11"
+              }, {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },


### PR DESCRIPTION
This particular case is https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi. 

Notably, `isolate-override` and `plaintext` are listed as unsupported. https://bugs.webkit.org/show_bug.cgi?id=50949 and http://trac.webkit.org/changeset/89864 indicate that `plaintext` was implemented in 2011. https://bugs.webkit.org/show_bug.cgi?id=73164 and http://trac.webkit.org/changeset/109806 indicate that `isolate-override` was implemented in 2012.