### PR TITLE
Support for image-set in Firefox 88

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2138,11 +2138,17 @@
               },
               "firefox": {
                 "version_added": "88",
-                "notes": "The <code>type()</code> function and support for gradients in <code>cursor</code> and <code>content</code> is yet to be implemented <a href='https://bugzil.la/1695404'>bug 1695404</a> and <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                "notes": [
+                  "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>. See <a href='https://bugzil.la/1695404'>bug 1695404</a>.",
+                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                ]
               },
               "firefox_android": {
                 "version_added": "88",
-                "notes": "The <code>type()</code> function and support for gradients in <code>cursor</code> and <code>content</code> is yet to be implemented <a href='https://bugzil.la/1695404'>bug 1695404</a> and <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                "notes": [
+                  "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>. See <a href='https://bugzil.la/1695404'>bug 1695404</a>.",
+                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                ]
               },
               "ie": {
                 "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2137,12 +2137,12 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+                "version_added": "88",
+                "notes": "The <code>type()</code> function and support for gradients in <code>cursor</code> and <code>content</code> is yet to be implemented <a href='https://bugzil.la/1695404'>bug 1695404</a> and <a href='https://bugzil.la/1696314'>bug 1696314</a>."
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+                "version_added": "88",
+                "notes": "The <code>type()</code> function and support for gradients in <code>cursor</code> and <code>content</code> is yet to be implemented <a href='https://bugzil.la/1695404'>bug 1695404</a> and <a href='https://bugzil.la/1696314'>bug 1696314</a>."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/3456

This PR adds support for `image-set()` in Firefox with a note about two outstanding bugs.
