### PR TITLE
Mark WebKitMutationObserver as still supported

### DIFF
--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -10,7 +10,6 @@
             },
             {
               "version_added": "18",
-              "version_removed": "26",
               "prefix": "WebKit"
             }
           ],
@@ -20,7 +19,6 @@
             },
             {
               "version_added": "18",
-              "version_removed": "26",
               "prefix": "WebKit"
             }
           ],
@@ -48,7 +46,6 @@
             },
             {
               "version_added": "6",
-              "version_removed": "7",
               "prefix": "WebKit"
             }
           ],
@@ -58,7 +55,6 @@
             },
             {
               "version_added": "6",
-              "version_removed": "7",
               "prefix": "WebKit"
             }
           ],
@@ -67,9 +63,8 @@
               "version_added": "1.5"
             },
             {
-              "prefix": "WebKit",
               "version_added": "1.0",
-              "version_removed": "1.5"
+              "prefix": "WebKit"
             }
           ],
           "webview_android": [
@@ -78,7 +73,6 @@
             },
             {
               "version_added": "≤37",
-              "version_removed": "≤37",
               "prefix": "WebKit"
             }
           ]
@@ -100,7 +94,6 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "26",
                 "prefix": "WebKit"
               }
             ],
@@ -110,7 +103,6 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "26",
                 "prefix": "WebKit"
               }
             ],
@@ -138,7 +130,6 @@
               },
               {
                 "version_added": "6",
-                "version_removed": "7",
                 "prefix": "WebKit"
               }
             ],
@@ -148,7 +139,6 @@
               },
               {
                 "version_added": "6",
-                "version_removed": "7",
                 "prefix": "WebKit"
               }
             ],
@@ -157,9 +147,8 @@
                 "version_added": "1.5"
               },
               {
-                "prefix": "WebKit",
                 "version_added": "1.0",
-                "version_removed": "1.5"
+                "prefix": "WebKit"
               }
             ],
             "webview_android": [
@@ -168,7 +157,6 @@
               },
               {
                 "version_added": "≤37",
-                "version_removed": "≤37",
                 "prefix": "WebKit"
               }
             ]


### PR DESCRIPTION
https://trac.webkit.org/changeset/143386/webkit added support for
MutationObserver in addition to WebKitMutationObserver, but support for
the latter was never removed.

Confirmed supported in Chrome 89 and Safari 14.

Part of https://github.com/mdn/browser-compat-data/pull/9610.