### PR TITLE
Remove irrelevant flags in Firefox for HTMLScriptElement API

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -389,38 +389,12 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "55",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "55",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.moduleScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": "60"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLScriptElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
