### PR TITLE
browserSettings.ftpProtocolEnabled readonly in FF88

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -114,7 +114,7 @@
               },
               "firefox": {
                 "version_added": "72",
-                "notes": "From Firefox version 88 this setting is read-only (<a href='https://bugzil.la/1363010'>bug 1626365</a>)."
+                "notes": "From version 88, this setting is read-only (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -114,7 +114,7 @@
               },
               "firefox": {
                 "version_added": "72",
-                "notes": "From Firefox version 88 this setting is read-only."
+                "notes": "From Firefox version 88 this setting is read-only (<a href='https://bugzil.la/1363010'>bug 1626365</a>)."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -113,7 +113,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "72"
+                "version_added": "72",
+                "notes": "From Firefox version 88 this setting is read-only."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
This adds a note from FF88 the setting is read only. This comes from https://bugzilla.mozilla.org/show_bug.cgi?id=1626365.

