### PR TITLE
Update data for CreateOscillator and related APIs

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -752,10 +752,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createOscillator",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -782,7 +782,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -853,7 +853,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "14"
+                "version_added": "30"
               }
             ],
             "chrome_android": [
@@ -862,7 +862,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "18"
+                "version_added": "30"
               }
             ],
             "edge": {
@@ -878,16 +878,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "8"
             },
             "samsunginternet_android": [
               {
@@ -895,7 +895,7 @@
                 "notes": "Default values supported"
               },
               {
-                "version_added": "1.0"
+                "version_added": "2.0"
               }
             ],
             "webview_android": [

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode",
         "support": {
           "chrome": {
-            "version_added": "14"
+            "version_added": "20"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
@@ -32,10 +32,10 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -105,10 +105,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/detune",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -132,10 +132,10 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -153,10 +153,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/frequency",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -180,10 +180,10 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -249,10 +249,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/setPeriodicWave",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -267,19 +267,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -397,10 +397,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/type",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -424,10 +424,10 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PeriodicWave",
         "support": {
           "chrome": {
-            "version_added": "14"
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "30"
           },
           "edge": {
             "version_added": "≤18"
@@ -23,19 +23,19 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "17"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "≤37"


### PR DESCRIPTION
Chrome 20 initially confirmed/suggested by this mdn-bcd-collector test:
http://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext/createOscillator

This was implemented in WebKit trunk version 536.6:
https://trac.webkit.org/changeset/112938/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=112938

That maps to Chrome 20 and Safari 6.

Oscillator and its detune, frequency and type members can also be
confirmed shipping in Chrome 20 with this test:
http://mdn-bcd-collector.appspot.com/tests/api/OscillatorNode

PeriodicWave was originally called WaveTable, and was renamed in WebKit
trunk version 538.1:
https://trac.webkit.org/changeset/151914/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=151914

That was after the Blink fork, but mdn-bcd-collector confirms Chrome 30.
538.1 maps to Safari 8. The available browsers on BrowserStack make it
impossible to confirm this, so just assume 8 is correct.

Don't bother adding the alternative_name entries for WaveTable. There
has been a lot of renaming in the Web Audio API, especially early on,
and trying to capture it all will make the data messier for no real
benefit given how far in the past this is now.