### PR TITLE
Add Edge versions for FocusEvent API

### DIFF
--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "24"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FocusEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FocusEvent
