### PR TITLE
Remove the api.WorkerGlobalScope.console entry

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1630,10 +1630,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "29"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "29"
             },
             "ie": {
               "version_added": "10"
@@ -1642,10 +1642,10 @@
               "version_added": "10.5.0"
             },
             "opera": {
-              "version_added": "18"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6.1"
@@ -1657,7 +1657,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -47,56 +47,6 @@
           "deprecated": false
         }
       },
-      "console": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/console",
-          "support": {
-            "chrome": {
-              "version_added": "4"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "29",
-              "notes": "Before Firefox 30, the console would be of type <code>WorkerConsole</code> instead of <code>Console</code>."
-            },
-            "firefox_android": {
-              "version_added": "29",
-              "notes": "Before Firefox 30, the console would be of type <code>WorkerConsole</code> instead of <code>Console</code>."
-            },
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "dump": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/dump",


### PR DESCRIPTION
This duplicates the api.Console.worker_support entry, which is more
accurate.

http://mdn-bcd-collector.appspot.com/tests/api/Console/log was used to
confirm the following version_added:
 - Chrome 31
 - Firefox 29
 - IE 10 (so Edge not tested)
 - Opera 12.16
 - Safari 6.1 or 6.2 (in 6.2 but not in 6, 6.1 not available)

In the preceding versions, an exception like "console is not defined"
was thrown, it wasn't `console.log` that was somehow missing.

The WebView version was inferred from Chromium 31.