### PR TITLE
Add Edge versions for DataTransfer API

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -61,7 +61,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "62"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `DataTransfer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransfer
