### PR TITLE
Remove old flags for CSS Flexbox

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -45,17 +45,6 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -65,17 +54,6 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -56,28 +56,6 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "version_removed": "20",
-                  "version_added": "18",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -88,28 +66,6 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "version_removed": "20",
-                  "version_added": "18",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -48,30 +48,8 @@
                   "notes": "Before Firefox 27, only single-line flexbox is supported."
                 },
                 {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -80,30 +58,8 @@
                   "notes": "Before Firefox 27, only single-line flexbox is supported."
                 },
                 {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -337,40 +337,14 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Firefox 28 added multi-line flexbox support."
-                },
-                {
-                  "version_added": "18",
-                  "version_removed": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "20",
-                  "notes": "Firefox 28 added multi-line flexbox support."
-                },
-                {
-                  "version_added": "18",
-                  "version_removed": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "20",
+                "notes": "Firefox 28 added multi-line flexbox support."
+              },
+              "firefox_android": {
+                "version_added": "20",
+                "notes": "Firefox 28 added multi-line flexbox support."
+              },
               "ie": [
                 {
                   "version_added": "11",
@@ -636,40 +610,14 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Firefox 28 added multi-line flexbox support."
-                },
-                {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "20",
-                  "notes": "Firefox 28 added multi-line flexbox support."
-                },
-                {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "20",
+                "notes": "Firefox 28 added multi-line flexbox support."
+              },
+              "firefox_android": {
+                "version_added": "20",
+                "notes": "Firefox 28 added multi-line flexbox support."
+              },
               "ie": [
                 {
                   "version_added": "11"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -132,10 +132,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "18"
+                "version_added": "22"
               },
               "firefox_android": {
-                "version_added": "18"
+                "version_added": "22"
               },
               "ie": {
                 "version_added": "11"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -41,28 +41,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -73,28 +51,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -43,30 +43,8 @@
                 ]
               },
               {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -79,30 +57,8 @@
                 ]
               },
               {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -34,17 +34,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -54,17 +43,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -33,40 +33,14 @@
                 "version_added": "12"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "20",
-                "notes": "Since Firefox 28, multi-line flexbox is supported."
-              },
-              {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "20",
-                "notes": "Since Firefox 28, multi-line flexbox is supported."
-              },
-              {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "20",
+              "notes": "Since Firefox 28, multi-line flexbox is supported."
+            },
+            "firefox_android": {
+              "version_added": "20",
+              "notes": "Since Firefox 28, multi-line flexbox is supported."
+            },
             "ie": [
               {
                 "version_added": "11"

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -44,28 +44,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -79,28 +57,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -43,30 +43,8 @@
                 ]
               },
               {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -79,30 +57,8 @@
                 ]
               },
               {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -54,30 +54,8 @@
                   "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
                 },
                 {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -86,30 +64,8 @@
                   "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
                 },
                 {
-                  "version_added": "18",
-                  "version_removed": "20",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.flexbox.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
                   "prefix": "-webkit-",
                   "version_added": "49"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -41,28 +41,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -73,28 +51,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "18",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.flexbox.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [


### PR DESCRIPTION
These were all enabled more than two years ago and can be removed:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data

Initial changes produced using @vinyldarkscratch's excellent script:
https://github.com/vinyldarkscratch/browser-compat-data/tree/scripts/remove-redundant-flags