### PR TITLE
updating fx release version to 87

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -623,27 +623,28 @@
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-04-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "88"
         },
         "89": {
           "release_date": "2021-05-18",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/89",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "89"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -490,27 +490,28 @@
         "86": {
           "release_date": "2021-02-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/86",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-04-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "88"
         },
         "89": {
           "release_date": "2021-05-18",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/89",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "89"
         },


### PR DESCRIPTION
Fx 87 was released on March 23 (see [release calendar](https://wiki.mozilla.org/Release_Management/Calendar#Future_branch_dates)). This PR updates the Fx and FxA browser files to account for this.


A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
