### PR TITLE
Make Android data for BaseAudioContext more consistent

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -179,7 +179,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -206,10 +206,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -227,7 +227,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -254,10 +254,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -275,7 +275,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -302,10 +302,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -323,7 +323,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -350,10 +350,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -371,7 +371,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -398,10 +398,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -419,7 +419,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -446,10 +446,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -515,7 +515,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -542,10 +542,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -563,7 +563,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -590,10 +590,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -611,7 +611,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -638,10 +638,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -659,7 +659,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -686,10 +686,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -755,7 +755,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -782,10 +782,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -803,7 +803,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -830,10 +830,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -862,7 +862,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "33"
+                "version_added": "18"
               }
             ],
             "edge": {
@@ -895,7 +895,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "2.0"
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -904,7 +904,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "4.4.3"
+                "version_added": "≤37"
               }
             ]
           },
@@ -971,7 +971,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -998,10 +998,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1067,7 +1067,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1094,10 +1094,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1115,7 +1115,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1142,10 +1142,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1163,7 +1163,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1190,10 +1190,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1259,7 +1259,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1286,10 +1286,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1307,7 +1307,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1334,10 +1334,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1403,7 +1403,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1430,10 +1430,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
The origin of "33" appears to be when Web Audio was unprefixed:
https://github.com/mdn/browser-compat-data/pull/1890

(It was actually unprefixed in Chromium 35.)

The data references at the time does not inspire confidence:
https://web.archive.org/web/20180421031716/https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext#Browser_compatibility
https://web.archive.org/web/20180309013210/https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createPeriodicWave#Browser_compatibility

Instead set support to "18" like most of the Web Audio API and mirror
that to Samsung Internet which appears to have been mirrored from this.
WebView Android is similar, but set it to ≤37 like most of the Web Audio
API. It might have been supported earlier, but it's hard to test for.

The important part of this is the data previously said a lot of this was
shipped in Chrome for Android 33, but that's inconsistent with all the
other Web Audio API data, which says 18.