### PR TITLE
Add WebView versions for IDBCursorWithValue API

### DIFF
--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -68,10 +68,10 @@
           ],
           "webview_android": [
             {
-              "version_added": true
+              "version_added": "≤37"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "57",
               "prefix": "webkit"
             }


### PR DESCRIPTION
This PR adds real values for WebView Android for the `IDBCursorWithValue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBCursorWithValue
