### PR TITLE
Remove irrelevant flags in Chromium for FeaturePolicy API

### DIFF
--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -18,18 +18,6 @@
                   "value_to_set": "Enabled"
                 }
               ]
-            },
-            {
-              "version_added": "69",
-              "version_removed": "73",
-              "alternative_name": "Policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
             }
           ],
           "chrome_android": [
@@ -39,18 +27,6 @@
             {
               "version_added": "73",
               "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "69",
-              "version_removed": "73",
-              "alternative_name": "Policy",
               "flags": [
                 {
                   "type": "preference",
@@ -150,38 +126,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowedFeatures",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -258,38 +208,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowsFeature",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -421,38 +345,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/getAllowlistForFeature",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FeaturePolicy` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
