### PR TITLE
Remove the api.FormData.SupportForOf entry (dupe of @@iterator)

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -99,54 +99,6 @@
           }
         }
       },
-      "SupportForOf": {
-        "__compat": {
-          "description": "Support of <code>for...of</code>",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "50"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "append": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormData/append",


### PR DESCRIPTION
These entries were added separately at different times:
- SupportForOf in https://github.com/mdn/browser-compat-data/pull/1487
- @@iterator in https://github.com/mdn/browser-compat-data/pull/8104

The data is the same (or missing) except for Edge and Safari.

The @@iterator entry is based on mdn-bcd-collector results, but
https://software.hixie.ch/utilities/js/live-dom-viewer/saved/9119 was
used to confirm support of for...of loops in Edge 18 (but not 17) and in
Safari 11.1 (but not 11).

In other words, no data needed updating on the @@iterator entry.