### PR TITLE
Mark BatteryManager as never shipped in Safari iOS

### DIFF
--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -70,8 +70,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": true,
-            "version_removed": true
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "3.0",
@@ -157,8 +156,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -245,8 +243,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -333,8 +330,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -421,8 +417,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -509,8 +504,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -597,8 +591,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -685,8 +678,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",
@@ -773,8 +765,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0",


### PR DESCRIPTION
The implementation was removed here:
https://trac.webkit.org/changeset/208300/webkit

Per https://bugs.webkit.org/show_bug.cgi?id=164213, "Apple never enabled
it on their ports."