### PR TITLE
Mark originAgentCluster as shipped in Chromium 90 for non-Chrome

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5894,10 +5894,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "future-version-based-on-Blink-90"
             },
             "safari": {
               "version_added": false
@@ -5906,7 +5906,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "future-version-based-on-Blink-90"
             },
             "webview_android": {
               "version_added": "90"


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/8891.