### PR TITLE
Remove old flags for Firefox CSS features

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -165,36 +165,12 @@
               "edge": {
                 "version_added": "14"
               },
-              "firefox": [
-                {
-                  "version_added": "39"
-                },
-                {
-                  "version_added": "35",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.downloadable_fonts.woff2.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "39"
-                },
-                {
-                  "version_added": "35",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.downloadable_fonts.woff2.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -523,38 +523,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "60",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-variations.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "60",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-variations.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -16,36 +16,12 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },
@@ -88,36 +64,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -161,36 +113,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -233,36 +161,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -306,36 +210,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -379,36 +259,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -452,36 +308,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -525,36 +357,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -19,38 +19,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "17",
-                "version_removed": "22",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.supports-rule.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "17",
-                "version_removed": "22",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.supports-rule.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "22"
+            },
+            "firefox_android": {
+              "version_added": "22"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -200,36 +200,12 @@
                   "notes": "Before Edge 15, this value was supported with the prefixed version of the property only."
                 }
               ],
-              "firefox": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.background-clip-text.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.background-clip-text.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -20,16 +20,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-border-end-color"
               }
@@ -37,16 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -20,16 +20,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-border-end-style"
               }
@@ -37,16 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -20,16 +20,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-border-end-width"
               }
@@ -37,16 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -20,16 +20,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-border-start-color"
               }
@@ -37,16 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -20,16 +20,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-border-start-style"
               }
@@ -37,16 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -163,38 +163,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "54"
-                },
-                {
-                  "version_added": "47",
-                  "version_removed": "54",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-shapes.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "54"
-                },
-                {
-                  "version_added": "47",
-                  "version_removed": "54",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-shapes.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -38,42 +38,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "29",
-                "version_removed": "55",
-                "partial_implementation": true,
-                "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.variables.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "29",
-                "version_removed": "55",
-                "partial_implementation": true,
-                "notes": "From Firefox 29 until Firefox 31, this feature was implemented by the <code>var-variablename</code> syntax.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.variables.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": false
             },
@@ -203,38 +173,12 @@
               "edge": {
                 "version_added": "15"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "29",
-                  "version_removed": "55",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.variables.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "29",
-                  "version_removed": "55",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.variables.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1055,38 +1055,12 @@
                 "version_added": "12",
                 "version_removed": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "34",
-                  "version_removed": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.ruby.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "34",
-                  "version_removed": "38",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.ruby.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "38"
+              },
+              "firefox_android": {
+                "version_added": "38"
+              },
               "ie": {
                 "version_added": "7"
               },

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -29,38 +29,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -20,17 +20,6 @@
                 "version_added": "34"
               },
               {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "4"
               }
@@ -38,17 +27,6 @@
             "firefox_android": [
               {
                 "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -15,22 +15,9 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "33",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
             "firefox_android": {
               "version_added": "34"
             },

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -14,38 +14,12 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },
@@ -88,38 +62,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -163,38 +111,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -238,38 +160,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -313,38 +209,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -388,38 +258,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },
@@ -463,38 +307,12 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -27,38 +27,12 @@
                 "version_added": "79"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-features.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -62,38 +62,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "33",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "34"
-                },
-                {
-                  "version_added": "33",
-                  "version_removed": "34",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-features.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-variations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },
@@ -90,11 +64,11 @@
               },
               "firefox": {
                 "prefix": "-moz-",
-                "version_added": "38"
+                "version_added": "41"
               },
               "firefox_android": {
                 "prefix": "-moz-",
-                "version_added": "38"
+                "version_added": "41"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-block-end",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-block-end",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-block-start",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-block-start",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-block",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-block",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-inline-end",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-inline-end",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-inline-start",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-inline-start",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -54,17 +54,6 @@
                 "alternative_name": "offset-inline",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -75,17 +64,6 @@
                 "alternative_name": "offset-inline",
                 "version_added": "41",
                 "version_removed": "63"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -38,17 +38,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-margin-end"
               }
@@ -56,17 +45,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -38,17 +38,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-margin-start"
               }
@@ -56,17 +45,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },
@@ -102,11 +76,11 @@
               },
               "firefox": {
                 "prefix": "-moz-",
-                "version_added": "38"
+                "version_added": "41"
               },
               "firefox_android": {
                 "prefix": "-moz-",
-                "version_added": "38"
+                "version_added": "41"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -38,17 +38,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-padding-end"
               }
@@ -56,17 +45,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -38,17 +38,6 @@
                 "version_added": "41"
               },
               {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "3",
                 "alternative_name": "-moz-padding-start"
               }
@@ -56,17 +45,6 @@
             "firefox_android": [
               {
                 "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "4",

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -217,38 +217,12 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "32"
-                },
-                {
-                  "version_added": "26",
-                  "version_removed": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.sticky.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "32"
-                },
-                {
-                  "version_added": "26",
-                  "version_removed": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.sticky.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": {
+                "version_added": "32"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -56,29 +56,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "31",
-                "version_removed": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "26",
-                "version_removed": "31",
-                "alternative_name": "text-combine-horizontal",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -96,29 +73,6 @@
                   {
                     "type": "preference",
                     "name": "layout.css.text-combine-upright.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "31",
-                "version_removed": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "26",
-                "version_removed": "31",
-                "alternative_name": "text-combine-horizontal",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
                     "value_to_set": "true"
                   }
                 ]

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -33,38 +33,12 @@
                 "version_added": "79"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "38",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "41"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -33,40 +33,14 @@
                 "version_added": "12"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "41",
-                "notes": "Firefox 42 added support for bidirectional and RTL scripts in vertical modes."
-              },
-              {
-                "version_added": "36",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "41",
-                "notes": "Firefox 42 added support for bidirectional and RTL scripts in vertical modes."
-              },
-              {
-                "version_added": "36",
-                "version_removed": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.vertical-text.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "41",
+              "notes": "Firefox 42 added support for bidirectional and RTL scripts in vertical modes."
+            },
+            "firefox_android": {
+              "version_added": "41",
+              "notes": "Firefox 42 added support for bidirectional and RTL scripts in vertical modes."
+            },
             "ie": [
               {
                 "version_added": "9",


### PR DESCRIPTION
These were all enabled more than two years ago and can be removed:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data

Initial changes produced using @vinyldarkscratch's excellent script:
https://github.com/vinyldarkscratch/browser-compat-data/tree/scripts/remove-redundant-flags