### PR TITLE
Update WebView Android versions for -webkit-prefixed at-rules

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -2088,8 +2088,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "≤37"
+                "version_added": "2",
+                "version_removed": "37"
               }
             },
             "status": {
@@ -2473,8 +2473,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "≤37"
+                "version_added": "2",
+                "version_removed": "37"
               }
             },
             "status": {
@@ -2554,8 +2554,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "≤37"
+                "version_added": "2",
+                "version_removed": "37"
               }
             },
             "status": {
@@ -2609,8 +2609,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "≤37"
+                "version_added": "2",
+                "version_removed": "37"
               }
             },
             "status": {


### PR DESCRIPTION
This is the result of bulk mirroring:
https://github.com/mdn/browser-compat-data/pull/4637

However, the versions can be made more precise with fairly high
confidence. Assuming that Safari 4 is correct, that was based on WebKit
530.17, exactly the same version as WebView 2. Both were in 2009 and
shouldn't be off by much, even if there's a chance of off-by-one here.

The removal is straightforward: Chrome 36 maps to WebView 37.

Part of https://github.com/mdn/browser-compat-data/pull/9610.