### PR TITLE
Add originAgentCluster attribute (enabled in Chrome 88)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6021,7 +6021,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -6023,7 +6023,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -5979,6 +5979,54 @@
           }
         }
       },
+      "originAgentCluster": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "outerHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/outerHeight",


### PR DESCRIPTION
As discussed in https://github.com/mdn/browser-compat-data/issues/8891,
this was enabled in Chrome 88 using Finch, and will reach other
Chromium-based browsers when they ship with Chromium 90.

https://mdn-bcd-collector.appspot.com/tests/api/Window/originAgentCluster
has been tested to confirm it's *not* enabled in Edge 89, but *is*
enabled in Chrome 89 on my own computer.