### PR TITLE
Remove irrelevant flags in Firefox for api.Document.scrollingElement

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10275,36 +10275,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "48"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.document.scrollingElement.enabled"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "48"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.document.scrollingElement.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `scrollingElement` member of the `Document` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
