### PR TITLE
Mark link[as] Chrome support partial, with note

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1074,15 +1074,18 @@
               "support": {
                 "chrome": {
                   "version_added": "50",
-                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
+                  "partial_implementation": true,
+                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt</code>"
                 },
                 "chrome_android": {
                   "version_added": "50",
-                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
+                  "partial_implementation": true,
+                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt</code>"
                 },
                 "edge": {
                   "version_added": "≤79",
-                  "notes": "<code>as=\"document\"</code> is unsupported. See <a href='https://crbug.com/593267'>bug 593267</a>."
+                  "partial_implementation": true,
+                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt"
                 },
                 "firefox": [
                   {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1075,17 +1075,17 @@
                 "chrome": {
                   "version_added": "50",
                   "partial_implementation": true,
-                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt</code>"
+                  "notes": "Doesn’t support <code>as=\"audio\"</code>, <code>as=\"audioworklet\"</code>, <code>as=\"document\"</code>, <code>as=\"embed\"</code>, <code>as=\"manifest\"</code>, <code>as=\"object\"</code>, <code>as=\"paintworklet\"</code>, <code>as=\"report\"</code>, <code>as=\"sharedworker\"</code>, <code>as=\"video\"</code>, <code>as=\"worker\"</code>, or <code>as=\"xslt\"</code>."
                 },
                 "chrome_android": {
                   "version_added": "50",
                   "partial_implementation": true,
-                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt</code>"
+                  "notes": "Doesn’t support <code>as=\"audio\"</code>, <code>as=\"audioworklet\"</code>, <code>as=\"document\"</code>, <code>as=\"embed\"</code>, <code>as=\"manifest\"</code>, <code>as=\"object\"</code>, <code>as=\"paintworklet\"</code>, <code>as=\"report\"</code>, <code>as=\"sharedworker\"</code>, <code>as=\"video\"</code>, <code>as=\"worker\"</code>, or <code>as=\"xslt\"</code>."
                 },
                 "edge": {
                   "version_added": "≤79",
                   "partial_implementation": true,
-                  "notes": "Doesn’t support <code>as=audio</code>, <code>as=video</code>, <code>as=document</code>, <code>as=embed, <code>as= object</code>, <code>as=manifest</code>, <code>as=worker</code>, <code>as=sharedworker</code>, <code>as=audioworklet</code>, <code>as=paintworklet</code>, <code>as=report</code>, or <code>as=xslt"
+                  "notes": "Doesn’t support <code>as=\"audio\"</code>, <code>as=\"audioworklet\"</code>, <code>as=\"document\"</code>, <code>as=\"embed\"</code>, <code>as=\"manifest\"</code>, <code>as=\"object\"</code>, <code>as=\"paintworklet\"</code>, <code>as=\"report\"</code>, <code>as=\"sharedworker\"</code>, <code>as=\"video\"</code>, <code>as=\"worker\"</code>, or <code>as=\"xslt\"</code>."
                 },
                 "firefox": [
                   {


### PR DESCRIPTION
https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/loader/preload_helper.cc;l=135 indicates Blink doesn’t  yet support `audio`, `video`, `document`, `embed`, `object`, `manifest`, `worker`, `sharedworker`, `audioworklet`, `paintworklet`, `report`, or `xslt` as values for the `as` attribute.

So this change marks support in Chrome with partial_implementation:true, and a note listing the above `as` values as not supported.

Fixes https://github.com/mdn/browser-compat-data/issues/9577

---

This PR as currently scoped on updates the Chrome data for this.

I think Gecko and WebKit both also don’t support a number of of `as` values, but I’m not sure it’s as easy to identify which values they don’t support as it is for Chrome.