### PR TITLE
Drop object[typemustmatch] and typeMustMatch IDL attribute

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -1007,56 +1007,6 @@
           }
         }
       },
-      "typeMustMatch": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/typeMustMatch",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "27",
-              "version_removed": "68"
-            },
-            "firefox_android": {
-              "version_added": "27",
-              "version_removed": "68"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "useMap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/useMap",

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -721,53 +721,6 @@
             }
           }
         },
-        "typemustmatch": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "27"
-              },
-              "firefox_android": {
-                "version_added": "27"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "usemap": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This change deletes `typeMustMatch` from `api/HTMLObjectElement.json` and deletes `typemustmatch` from `html/elements/object.json`.

The history of `typeMustMatch`/`typemustmatch` is that it was added to the spec in 2011 in https://github.com/whatwg/html/commit/4030e71 but never got implemented across browsers and never got adopted by web developers.  So https://github.com/whatwg/html/pull/4590 dropped it from the spec in 2019, and it's now just a footnote in the “Non-conforming features” section at https://html.spec.whatwg.org/obsolete.html#attr-object-typemustmatch

So there's statistically near-zero content on the web that’s using `typeMustMatch`/`typemustmatch`, and there’s no value to continue tracking support data for it in BCD.

Related MDN content change: https://github.com/mdn/content/pull/3655