### PR TITLE
:user-valid and :user-invalid updates

### DIFF
--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -16,14 +16,24 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
+            "firefox": [
+              {
+                "version_added": "88"
+              },
+              {
               "version_added": "4",
-              "alternative_name": "::-moz-ui-invalid"
-            },
-            "firefox_android": {
+              "alternative_name": ":-moz-ui-invalid"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "88"
+              },
+              {
               "version_added": "4",
-              "alternative_name": "::-moz-ui-invalid"
-            },
+              "alternative_name": ":-moz-ui-invalid"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -21,8 +21,8 @@
                 "version_added": "88"
               },
               {
-              "version_added": "4",
-              "alternative_name": ":-moz-ui-invalid"
+                "version_added": "4",
+                "alternative_name": ":-moz-ui-invalid"
               }
             ],
             "firefox_android": [

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -30,8 +30,8 @@
                 "version_added": "88"
               },
               {
-              "version_added": "4",
-              "alternative_name": ":-moz-ui-invalid"
+                "version_added": "4",
+                "alternative_name": ":-moz-ui-invalid"
               }
             ],
             "ie": {

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -1,10 +1,11 @@
 {
   "css": {
     "selectors": {
-      "-moz-ui-valid": {
+      "user-valid": {
         "__compat": {
-          "description": "<code>:-moz-ui-valid</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-ui-valid",
+          "description": "<code>:user-valid</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:user-valid",
+          "spec_url": "https://drafts.csswg.org/selectors/#user-valid-pseudo",
           "support": {
             "chrome": {
               "version_added": false
@@ -15,12 +16,24 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "88"
+              },
+              {
+              "version_added": "4",
+              "alternative_name": ":-moz-ui-valid"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "88"
+              },
+              {
+              "version_added": "4",
+              "alternative_name": ":-moz-ui-valid"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -44,8 +57,8 @@
             }
           },
           "status": {
-            "experimental": false,
-            "standard_track": false,
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -21,8 +21,8 @@
                 "version_added": "88"
               },
               {
-              "version_added": "4",
-              "alternative_name": ":-moz-ui-valid"
+                "version_added": "4",
+                "alternative_name": ":-moz-ui-valid"
               }
             ],
             "firefox_android": [

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -30,8 +30,8 @@
                 "version_added": "88"
               },
               {
-              "version_added": "4",
-              "alternative_name": ":-moz-ui-valid"
+                "version_added": "4",
+                "alternative_name": ":-moz-ui-valid"
               }
             ],
             "ie": {


### PR DESCRIPTION
This PR:

- adds `:user-valid`
- removes `:-moz-ui-valid`
- updates Firefox data for `:user-invalid` and fixes the alternate name (it's a pseudo-class not pseudo-element, so one colon.)

Part of https://github.com/mdn/content/issues/3455
