### PR TITLE
Add Edge versions for CanvasCaptureMediaStreamTrack API

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -11,7 +11,7 @@
             "version_added": "51"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "41",
@@ -134,7 +134,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CanvasCaptureMediaStreamTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasCaptureMediaStreamTrack
