### PR TITLE
Add Edge versions for ClipboardItem API

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -11,7 +11,7 @@
             "version_added": "66"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "87",
@@ -77,7 +77,7 @@
               "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data. Full implementation would also allow for a string or a Promise which resolves with either a string or blob. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "partial_implementation": true,
               "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
             },
@@ -149,7 +149,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "87",
@@ -273,7 +273,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "87",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ClipboardItem` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ClipboardItem
