### PR TITLE
Remove irrelevant flags in Firefox for HTMLSourceElement API

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -167,36 +167,12 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },
@@ -287,36 +263,12 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "33",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLSourceElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
