### PR TITLE
Remove irrelevant flags in all browsers for MediaDevices API

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -175,23 +175,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia",
           "description": "<code>getDisplayMedia()</code>",
           "support": {
-            "chrome": [
-              {
-                "version_added": "72"
-              },
-              {
-                "version_added": "70",
-                "version_removed": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Chrome 70 and 71."
-              }
-            ],
+            "chrome": {
+              "version_added": "72"
+            },
             "chrome_android": {
               "version_added": false
             },
@@ -486,23 +472,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "51",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.ondevicechange.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "<code>MediaDevices.ondevicechange</code> is supported only on macOS."
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
             "firefox_android": {
               "version_added": true
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for all browsers for the `MediaDevices` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
