### PR TITLE
Remove irrelevant flags in Firefox for HTMLVideoElement API

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -254,22 +254,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "42"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLVideoElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
