### PR TITLE
Reconcile "Trailing comma" features

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -1020,7 +1020,7 @@
                 "version_added": "7.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "58"
               }
             },
             "status": {

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -981,7 +981,7 @@
         },
         "trailing_commas_in_functions": {
           "__compat": {
-            "description": "Trailing comma in functions",
+            "description": "Trailing comma in function parameters",
             "support": {
               "chrome": {
                 "version_added": "58"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -64,7 +64,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"
@@ -85,10 +85,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This PR resolves some inconsistencies in the data between different features reports of support for trailing commas in function definition parameters. It fixes the data for WebView, Safari, and Edge. I made sure the data made sense by testing in each of the main browsers (Chrome desktop, Safari on macOS, and Edge).

This depends on #9592. It fixes #9417.