### PR TITLE
Update Samsung Internet support for Promise.allSettled()

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -203,7 +203,7 @@
                 "version_added": "13"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "12.0"
               },
               "webview_android": {
                 "version_added": "76"


### PR DESCRIPTION
This PR updates the support for the `Promise.allSettled()` method in Samsung Internet. Samsung Internet version 12.0.1.47 is using Chromium version 79.3945, which has support for this method.

See the [release notes](https://developer.samsung.com/internet/release-note.html) of Samsung Internet for more information. Closes #9636
