### PR TITLE
Mark customized built-in element support as shipped in Chromium 67

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -110,10 +110,10 @@
           "description": "Customized built-in element support",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "67"
             },
             "edge": {
               "version_added": "79"
@@ -186,10 +186,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "53"
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -201,7 +201,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "67"
             }
           },
           "status": {
@@ -217,7 +217,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -227,7 +227,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -314,7 +314,7 @@
             },
             "opera": [
               {
-                "version_added": "53",
+                "version_added": "54",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -324,7 +324,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "47",
+                "version_added": "48",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -352,7 +352,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -374,7 +374,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -384,7 +384,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -471,7 +471,7 @@
             },
             "opera": [
               {
-                "version_added": "53",
+                "version_added": "54",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -481,7 +481,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "47",
+                "version_added": "48",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -509,7 +509,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -579,7 +579,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -589,7 +589,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -676,7 +676,7 @@
             },
             "opera": [
               {
-                "version_added": "53",
+                "version_added": "54",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -686,7 +686,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "47",
+                "version_added": "48",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -714,7 +714,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "66",
+                "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1133,7 +1133,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "55"
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": "48"


### PR DESCRIPTION
This was controlled by the CustomElementsBuiltin feature, enabled here:
https://bugs.chromium.org/p/chromium/issues/detail?id=648828
https://storage.googleapis.com/chromium-find-releases-static/4a2.html#4a2b6e0a71e6d8f664697210b5fb407281ba0941

The data was slightly inconsistent, off-by-one in both directions.