### PR TITLE
Remove irrelevant flags in Chromium for api.Element.animation

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3423,31 +3423,6 @@
                     "name": "Experimental Web Platform Features"
                   }
                 ]
-              },
-              {
-                "version_added": "44",
-                "version_removed": "67",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "38",
-                "version_removed": "44",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -3468,31 +3443,6 @@
                 "version_removed": "79",
                 "partial_implementation": true,
                 "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "44",
-                "version_removed": "67",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "38",
-                "version_removed": "44",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",
@@ -3667,31 +3617,6 @@
                     "name": "Experimental Web Platform Features"
                   }
                 ]
-              },
-              {
-                "version_added": "31",
-                "version_removed": "54",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "25",
-                "version_removed": "31",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
               }
             ],
             "opera_android": [
@@ -3712,31 +3637,6 @@
                 "version_removed": "57",
                 "partial_implementation": true,
                 "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "32",
-                "version_removed": "48",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "25",
-                "version_removed": "32",
-                "partial_implementation": true,
-                "notes": "Does not automatically flush pending style changes and does not support the <code>subtree</code> option.",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `animation` member of the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
