### PR TITLE
Add release information for GravitySensor API

### DIFF
--- a/api/GravitySensor.json
+++ b/api/GravitySensor.json
@@ -1,0 +1,101 @@
+{
+  "api": {
+    "GravitySensor": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GravitySensor",
+        "support": {
+          "chrome": {
+            "version_added": "91"
+          },
+          "chrome_android": {
+            "version_added": "91"
+          },
+          "edge": {
+            "version_added": "91"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": true
+          },
+          "opera_android": {
+            "version_added": true
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "91"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "GravitySensor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GravitySensor/GravitySensor",
+          "description": "<code>GravitySensor()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": {
+              "version_added": "91"
+            },
+            "edge": {
+              "version_added": "91"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "91"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
GravitySensor API is now implemented for Chrome. [1][2]

Expected Release in Chrome 91.

[1] https://github.com/arskama/GravitySensor/blob/main/explainer.md
[2]https://chromestatus.com/features/5384099747332096
