### PR TITLE
Fix phantom "Experimental productivity features" in Chrome

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -763,34 +763,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/legacy-image-formats",
             "support": {
               "chrome": {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -802,24 +781,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -836,7 +801,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -812,34 +812,13 @@
             "spec_url": "https://w3c.github.io/permissions/#magnetometer",
             "support": {
               "chrome": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "chrome_android": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -851,24 +830,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "54"
               },
               "opera_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -1021,34 +986,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/oversized-images",
             "support": {
               "chrome": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1060,24 +1004,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "50",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1094,7 +1024,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1289,34 +1289,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/unsized-media",
             "support": {
               "chrome": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1328,24 +1307,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "47",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1354,7 +1319,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "9.0"
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -1362,7 +1327,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -73,34 +73,13 @@
             "spec_url": "https://w3c.github.io/permissions/#accelerometer",
             "support": {
               "chrome": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "chrome_android": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -112,24 +91,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "54"
               },
               "opera_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -141,7 +106,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "67"
               }
             },
             "status": {
@@ -157,34 +122,13 @@
             "spec_url": "https://w3c.github.io/permissions/#ambient-light-sensor",
             "support": {
               "chrome": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "chrome_android": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -196,24 +140,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "54"
               },
               "opera_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -225,7 +155,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "67"
               }
             },
             "status": {
@@ -737,34 +667,13 @@
             "spec_url": "https://w3c.github.io/permissions/#gyroscope",
             "support": {
               "chrome": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "chrome_android": {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "67"
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -776,24 +685,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "54"
               },
               "opera_android": {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -805,7 +700,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "67"
               }
             },
             "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1241,34 +1241,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/unoptimized-images",
             "support": {
               "chrome": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1280,24 +1259,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "50",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1314,7 +1279,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }


### PR DESCRIPTION
Investigating #9499 uncovered a complex problem relating to `Feature-Policy` features reported to be behind flags. This mostly cleans up after the mess.

The story thus far:

1. [As of Chrome 89](https://storage.googleapis.com/chromium-find-releases-static/198.html#19853a06c5b767f2ec26dc17de209757e5877d5e), there's no more _Experimental productivity features_ flag. This suggested that any entry with this flag still supported was suspect. It turned out these were all features of `http.headers.Feature-Policy`.
2. The permissions for `accelerometer`, `ambient-light-sensor`, and `gyroscope` were all reported as being behind flags, even though they were [enabled in Chrome 67](https://storage.googleapis.com/chromium-find-releases-static/b90.html#b90312615c24b59834bfbb2f648bf1e3e9187065) (the corresponding APIs were already up-to-date). I've corrected those.
3. Some other permissions were like `legacy-image-format`: reportedly behind a flag according to Chrome Platform Status, but no further public information provided (see individual commits for details). These features have been dropped from the Permissions Policy (former Feature Policy) spec. Since I could not substantiate any sort of support for them, I decided to mark them as wholly unsupported.

   As a consequence, these features are now all-`false`. These now-fictitious features should also be dropped from MDN, so I thought I'd take care of both BCD and MDN removals in follow-up PRs.

I expect much of this stuff to change when the renaming for Permissions Policy is done (see #9556), but hopefully this will make the alt name stuff apply more gracefully.

Merging this will fix #9499.