### PR TITLE
Clean up the data for navigator.getBattery()

### DIFF
--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -8,55 +8,19 @@
             "version_added": "38"
           },
           "chrome_android": {
-            "version_added": "38",
-            "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            "version_added": "38"
           },
           "edge": {
             "version_added": "79"
           },
-          "firefox": [
-            {
-              "version_added": "16",
-              "version_removed": "52"
-            },
-            {
-              "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
-            },
-            {
-              "version_added": "52",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.battery.enabled"
-                }
-              ],
-              "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-            },
-            {
-              "version_added": "72",
-              "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
-            },
-            {
-              "version_added": "16",
-              "version_removed": "52",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.battery.enabled"
-                }
-              ],
-              "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-            }
-          ],
+          "firefox": {
+            "version_added": "43",
+            "version_removed": "52"
+          },
+          "firefox_android": {
+            "version_added": "43",
+            "version_removed": "52"
+          },
           "ie": {
             "version_added": false
           },
@@ -73,17 +37,16 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "3.0",
-            "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": "40"
+            "version_added": "38"
           }
         },
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       },
       "charging": {
@@ -94,55 +57,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -159,17 +86,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -180,83 +106,78 @@
             "chrome": {
               "version_added": "38"
             },
-            "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>0</code> or <code>Infinity</code>."
+              }
+            ],
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
             "opera": {
               "version_added": "25"
             },
-            "opera_android": {
-              "version_added": "25"
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "29",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>0</code> or <code>Infinity</code>."
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "version_added": "3.0",
+                "version_removed": "4.0",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>0</code> or <code>Infinity</code>."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>0</code> or <code>Infinity</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -267,83 +188,78 @@
             "chrome": {
               "version_added": "38"
             },
-            "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
-            },
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>Infinity</code>."
+              }
+            ],
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
             "opera": {
               "version_added": "25"
             },
-            "opera_android": {
-              "version_added": "25"
-            },
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "29",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>Infinity</code>."
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "version_added": "3.0",
+                "version_removed": "4.0",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>Infinity</code>."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "38",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Always equal to <code>Infinity</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -355,55 +271,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -420,17 +300,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -442,55 +321,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -507,17 +350,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -529,55 +371,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -594,17 +400,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -616,55 +421,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -681,17 +450,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },
@@ -703,55 +471,19 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "38",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "38"
             },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "52"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Firefox 18. Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              },
-              {
-                "version_added": "72",
-                "notes": "From this version onwards, <code>BatteryManager</code> is only available in chrome/privileged code."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "16",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled"
-                  }
-                ],
-                "notes": "Disabled by default in Firefox 10.0, but can be enabled setting the preference <code>dom.battery.enabled</code> to <code>true</code>. Starting with Firefox 11.0, <code>mozBattery</code> is enabled by default. The Battery API is currently supported on Android, Windows, and Linux with UPower installed. Support for macOS is available starting with Gecko 18.0 (Firefox 18.0 / Thunderbird 18.0 / SeaMonkey 2.15). Firefox also provides support for the deprecated <a href='https://developer.mozilla.org/docs/Web/API/Navigator/battery'><code>navigator.battery</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
             "ie": {
               "version_added": false
             },
@@ -768,17 +500,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0",
-              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "38"
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -225,102 +225,6 @@
           }
         }
       },
-      "battery": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/battery",
-          "support": {
-            "chrome": {
-              "version_added": "20",
-              "version_removed": "29",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": [
-              {
-                "version_added": "16",
-                "version_removed": "50",
-                "notes": [
-                  "Removed in favor of <code>navigator.getBattery()</code>.",
-                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for macOS was available starting with Firefox 18."
-                ]
-              },
-              {
-                "version_added": "11",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "16",
-                "version_removed": "50",
-                "notes": [
-                  "Removed in favor of <code>navigator.getBattery()</code>.",
-                  "The Battery API was supported on Android, Windows, and Linux with UPower installed. Support for macOS was available starting with Firefox 18."
-                ]
-              },
-              {
-                "version_added": "14",
-                "version_removed": "16",
-                "prefix": "moz"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "bluetooth": {
         "__compat": {
           "support": {
@@ -990,13 +894,11 @@
             },
             "firefox": {
               "version_added": "43",
-              "version_removed": "52",
-              "notes": "From Firefox 52 onwards, the Battery Status API is only available in chrome/privileged code."
+              "version_removed": "52"
             },
             "firefox_android": {
               "version_added": "43",
-              "version_removed": "52",
-              "notes": "From Firefox 52 onwards, the Battery Status API is only available in chrome/privileged code."
+              "version_removed": "52"
             },
             "ie": {
               "version_added": false
@@ -1023,7 +925,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
Summary of changes:
 - Remove navigator.battery, which has been removed since 2013/2016 in
   Chrome and Firefox respectively.
 - Treat BatteryManager as only supported since navigator.getBattery()
   was supported, making the data consistent but technically wrong.
 - Simplify Firefox support to only represent when it was on by default
   for web content. Flags before that and chrome-only after is removed.
 - Remove claims of prefixes on BatteryManager, the only prefixes here
   have been navigator.mozBattery and navigator.webkitBattery.
 - Don't claim it's deprecated, https://w3c.github.io/battery/ is still
   a "real" spec and Chromium hasn't deprecated it.
 - Scope the chargingTime/dischargingTime notes to just those entries,
   and treat it as fixed in Chromium 42 (see below).

The chargingTime/dischargingTime issue was fixed in Chromium 42:
https://bugs.chromium.org/p/chromium/issues/detail?id=401553
https://storage.googleapis.com/chromium-find-releases-static/13e.html#13e397e55501bee3903bfe46edfd56f2442c1f11

Data originally from https://github.com/mdn/browser-compat-data/pull/1102.
There was no evidence for or discussion on the webview_android version
being 40. All existing versions were treated as untrustworthy and data
was mirrored to all Chromium browsers.