### PR TITLE
Remove irrelevant flags in Firefox for Crypto API

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -116,38 +116,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `Crypto` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
