### PR TITLE
Mark originAgentCluster as shipped in Chromium 90 for non-Chrome

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5990,7 +5990,7 @@
               "version_added": "88"
             },
             "edge": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox": {
               "version_added": false
@@ -6002,10 +6002,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "future-version-based-on-Blink-90"
             },
             "safari": {
               "version_added": false
@@ -6014,10 +6014,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "future-version-based-on-Blink-90"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/8891.