### PR TITLE
Mirror Android data for NodeFilter and TreeWalker APIs

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2419,7 +2419,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2446,7 +2446,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -2771,7 +2771,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2798,7 +2798,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/api/NodeFilter.json
+++ b/api/NodeFilter.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,7 +35,7 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "1"
@@ -55,7 +55,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,7 +82,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,7 +35,7 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "1"
@@ -55,7 +55,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -84,7 +84,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -106,7 +106,7 @@
               "version_removed": "41"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "41"
             },
             "edge": {
@@ -141,7 +141,7 @@
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0"
             },
             "webview_android": {
@@ -164,7 +164,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -191,7 +191,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -212,7 +212,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -239,7 +239,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -260,7 +260,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -287,7 +287,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -308,7 +308,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -335,7 +335,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -356,7 +356,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -383,7 +383,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -404,7 +404,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -431,7 +431,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -452,7 +452,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -479,7 +479,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,7 +35,7 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "3"
@@ -55,7 +55,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,7 +82,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -104,7 +104,7 @@
               "version_removed": "41"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "41"
             },
             "edge": {
@@ -139,7 +139,7 @@
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0"
             },
             "webview_android": {
@@ -162,7 +162,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -189,7 +189,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -210,7 +210,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -237,7 +237,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -258,7 +258,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -285,7 +285,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -306,7 +306,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -333,7 +333,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -354,7 +354,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -381,7 +381,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -402,7 +402,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -429,7 +429,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -450,7 +450,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -477,7 +477,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -498,7 +498,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -525,7 +525,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -546,7 +546,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -573,7 +573,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -594,7 +594,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -621,7 +621,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"


### PR DESCRIPTION
These APIs are a very old part of the platform and can be safely assumed
to have been in Chrome for Android and Samsung Internet based on their
support early in Chrome and Safari.