### PR TITLE
Add Opera for Android 62

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -332,9 +332,16 @@
         "61": {
           "release_date": "2020-12-07",
           "release_notes": "https://blogs.opera.com/mobile/2020/12/new-opera-for-android-61/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "86"
+        },
+        "62": {
+          "release_date": "2021-02-16",
+          "release_notes": "https://blogs.opera.com/mobile/2021/02/the-opera-browser-for-android-hit-a-new-record-of-80-million-maus/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "87"
         }
       }
     }


### PR DESCRIPTION
That it's based on Chromium 87 was confirmed by looking at the UA string
on Opera installed on a real Android phone.