### PR TITLE
Add AbortSignal.abort() static method

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "75"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -55,13 +55,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "89"
+              "version_added": false
             },
             "edge": {
-              "version_added": "89"
+              "version_added": false
             },
             "firefox": {
               "version_added": "88"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -91,7 +91,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "89"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -50,6 +50,57 @@
           "deprecated": false
         }
       },
+      "abort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": "88"
+            },
+            "firefox_android": {
+              "version_added": "88"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "abort_event": {
         "__compat": {
           "description": "<code>abort</code> event",


### PR DESCRIPTION
AbortSignal.abort() static method added to spec very recently
- FF88 
  - Bugzilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=1698468 
  - docs bug https://github.com/mdn/content/issues/3460
  - docs PR https://github.com/mdn/content/pull/3616
- Webkit Safari - not present yet https://bugs.webkit.org/show_bug.cgi?id=223071
- Chromium - not present yet : https://bugs.chromium.org/p/chromium/issues/detail?id=1187117
- Note - 15.12.0 (https://github.com/nodejs/node/pull/37693)

Should AbortSignal still be marked as experimental?