### PR TITLE
Remove irrelevant flags in Firefox for HTMLTrackElement API

### DIFF
--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -13,40 +13,14 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "31",
-              "notes": "Prior to Firefox 50, text tracks would only load if the <track> element is in a document."
-            },
-            {
-              "version_added": "24",
-              "version_removed": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webvtt.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "31",
-              "notes": "Prior to Firefox 50, text tracks would only load if the <track> element is in a document."
-            },
-            {
-              "version_added": "24",
-              "version_removed": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webvtt.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "31",
+            "notes": "Prior to Firefox 50, text tracks would only load if the <track> element is in a document."
+          },
+          "firefox_android": {
+            "version_added": "31",
+            "notes": "Prior to Firefox 50, text tracks would only load if the <track> element is in a document."
+          },
           "ie": {
             "version_added": "10"
           },
@@ -137,38 +111,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -211,38 +159,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -285,38 +207,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -359,38 +255,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -433,40 +303,14 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31",
-                "notes": "Setting the <code>src</code> property did not work properly in versions prior to 50."
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31",
-                "notes": "Setting the <code>src</code> property did not work properly in versions prior to 50."
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31",
+              "notes": "Setting the <code>src</code> property did not work properly in versions prior to 50."
+            },
+            "firefox_android": {
+              "version_added": "31",
+              "notes": "Setting the <code>src</code> property did not work properly in versions prior to 50."
+            },
             "ie": {
               "version_added": "10"
             },
@@ -509,38 +353,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -583,38 +401,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLTrackElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
