### PR TITLE
Remove irrelevant flags in all browsers for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -253,17 +253,6 @@
                 "version_added": "11",
                 "version_removed": "16",
                 "prefix": "moz"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -279,17 +268,6 @@
                 "version_added": "14",
                 "version_removed": "16",
                 "prefix": "moz"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.battery.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {
@@ -2450,20 +2428,9 @@
             "chrome_android": {
               "version_added": "40"
             },
-            "edge": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "16",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable service workers"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "17"
+            },
             "firefox": {
               "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."


### PR DESCRIPTION
This PR removes irrelevant flag data for all browsers for the `Navigator` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
