### PR TITLE
Remove irrelevant flags in Firefox for api.Document.*fullscreen

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5301,17 +5301,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "49",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": "mozFullScreen"
@@ -5320,17 +5309,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "49",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "9",
@@ -5424,17 +5402,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "10",
                 "version_removed": "64",
                 "alternative_name": "mozfullscreenchange"
@@ -5443,17 +5410,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "10",
@@ -5527,17 +5483,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "10",
                 "version_removed": "65",
                 "alternative_name": "mozFullScreenEnabled"
@@ -5546,17 +5491,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "10",
@@ -5639,17 +5573,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "10",
                 "version_removed": "64",
                 "alternative_name": "mozfullscreenerror"
@@ -5658,17 +5581,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "10",
@@ -7597,17 +7509,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "10",
                 "version_removed": "65",
                 "alternative_name": "onmozfullscreenchange"
@@ -7616,17 +7517,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "10",
@@ -7702,17 +7592,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "10",
                 "version_removed": "65",
                 "alternative_name": "onmozfullscreenerror"
@@ -7721,17 +7600,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "10",

--- a/api/Document.json
+++ b/api/Document.json
@@ -4549,17 +4549,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "49",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": "mozCancelFullScreen"
@@ -4568,17 +4557,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "49",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "9",


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the fullscreen-related members of the `Document` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
