### PR TITLE
Remove irrelevant flags in Firefox for HTMLPictureElement API

### DIFF
--- a/api/HTMLPictureElement.json
+++ b/api/HTMLPictureElement.json
@@ -13,38 +13,12 @@
           "edge": {
             "version_added": "13"
           },
-          "firefox": [
-            {
-              "version_added": "38"
-            },
-            {
-              "version_added": "32",
-              "version_removed": "52",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.image.picture.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "38"
-            },
-            {
-              "version_added": "32",
-              "version_removed": "52",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.image.picture.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "38"
+          },
+          "firefox_android": {
+            "version_added": "38"
+          },
           "ie": {
             "version_added": false
           },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLPictureElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
