### PR TITLE
Add Edge versions for EventTarget API

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -64,7 +64,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `EventTarget` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EventTarget
