### PR TITLE
Remove irrelevant flags in all browsers for CanvasRenderingContext2D API

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -880,9 +880,20 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/direction",
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": "39",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": "77"
             },
@@ -898,9 +909,20 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "64"
-            },
+            "opera": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "26",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": "55"
             },

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -880,20 +880,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/direction",
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "77"
+            },
             "chrome_android": {
               "version_added": "77"
             },
@@ -909,20 +898,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "64"
-              },
-              {
-                "version_added": "26",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "64"
+            },
             "opera_android": {
               "version_added": "55"
             },
@@ -964,15 +942,6 @@
                 "version_added": "32"
               },
               {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.focusring.enabled"
-                  }
-                ]
-              },
-              {
                 "version_added": "28",
                 "alternative_name": "drawSystemFocusRing"
               }
@@ -980,15 +949,6 @@
             "firefox_android": [
               {
                 "version_added": "32"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.focusring.enabled"
-                  }
-                ]
               },
               {
                 "version_added": "28",
@@ -1663,38 +1623,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.filters.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.filters.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for all browsers for the `CanvasRenderingContext2D` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
