### PR TITLE
Update when webkitConvertPointFromNodeToPage/PageToNode were removed

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1325,7 +1325,7 @@
             },
             "chrome_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "39",
               "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "edge": {
@@ -1342,12 +1342,12 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "26",
               "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "26",
               "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "safari": {
@@ -1360,12 +1360,12 @@
             },
             "samsunginternet_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "4.0",
               "alternative_name": "webkitConvertPointFromNodeToPage"
             },
             "webview_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "39",
               "alternative_name": "webkitConvertPointFromNodeToPage"
             }
           },
@@ -1387,7 +1387,7 @@
             },
             "chrome_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "39",
               "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "edge": {
@@ -1404,12 +1404,12 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "26",
               "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "26",
               "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "safari": {
@@ -1422,12 +1422,12 @@
             },
             "samsunginternet_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "4.0",
               "alternative_name": "webkitConvertPointFromPageToNode"
             },
             "webview_android": {
               "version_added": true,
-              "version_removed": true,
+              "version_removed": "39",
               "alternative_name": "webkitConvertPointFromPageToNode"
             }
           },


### PR DESCRIPTION
Version determined using mdn-bcd-collector results for Chrome and
mirrored.

Intent to Deprecate and Remove on blink-dev:
https://groups.google.com/a/chromium.org/g/blink-dev/c/KS5GAM7JXtg/m/7KyhsqQFZMkJ