### PR TITLE
Adjusting SAB support for Chrome on Android

### DIFF
--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -19,9 +19,9 @@
             "chrome_android": [
               {
                 "version_added": "89",
-                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
               },
-              { 
+              {
                 "version_added": "60",
                 "version_removed": "63",
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
@@ -154,7 +154,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
                 { 
                   "version_added": "60",
@@ -289,7 +289,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
                 { 
                   "version_added": "60",
@@ -424,7 +424,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
                 { 
                   "version_added": "60",

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -19,7 +19,7 @@
             "chrome_android": [
               {
                 "version_added": "89",
-                "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
+                "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
               },
               {
                 "version_added": "60",
@@ -154,7 +154,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",
@@ -289,7 +289,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",
@@ -424,7 +424,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -16,10 +16,17 @@
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
               }
             ],
-            "chrome_android": {
-              "version_added": "89",
-              "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
-            },
+            "chrome_android": [
+              {
+                "version_added": "89",
+                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+              },
+              { 
+                "version_added": "60",
+                "version_removed": "63",
+                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+              }
+            ],
             "edge": [
               {
                 "version_added": "79"
@@ -144,10 +151,17 @@
                   "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
                 }
               ],
-              "chrome_android": {
-                "version_added": "89",
-                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "89",
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                },
+                { 
+                  "version_added": "60",
+                  "version_removed": "63",
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                }
+              ],
               "edge": [
                 {
                   "version_added": "79"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -286,9 +286,17 @@
                   "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
                 }
               ],
-              "chrome_android": {
-                "version_added": "89"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "89",
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                },
+                { 
+                  "version_added": "60",
+                  "version_removed": "63",
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                }
+              ],
               "edge": [
                 {
                   "version_added": "79"
@@ -413,9 +421,17 @@
                   "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
                 }
               ],
-              "chrome_android": {
-                "version_added": "89"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "89",
+                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
+                },
+                { 
+                  "version_added": "60",
+                  "version_removed": "63",
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                }
+              ],
               "edge": [
                 {
                   "version_added": "79"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -24,7 +24,7 @@
               {
                 "version_added": "60",
                 "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
               }
             ],
             "edge": [
@@ -156,10 +156,10 @@
                   "version_added": "89",
                   "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
-                { 
+                {
                   "version_added": "60",
                   "version_removed": "63",
-                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
                 }
               ],
               "edge": [
@@ -291,10 +291,10 @@
                   "version_added": "89",
                   "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
-                { 
+                {
                   "version_added": "60",
                   "version_removed": "63",
-                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
                 }
               ],
               "edge": [
@@ -426,10 +426,10 @@
                   "version_added": "89",
                   "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
                 },
-                { 
+                {
                   "version_added": "60",
                   "version_removed": "63",
-                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place." 
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
                 }
               ],
               "edge": [

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -19,7 +19,7 @@
             "chrome_android": [
               {
                 "version_added": "89",
-                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
+                "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
               },
               {
                 "version_added": "60",
@@ -154,7 +154,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",
@@ -289,7 +289,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",
@@ -424,7 +424,7 @@
               "chrome_android": [
                 {
                   "version_added": "89",
-                  "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP. Additional details can be found at <a href='https://web.dev/coop-coep/'>web.dev</a>"
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website "cross-origin isolated" using COOP and COEP</a>."
                 },
                 {
                   "version_added": "60",

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -17,9 +17,8 @@
               }
             ],
             "chrome_android": {
-              "version_added": "60",
-              "version_removed": "63",
-              "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+              "version_added": "89",
+              "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
             },
             "edge": [
               {
@@ -146,9 +145,8 @@
                 }
               ],
               "chrome_android": {
-                "version_added": "60",
-                "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+                "version_added": "89",
+                "notes": "SharedArrayBuffer are available on Android gated behind COOP/COEP"
               },
               "edge": [
                 {
@@ -275,9 +273,7 @@
                 }
               ],
               "chrome_android": {
-                "version_added": "60",
-                "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+                "version_added": "89"
               },
               "edge": [
                 {
@@ -404,9 +400,7 @@
                 }
               ],
               "chrome_android": {
-                "version_added": "60",
-                "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+                "version_added": "89"
               },
               "edge": [
                 {


### PR DESCRIPTION
Adjusting the page to reflect the SAB support in Chrome on Android starting M89

