### PR TITLE
Remove irrelevant flags in Firefox for CSS API

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -13,34 +13,12 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "20",
-              "flags": [
-                {
-                  "name": "layout.css.supports-rule.enabled",
-                  "type": "preference"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "version_added": "20",
-              "flags": [
-                {
-                  "name": "layout.css.supports-rule.enabled",
-                  "type": "preference"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "22"
+          },
+          "firefox_android": {
+            "version_added": "22"
+          },
           "ie": {
             "version_added": false
           },
@@ -1553,16 +1531,6 @@
                 "version_added": "22",
                 "partial_implementation": true,
                 "notes": "Version 54 or older didn't support parentheses-less one-argument version."
-              },
-              {
-                "version_added": "20",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "name": "layout.css.supports-rule.enabled",
-                    "type": "preference"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -1573,16 +1541,6 @@
                 "version_added": "22",
                 "partial_implementation": true,
                 "notes": "Version 54 or older didn't support parentheses-less one-argument version."
-              },
-              {
-                "version_added": "20",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "name": "layout.css.supports-rule.enabled",
-                    "type": "preference"
-                  }
-                ]
               }
             ],
             "ie": {


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `CSS` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
