### PR TITLE
Update when webkitCreateShadowRoot was removed in Chromium

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2553,7 +2553,7 @@
               },
               {
                 "version_added": "25",
-                "version_removed": true,
+                "version_removed": "36",
                 "prefix": "webkit"
               }
             ],
@@ -2564,7 +2564,7 @@
               },
               {
                 "version_added": "25",
-                "version_removed": true,
+                "version_removed": "36",
                 "prefix": "webkit"
               }
             ],
@@ -2629,7 +2629,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": true,
+                "version_removed": "23",
                 "prefix": "webkit"
               }
             ],
@@ -2640,7 +2640,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": true,
+                "version_removed": "24",
                 "prefix": "webkit"
               }
             ],
@@ -2652,12 +2652,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "5.0",
+                "version_added": "3.0",
                 "notes": "In Samsung Internet 5.0, the ability to have multiple shadow roots was deprecated."
               },
               {
-                "version_added": "4.0",
-                "version_removed": true,
+                "version_added": "1.5",
+                "version_removed": "3.0",
                 "prefix": "webkit"
               }
             ],
@@ -2667,8 +2667,8 @@
                 "notes": "In version 45, the ability to have multiple shadow roots was deprecated."
               },
               {
-                "version_added": true,
-                "version_removed": true,
+                "version_added": "4.4",
+                "version_removed": "37",
                 "prefix": "webkit"
               }
             ]


### PR DESCRIPTION
These tests were used:
http://staging-dot-mdn-bcd-collector.appspot.com/tests/api/Element/createShadowRoot
http://staging-dot-mdn-bcd-collector.appspot.com/tests/api/Element/webkitCreateShadowRoot

Chrome 34, 35 and 36 were tested to confirm the versions and that the
two did indeed overlap in Chrome 35, it wasn't a straight rename.

The data was mirrored for other Chromium-based browsers, achieving the
real point of this, namely avoiding version_added==version_removed for
the prefixed entry for webview_android.

Part of https://github.com/mdn/browser-compat-data/pull/9610.