### PR TITLE
Add Edge versions for FileError API

### DIFF
--- a/api/FileError.json
+++ b/api/FileError.json
@@ -15,7 +15,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": true,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileError
