### PR TITLE
Add Edge versions for DedicatedWorkerGlobalScope API

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -204,7 +204,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "55"
@@ -300,7 +300,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "57"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `DedicatedWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DedicatedWorkerGlobalScope
