### PR TITLE
Update when initProgressEvent was removed

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -106,7 +106,7 @@
             },
             "chrome_android": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "18"
             },
             "edge": {
               "version_added": "12",
@@ -133,11 +133,11 @@
             },
             "safari": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "6"
             },
             "safari_ios": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "6"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
The removal was in WebKit trunk version 535.10:
https://trac.webkit.org/changeset/100727/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=100727

All versions were inferred from that. This is not a 100% reliable
method, but being off by one version doesn't matter here.