### PR TITLE
Remove irrelevant flags in Firefox for IdleDeadline API

### DIFF
--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -13,36 +13,12 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": [
-            {
-              "version_added": "55"
-            },
-            {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.requestIdleCallback.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "55"
-            },
-            {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.requestIdleCallback.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "55"
+          },
+          "firefox_android": {
+            "version_added": "55"
+          },
           "ie": {
             "version_added": false
           },
@@ -84,36 +60,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -156,36 +108,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `IdleDeadline` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
