### PR TITLE
Remove irrelevant flags in Firefox for ByteLengthQueuingStrategy API

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -13,46 +13,12 @@
           "edge": {
             "version_added": "16"
           },
-          "firefox": [
-            {
-              "version_added": "65"
-            },
-            {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "javascript.options.streams",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "65"
-            },
-            {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "javascript.options.streams",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "65"
+          },
+          "firefox_android": {
+            "version_added": "65"
+          },
           "ie": {
             "version_added": false
           },
@@ -95,46 +61,12 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
             "ie": {
               "version_added": false
             },
@@ -176,50 +108,16 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "65",
-                "partial_implementation": true,
-                "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65",
-                "partial_implementation": true,
-                "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65",
+              "partial_implementation": true,
+              "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>"
+            },
+            "firefox_android": {
+              "version_added": "65",
+              "partial_implementation": true,
+              "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>"
+            },
             "ie": {
               "version_added": false
             },
@@ -262,46 +160,12 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "65"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.streams.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.streams",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `ByteLengthQueuingStrategy` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
