### PR TITLE
Add Edge versions for HTMLSelectElement API

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -263,7 +263,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -407,7 +407,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `HTMLSelectElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLSelectElement
