### PR TITLE
Remove irrelevant flags in Firefox for HMDVRDevice API

### DIFF
--- a/api/HMDVRDevice.json
+++ b/api/HMDVRDevice.json
@@ -24,23 +24,10 @@
             ],
             "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
           },
-          "firefox_android": [
-            {
-              "version_added": "44",
-              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-            },
-            {
-              "version_added": "39",
-              "version_removed": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.vr*"
-                }
-              ],
-              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
-            }
-          ],
+          "firefox_android": {
+            "version_added": "44",
+            "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+          },
           "ie": {
             "version_added": false
           },
@@ -93,23 +80,10 @@
               ],
               "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
             },
-            "firefox_android": [
-              {
-                "version_added": "44",
-                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-              },
-              {
-                "version_added": "39",
-                "version_removed": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.vr*"
-                  }
-                ],
-                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
             "ie": {
               "version_added": false
             },
@@ -163,23 +137,10 @@
               ],
               "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>"
             },
-            "firefox_android": [
-              {
-                "version_added": "44",
-                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-              },
-              {
-                "version_added": "39",
-                "version_removed": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.vr*"
-                  }
-                ],
-                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HMDVRDevice` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
