### PR TITLE
Drop Permissions Policy spec URL for XHR

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1394,7 +1394,6 @@
         "sync-xhr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/sync-xhr",
-            "spec_url": "https://xhr.spec.whatwg.org/#permissions-policy-integration",
             "support": {
               "chrome": {
                 "version_added": "65"


### PR DESCRIPTION
See https://github.com/whatwg/xhr/pull/321:

> We should probably drop this section for now as it doesn't have multi-implementer interest.

Related: https://github.com/whatwg/xhr/pull/295

---

So, while the section in question is currently still in the XHR spec, for BCD purposes, we should just ignore it anyway (per the comment cited above from the spec editor).