### PR TITLE
Remove irrelevant flags in Firefox for MediaSource API

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -27,22 +27,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "25",
-              "version_removed": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.mediasource.enabled"
-                }
-              ],
-              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-            }
-          ],
+          "firefox": {
+            "version_added": "42"
+          },
           "firefox_android": {
             "version_added": "41"
           },
@@ -116,22 +103,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -178,22 +152,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -240,22 +201,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -347,22 +295,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -409,22 +344,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -471,22 +393,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -584,22 +493,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -646,22 +542,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -708,22 +591,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -770,22 +640,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },
@@ -877,22 +734,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": "41"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `MediaSource` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
