### PR TITLE
String.prototype.replace is not fully supported until IE5.5 (#8908)

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1824,9 +1824,17 @@
               "firefox_android": {
                 "version_added": "4"
               },
-              "ie": {
-                "version_added": "4"
-              },
+              "ie": [
+                {
+                  "version_added": "5.5"
+                },
+                {
+                  "version_added": "4",
+                  "version_removed": "5.5",
+                  "partial_implementation": true,
+                  "notes": "A replacement function as second argument is not supported."
+                }
+              ],
               "nodejs": {
                 "version_added": "0.10.0"
               },


### PR DESCRIPTION
This patch refines IE support of String.prototype.replace. The method was found not to be fully supported until IE5.5.