### PR TITLE
Remove irrelevant flags in Firefox for CSSPseudoElement API

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -32,39 +32,17 @@
                   "name": "dom.animations-api.getAnimations.enabled"
                 }
               ]
-            },
-            {
-              "version_added": "47",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled"
-                }
-              ]
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.getAnimations.enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "47",
-              "version_removed": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.animations-api.core.enabled"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "63",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.animations-api.getAnimations.enabled"
+              }
+            ]
+          },
           "ie": {
             "version_added": false
           },
@@ -136,17 +114,6 @@
                     "name": "dom.animations-api.getAnimations.enabled"
                   }
                 ]
-              },
-              {
-                "alternative_name": "parentElement",
-                "version_added": "47",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -167,17 +134,6 @@
                   {
                     "type": "preference",
                     "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "parentElement",
-                "version_added": "47",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
                   }
                 ]
               }
@@ -243,39 +199,17 @@
                     "name": "dom.animations-api.getAnimations.enabled"
                   }
                 ]
-              },
-              {
-                "version_added": "47",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "47",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.getAnimations.enabled"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `CSSPseudoElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
