### PR TITLE
Remove irrelevant full-screen-api.unprefix.enabled flag

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6632,17 +6632,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
@@ -6652,17 +6641,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "9",

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -253,17 +253,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": "mozFullScreenElement"
@@ -272,17 +261,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "9",


### PR DESCRIPTION
This PR removes irrelevant flag data (specifically `full-screen-api.unprefix.enabled`) for Firefox and Firefox Android for the fullscreen-related members of the `Document` and `Element` APIs as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
