### PR TITLE
Add Edge versions for DeviceMotionEvent API

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -59,7 +59,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `DeviceMotionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEvent
