### PR TITLE
Remove prefix for element.requestFullscreen() in Presto

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6685,8 +6685,7 @@
               },
               {
                 "version_added": "12",
-                "version_removed": "15",
-                "prefix": "o"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -6699,8 +6698,7 @@
               },
               {
                 "version_added": "12",
-                "version_removed": "14",
-                "prefix": "o"
+                "version_removed": "14"
               }
             ],
             "safari": {


### PR DESCRIPTION
The Fullscreen API was actually shipped unprefixed in Presto.

Tested with http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9122 in Opera 12.1.