### PR TITLE
Add Edge versions for CanvasRenderingContext2D API

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2207,7 +2207,7 @@
               "version_added": "54"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D
