### PR TITLE
Remove irrelevant flags in Chromium for PaymentCurrencyAmount API

### DIFF
--- a/api/PaymentCurrencyAmount.json
+++ b/api/PaymentCurrencyAmount.json
@@ -4,38 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentCurrencyAmount",
         "support": {
-          "chrome": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "56"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "56"
+          },
+          "chrome_android": {
+            "version_added": "56"
+          },
           "edge": {
             "version_added": "≤79"
           },
@@ -103,38 +77,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentCurrencyAmount/currency",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
             "edge": {
               "version_added": "≤79"
             },
@@ -259,38 +207,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentCurrencyAmount/value",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#web-payments",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
             "edge": {
               "version_added": "≤79"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PaymentCurrencyAmount` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
