### PR TITLE
Cookie Store API additions and updates

### DIFF
--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -1,7 +1,8 @@
 {
   "api": {
-    "CookieStore": {
+    "CookieChangeEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieChangeEvent",
         "support": {
           "chrome": {
             "version_added": "87"
@@ -42,12 +43,14 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
-      "delete": {
+      "CookieChangeEvent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieChangeEvent/CookieChangeEvent",
+          "description": "<code>CookieChangeEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -88,13 +91,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "get": {
+      "changed": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieChangeEvent/changed",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -135,13 +139,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "getAll": {
+      "deleted": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieChangeEvent/deleted",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -182,101 +187,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
-            "edge": {
-              "version_added": "87"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "87"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "set": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
-            "edge": {
-              "version_added": "87"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "87"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "73"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "62"
           },
           "safari": {
             "version_added": false
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -22,10 +22,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "73"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "62"
           },
           "safari": {
             "version_added": false
@@ -68,10 +68,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -115,10 +115,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -162,10 +162,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -209,10 +209,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -256,10 +256,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false

--- a/api/CookieStoreManager.json
+++ b/api/CookieStoreManager.json
@@ -22,10 +22,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "73"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "62"
           },
           "safari": {
             "version_added": false
@@ -68,13 +68,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari_ios": {
               "version_added": false
@@ -115,10 +112,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -162,10 +159,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false

--- a/api/CookieStoreManager.json
+++ b/api/CookieStoreManager.json
@@ -73,6 +73,9 @@
             "opera_android": {
               "version_added": "62"
             },
+            "safari": {
+              "version_added": false
+            },
             "safari_ios": {
               "version_added": false
             },

--- a/api/CookieStoreManager.json
+++ b/api/CookieStoreManager.json
@@ -10,7 +10,7 @@
             "version_added": "87"
           },
           "edge": {
-            "version_added": false
+            "version_added": "87"
           },
           "firefox": {
             "version_added": false
@@ -56,7 +56,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": false
@@ -103,7 +103,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": false
@@ -150,7 +150,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": false

--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -1,7 +1,8 @@
 {
   "api": {
-    "CookieStore": {
+    "ExtendableCookieChangeEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ExtendableCookieChangeEvent",
         "support": {
           "chrome": {
             "version_added": "87"
@@ -42,12 +43,14 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
-      "delete": {
+      "ExtendableCookieChangeEvent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ExtendableCookieChangeEvent/ExtendableCookieChangeEvent",
+          "description": "<code>ExtendableCookieChangeEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -88,13 +91,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "get": {
+      "changed": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ExtendableCookieChangeEvent/changed",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -130,18 +134,19 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "87"
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "getAll": {
+      "deleted": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ExtendableCookieChangeEvent/deleted",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -162,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15> ≤74"
             },
             "opera_android": {
               "version_added": false
@@ -182,101 +187,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
-            "edge": {
-              "version_added": "87"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "87"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "set": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
-            "edge": {
-              "version_added": "87"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "87"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -167,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15> ≤74"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "73"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "62"
           },
           "safari": {
             "version_added": false
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds the BCD files for the Interfaces:

- CookieChangeEvent
- ExtendableCookieChangeEvent

and updates Edge data for

- CookieStore
- CookieStoreManager

These are all part of the Cookie Store API which I have been documenting. 

https://wicg.github.io/cookie-store/
https://www.chromestatus.com/feature/5658847691669504