### PR TITLE
Remove old flags for CSS Grid

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -73,16 +73,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "29",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "chrome_android": [
@@ -92,16 +82,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "29",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "edge": [
@@ -120,18 +100,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -141,18 +109,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {
@@ -165,16 +121,6 @@
                 {
                   "version_added": "44",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "opera_android": [
@@ -184,16 +130,6 @@
                 {
                   "version_added": "43",
                   "alternative_name": "grid-column-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-column-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "safari": [

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -65,16 +65,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "29",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "chrome_android": [
@@ -84,16 +74,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "29",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "edge": [
@@ -112,18 +92,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -133,18 +101,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {
@@ -157,16 +113,6 @@
                 {
                   "version_added": "44",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "opera_android": [
@@ -176,16 +122,6 @@
                 {
                   "version_added": "43",
                   "alternative_name": "grid-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "safari": [

--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-area",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-area",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -6,34 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-auto-columns",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": [
               {
                 "version_added": "16"
@@ -52,19 +30,6 @@
                 "version_removed": "70",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -76,53 +41,18 @@
                 "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {
               "version_added": "10",
               "alternative_name": "-ms-grid-columns"
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-auto-flow",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -6,34 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-rows",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-auto-rows",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": [
               {
                 "version_added": "16"
@@ -52,19 +30,6 @@
                 "version_removed": "70",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -76,53 +41,18 @@
                 "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {
               "version_added": "10",
               "alternative_name": "-ms-grid-rows"
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-end",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-column-end",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-start",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-column-start",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-column",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-end",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-row-end",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-start",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-row-start",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-row",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-areas",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-template-areas",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -125,7 +125,7 @@
             "description": "<code>fit-content()</code>",
             "support": {
               "chrome": {
-                "version_added": "29"
+                "version_added": "57"
               },
               "chrome_android": {
                 "version_added": "57"
@@ -134,10 +134,10 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "51"
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "51"
+                "version_added": "52"
               },
               "ie": {
                 "version_added": false
@@ -252,11 +252,11 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": "76"
+                  "version_added": "79"
                 },
                 {
                   "version_added": "57",
-                  "version_removed": "76",
+                  "version_removed": "79",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
                   "partial_implementation": true
                 },

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -10,34 +10,12 @@
             "https://drafts.csswg.org/css-grid-3/#masonry-layout"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": [
               {
                 "version_added": "16"
@@ -48,70 +26,22 @@
                 "version_removed": "79"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": "10",
               "alternative_name": "-ms-grid-columns"
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -244,100 +174,30 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax",
             "description": "<code>minmax()</code>",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "44"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "43"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
               "safari": {
                 "version_added": "10.1"
               },
@@ -364,34 +224,12 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#funcdef-repeat",
             "description": "<code>repeat()</code>",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
               "edge": {
                 "version_added": "16"
               },
@@ -410,66 +248,34 @@
                   "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
                   "partial_implementation": true
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
                 {
-                  "version_added": "52"
+                  "version_added": "76"
                 },
                 {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "57",
+                  "version_removed": "76",
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
+                  "partial_implementation": true
+                },
+                {
+                  "version_added": "52",
+                  "version_removed": "57",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 }
               ],
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "44"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "43"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
               "safari": {
                 "version_added": "10.1"
               },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -10,34 +10,12 @@
             "https://drafts.csswg.org/css-grid-3/#masonry-layout"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": [
               {
                 "version_added": "16"
@@ -48,70 +26,22 @@
                 "version_removed": "79"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": "10",
               "alternative_name": "-ms-grid-rows"
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -300,100 +230,30 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax",
             "description": "<code>minmax()</code>",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "44"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "43"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
               "safari": {
                 "version_added": "10.1"
               },
@@ -420,34 +280,12 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#funcdef-repeat",
             "description": "<code>repeat()</code>",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
               "edge": {
                 "version_added": "16"
               },
@@ -466,66 +304,34 @@
                   "version_removed": "57",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
                   "partial_implementation": true
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
                 {
-                  "version_added": "52"
+                  "version_added": "76"
                 },
                 {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "57",
+                  "version_removed": "76",
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
+                  "partial_implementation": true
+                },
+                {
+                  "version_added": "52",
+                  "version_removed": "57",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 }
               ],
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "44"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "43"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
               "safari": {
                 "version_added": "10.1"
               },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -125,7 +125,7 @@
             "description": "<code>fit-content()</code>",
             "support": {
               "chrome": {
-                "version_added": "29"
+                "version_added": "57"
               },
               "chrome_android": {
                 "version_added": "57"
@@ -134,10 +134,10 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "51"
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": "51"
+                "version_added": "52"
               },
               "ie": {
                 "version_added": false
@@ -308,11 +308,11 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": "76"
+                  "version_added": "79"
                 },
                 {
                   "version_added": "57",
-                  "version_removed": "76",
+                  "version_removed": "79",
                   "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
                   "partial_implementation": true
                 },

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid-template",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -6,100 +6,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid",
           "spec_url": "https://drafts.csswg.org/css-grid/#propdef-grid",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "10.1"
             },

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -65,16 +65,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "29",
-                  "alternative_name": "grid-row-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "chrome_android": [
@@ -84,15 +74,6 @@
                 {
                   "version_added": "57",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "edge": [
@@ -111,18 +92,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-row-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -132,18 +101,6 @@
                 {
                   "version_added": "52",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "40",
-                  "version_removed": "59",
-                  "alternative_name": "grid-row-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.grid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {
@@ -156,16 +113,6 @@
                 {
                   "version_added": "44",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-row-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "opera_android": [
@@ -175,16 +122,6 @@
                 {
                   "version_added": "43",
                   "alternative_name": "grid-row-gap"
-                },
-                {
-                  "version_added": "28",
-                  "alternative_name": "grid-row-gap",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
                 }
               ],
               "safari": [


### PR DESCRIPTION
These were all enabled more than two years ago and can be removed:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data

The only irregular edit here is for the repeat() features of
grid-template-columns and grid-template-rows. There, the Firefox for
Android data was out of sync with Firefox, and was made to match.

Initial changes produced using @vinyldarkscratch's excellent script:
https://github.com/vinyldarkscratch/browser-compat-data/tree/scripts/remove-redundant-flags