### PR TITLE
Update -webkit-mask-attachment removal versions

### DIFF
--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -32,18 +32,20 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "6.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "3.2",
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
               "version_removed": "1.5"
             },
             "webview_android": {
-              "version_added": "≤37",
-              "version_removed": "≤37"
+              "version_added": "2",
+              "version_removed": "4.4"
             }
           },
           "status": {


### PR DESCRIPTION
This was removed in WebKit trunk version 537.20:
https://trac.webkit.org/changeset/136080/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=136080

The Safari versions can be determined with fairly high confidence based
on this. When this was added in WebView Android is a little bit more
uncertain, but doesn't really matter since this entry will now be
eligible for removal as an obsolete feature.

Part of https://github.com/mdn/browser-compat-data/pull/9610.