### PR TITLE
Add missing entries for Chrome for Android

### DIFF
--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -7,6 +7,9 @@
           "chrome": {
             "version_added": "1"
           },
+          "chrome_android": {
+            "version_added": "18"
+          },
           "edge": {
             "version_added": "12"
           },

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -7,6 +7,9 @@
           "chrome": {
             "version_added": "6"
           },
+          "chrome_android": {
+            "version_added": "18"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -47,6 +50,9 @@
           "support": {
             "chrome": {
               "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -90,6 +96,9 @@
             "chrome": {
               "version_added": "6"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "18"
             },
@@ -131,6 +140,9 @@
           "support": {
             "chrome": {
               "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -174,6 +186,9 @@
             "chrome": {
               "version_added": "6"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "13"
             },
@@ -215,6 +230,9 @@
           "support": {
             "chrome": {
               "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -258,6 +276,9 @@
             "chrome": {
               "version_added": "6"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "13"
             },
@@ -299,6 +320,9 @@
           "support": {
             "chrome": {
               "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"

--- a/api/Text.json
+++ b/api/Text.json
@@ -7,6 +7,9 @@
           "chrome": {
             "version_added": "1"
           },
+          "chrome_android": {
+            "version_added": "18"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -309,6 +312,9 @@
           "support": {
             "chrome": {
               "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
Each of these was found supported in Chrome for Android 88 using
mdn-bcd-collector, and manually edited to say 18 based on the earlier
support in Chrome and the fact that these APIs have no platform
dependency.