### PR TITLE
Presentation API mark version removal

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1896,6 +1896,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -1906,6 +1907,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1907,7 +1907,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -76,6 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -86,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -138,6 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -148,6 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -89,7 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -153,7 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -76,6 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -86,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -138,6 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -148,6 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -89,7 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -153,7 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -76,6 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -86,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -138,6 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -148,6 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -200,6 +206,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -210,6 +217,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -262,6 +270,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -272,6 +281,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -324,6 +334,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -334,6 +345,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -386,6 +398,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -396,6 +409,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -448,6 +462,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -458,6 +473,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -510,6 +526,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -520,6 +537,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -572,6 +590,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -582,6 +601,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -634,6 +654,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -644,6 +665,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -696,6 +718,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -706,6 +729,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -89,7 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -153,7 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -217,7 +217,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -281,7 +281,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -345,7 +345,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -409,7 +409,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -473,7 +473,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -537,7 +537,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -601,7 +601,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -665,7 +665,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -729,7 +729,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -77,6 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -87,6 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -139,6 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -149,6 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -90,7 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -154,7 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -90,7 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -154,7 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -218,7 +218,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -77,6 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -87,6 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -139,6 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -149,6 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -201,6 +207,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -211,6 +218,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -76,6 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -86,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -138,6 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -148,6 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -89,7 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -153,7 +153,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -89,7 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -76,6 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -86,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -26,7 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
-            "version_removed": "88",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -90,7 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -154,7 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -218,7 +218,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -282,7 +282,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -339,7 +339,7 @@
             },
             "firefox_android": {
               "version_added": true,
-              "version_removed": "88"
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false
@@ -396,7 +396,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -460,7 +460,7 @@
             },
             "firefox_android": {
               "version_added": "51",
-              "version_removed": "88",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -15,6 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
+            "version_removed": "61",
             "flags": [
               {
                 "type": "preference",
@@ -25,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "51",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -77,6 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -87,6 +90,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -139,6 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -149,6 +154,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -201,6 +207,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -211,6 +218,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -263,6 +271,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -273,6 +282,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -324,10 +334,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "88"
             },
             "ie": {
               "version_added": false
@@ -373,6 +385,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -383,6 +396,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -435,6 +449,7 @@
             },
             "firefox": {
               "version_added": "51",
+              "version_removed": "61",
               "flags": [
                 {
                   "type": "preference",
@@ -445,6 +460,7 @@
             },
             "firefox_android": {
               "version_added": "51",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This adds version removal information for Firefox on the [Presentation API](https://developer.mozilla.org/en-US/docs/Web/API/Presentation_API). 
- FF88 removes the API for Android: https://bugzilla.mozilla.org/show_bug.cgi?id=1697680
- FF61 removed it for desktop https://bugzilla.mozilla.org/show_bug.cgi?id=1371346

Associated docs tracking is in https://github.com/mdn/content/issues/3461