### PR TITLE
Remove irrelevant flags in Firefox for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -347,38 +347,12 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.srcset.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.srcset.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -1094,38 +1068,12 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.picture.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.picture.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -1216,38 +1164,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.srcset.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "name": "dom.image.srcset.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLImageElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
