### PR TITLE
Remove irrelevant flags in Firefox for api.Element.*animation

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -700,39 +700,17 @@
                       "name": "dom.animations-api.compositing.enabled"
                     }
                   ]
-                },
-                {
-                  "version_added": "53",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.core.enabled"
-                    }
-                  ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.compositing.enabled"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "53",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.core.enabled"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.compositing.enabled"
+                  }
+                ]
+              },
               "ie": {
                 "version_added": false
               },
@@ -897,39 +875,17 @@
                       "name": "dom.animations-api.compositing.enabled"
                     }
                   ]
-                },
-                {
-                  "version_added": "51",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.core.enabled"
-                    }
-                  ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.compositing.enabled"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "51",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.animations-api.core.enabled"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.compositing.enabled"
+                  }
+                ]
+              },
               "ie": {
                 "version_added": false
               },
@@ -3528,54 +3484,6 @@
                     "name": "dom.animations-api.getAnimations.enabled"
                   }
                 ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "40",
-                "version_removed": "48",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "35",
-                "version_removed": "40",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "33",
-                "version_removed": "35",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -3588,54 +3496,6 @@
                   {
                     "type": "preference",
                     "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "48",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "40",
-                "version_removed": "48",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "35",
-                "version_removed": "40",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "33",
-                "version_removed": "35",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.core.enabled"
                   }
                 ]
               }


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `animation` members of the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
