### PR TITLE
Remove irrelevant flags in Firefox for Gamepad API

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -27,22 +27,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "24",
-              "version_removed": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "29"
+          },
           "firefox_android": {
             "version_added": "32"
           },
@@ -122,22 +109,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -218,22 +192,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -314,22 +275,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -572,22 +520,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -668,22 +603,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -764,22 +686,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -909,22 +818,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -20,22 +20,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "24",
-              "version_removed": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "29"
+          },
           "firefox_android": {
             "version_added": "32"
           },
@@ -101,22 +88,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -231,22 +205,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -27,22 +27,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "24",
-              "version_removed": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.gamepad.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "29"
+          },
           "firefox_android": {
             "version_added": "32"
           },
@@ -102,22 +89,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },
@@ -177,22 +151,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.gamepad.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "29"
+            },
             "firefox_android": {
               "version_added": "32"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `Gamepad` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
