### PR TITLE
-moz-submit-invalid behind a flag

### DIFF
--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -17,7 +17,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='https://bugzil.la/1693969'>Bug: 1693969</a>",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1693969'>bug 1693969</a>.",
               "flags": [
                 {
                   "type": "preference",
@@ -28,7 +28,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='https://bugzil.la/1693969'>Bug: 1693969</a>",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1693969'>bug 1693969</a>.",
               "flags": [
                 {
                   "type": "preference",

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -17,7 +17,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='http://bugzil.la/1693969'>Bug: 1693969</a>",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='https://bugzil.la/1693969'>Bug: 1693969</a>",
               "flags": [
                 {
                   "type": "preference",
@@ -28,7 +28,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='http://bugzil.la/1693969'>Bug: 1693969</a>",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='https://bugzil.la/1693969'>Bug: 1693969</a>",
               "flags": [
                 {
                   "type": "preference",

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -17,7 +17,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1693969'>bug 1693969</a>.",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
               "flags": [
                 {
                   "type": "preference",
@@ -28,7 +28,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1693969'>bug 1693969</a>.",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
               "flags": [
                 {
                   "type": "preference",

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -32,23 +32,11 @@
                 "version_removed": "88"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "88",
-                "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.moz-submit-invalid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "4",
-                "version_removed": "88"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "88",
+              "notes": "From version 88, the feature has been withdrawn. See <a href='https://bugzil.la/1694129'>bug 1694129</a>."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -16,10 +16,26 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='http://bugzil.la/1693969'>Bug: 1693969</a>",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.moz-submit-invalid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Firefox 88 the feature has been placed behind a flag. <a href='http://bugzil.la/1693969'>Bug: 1693969</a>",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.moz-submit-invalid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -15,28 +15,40 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.moz-submit-invalid.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.moz-submit-invalid.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "88",
+                "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.moz-submit-invalid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "4",
+                "version_removed": "88"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "88",
+                "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.moz-submit-invalid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "4",
+                "version_removed": "88"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/3446

This feature is now behind a flag. I wasn't sure if I should do a separate block with version_removed for the unflagged version. If so let me know and I'll update it.
