### PR TITLE
Updates api.Blob.text in Opera Browser

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -347,7 +347,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "75"
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -347,7 +347,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": "54"


### PR DESCRIPTION
Hello everyone, everything good?

Regarding issue #9469, the `.text()` function of `api.Blob` is working on version 75 of Opera.

I carried out the consultation on the website https://mdn-bcd-collector.appspot.com/ and I had the result:

![opera](https://user-images.githubusercontent.com/17712401/112591061-89dcb400-8de2-11eb-9540-df5fdc8a3c53.png)

And I tested it on Opera v75 mentioned in the problem above and received feedback:

![blob](https://user-images.githubusercontent.com/17712401/112591271-e3dd7980-8de2-11eb-8b6e-fb3f0c49c085.png)

However, I was unable to perform a test on previous versions to see if there is a version before 75 that was already working.

Fixes #9469.