### PR TITLE
Remove irrelevant flags in Firefox for AnimationTimeline API

### DIFF
--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -26,17 +26,6 @@
                   "value_to_set": "true"
                 }
               ]
-            },
-            {
-              "version_added": "48",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
-                  "value_to_set": "true"
-                }
-              ]
             }
           ],
           "firefox_android": [
@@ -49,17 +38,6 @@
                 {
                   "type": "preference",
                   "name": "dom.animations-api.timelines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "48",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled",
                   "value_to_set": "true"
                 }
               ]
@@ -119,17 +97,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -142,17 +109,6 @@
                   {
                     "type": "preference",
                     "name": "dom.animations-api.timelines.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled",
                     "value_to_set": "true"
                   }
                 ]


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `AnimationTimeline` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
