### PR TITLE
Cut obsolete/superfluous Content-Encoding spec URL

### DIFF
--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -4,10 +4,7 @@
       "Content-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
-          "spec_url": [
-            "https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.2",
-            "https://datatracker.ietf.org/doc/html/rfc2616#section-14.11"
-          ],
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.2",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
rfc7231 obsoletes rfc2616 — so it’s only necessary to cite rfc7231 for Content-Encoding