### PR TITLE
Remove irrelevant flags in Firefox for HTMLIFrameElement API

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -429,18 +429,6 @@
                     "value_to_set": "Enabled"
                   }
                 ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -450,18 +438,6 @@
               {
                 "version_added": "73",
                 "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLIFrameElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
