### PR TITLE
Add XPath/XSLT spec URLs

### DIFF
--- a/xpath/axes/self.json
+++ b/xpath/axes/self.json
@@ -4,6 +4,7 @@
       "self": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/XPath/Axes/self",
+          "spec_url": "https://www.w3.org/TR/xpath-31/#axes",
           "support": {
             "chrome": {
               "version_added": true

--- a/xslt/elements/stylesheet.json
+++ b/xslt/elements/stylesheet.json
@@ -4,6 +4,7 @@
       "stylesheet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/XSLT/Element/stylesheet",
+          "spec_url": "https://www.w3.org/TR/xslt-30/#stylesheet-element",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
Given that for XSLT and XPath, we have only two BCD features that are documented in MDN, maybe we need to question the value of having these in BCD at all; maybe we should just `git rm -r` the `xpath` and `xslt` directories from the repo?