### PR TITLE
Updating visibility: collapse for ruby annotations

### DIFF
--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -78,7 +78,7 @@
                 "version_added": "1",
                 "notes": [
                   "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set.",
-                  "Prior to Firefox 88, <code>collapse</code> was not supported on ruby annotations."
+                  "Prior to Firefox 88, <code>collapse</code> is not supported on ruby annotations."
                 ]
               },
               "firefox_android": {

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -76,11 +76,17 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
+                "notes": [
+                  "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set.",
+                  "Prior to Firefox 88, <code>collapse</code> was not supported on ruby annotations."
+                ]
               },
               "firefox_android": {
                 "version_added": "4",
-                "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
+                "notes": [
+                  "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set.",
+                  "Prior to Firefox 88, <code>collapse</code> was not supported on ruby annotations."
+                ]
               },
               "ie": {
                 "version_added": "10"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -85,7 +85,7 @@
                 "version_added": "4",
                 "notes": [
                   "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set.",
-                  "Prior to Firefox 88, <code>collapse</code> was not supported on ruby annotations."
+                  "Prior to Firefox 88, <code>collapse</code> is not supported on ruby annotations."
                 ]
               },
               "ie": {


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/3457

`visibility: collapse` is now supported in Firefox for ruby annotations, added a note.
