### PR TITLE
Add support for ruby-position: alternate

### DIFF
--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -148,6 +148,54 @@
               "deprecated": false
             }
           }
+        },
+        "alternate": {
+          "__compat": {
+            "description": "<code>alternate</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "88"
+              },
+              "firefox_android": {
+                "version_added": "88"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
In firefox 88 `ruby-position: alternate` is supported, this PR updates the property.

reL https://github.com/mdn/content/issues/3457