### PR TITLE
Add missing entries for Firefox for Android

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -16,6 +16,9 @@
           "firefox": {
             "version_added": "38"
           },
+          "firefox_android": {
+            "version_added": "38"
+          },
           "ie": {
             "version_added": false
           },
@@ -61,6 +64,9 @@
             "firefox": {
               "version_added": "38"
             },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -104,6 +110,9 @@
               "version_added": "79"
             },
             "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
               "version_added": "38"
             },
             "ie": {
@@ -152,6 +161,9 @@
             "firefox": {
               "version_added": "38"
             },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -196,6 +208,9 @@
               "version_added": "≤79"
             },
             "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
               "version_added": "57"
             },
             "ie": {
@@ -243,6 +258,9 @@
             "firefox": {
               "version_added": "38"
             },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -286,6 +304,9 @@
               "version_added": "79"
             },
             "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
               "version_added": "38"
             },
             "ie": {
@@ -333,6 +354,9 @@
             "firefox": {
               "version_added": "57"
             },
+            "firefox_android": {
+              "version_added": "57"
+            },
             "ie": {
               "version_added": false
             },
@@ -376,6 +400,9 @@
               "version_added": "79"
             },
             "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
               "version_added": "38"
             },
             "ie": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -13,22 +13,12 @@
           "edge": {
             "version_added": "15"
           },
-          "firefox": [
-            {
-              "version_added": "55"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "55",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "55"
+          },
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -71,22 +61,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -175,22 +155,12 @@
               "version_added": "15",
               "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -230,22 +200,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -285,22 +245,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -340,22 +290,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -398,22 +338,12 @@
               "version_added": "15",
               "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -453,22 +383,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -509,22 +429,12 @@
               "version_added": "15",
               "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -13,22 +13,12 @@
           "edge": {
             "version_added": "15"
           },
-          "firefox": [
-            {
-              "version_added": "55"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "55",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.IntersectionObserver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "55"
+          },
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -116,22 +106,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -171,22 +151,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -226,22 +196,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -281,22 +241,12 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -336,22 +286,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -391,22 +331,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -446,22 +376,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.IntersectionObserver.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
BroadcastChannel and IntersectionObserver were found support in Firefox
for Android 86 using mdn-bcd-collector, but the exact version can't be
determined without exhaustive results from all Firefox for Android
versions. Instead mirror the desktop data, which is likely correct.

Also remove flags to simplify as allowed by this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data