### PR TITLE
Update versions for FormData.append() filename argument support

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -203,10 +203,10 @@
             "description": "<code>append</code> with filename",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "16"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -221,22 +221,22 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "≤14"
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {


### PR DESCRIPTION
This was added in WebKit trunk version 535.7.0:
https://trac.webkit.org/changeset/97274/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=97274

Versions are inferred from that, which isn't 100% reliable, but being
off by a version here is not a big issue.