### PR TITLE
Update browser support for file-selector-button

### DIFF
--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": false
+                "version_added": "89"
               },
               {
                 "version_added": "1",
@@ -17,7 +17,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": false
+                "version_added": "89"
               },
               {
                 "version_added": "18",
@@ -26,7 +26,7 @@
             ],
             "edge": [
               {
-                "version_added": false
+                "version_added": "89"
               },
               {
                 "version_added": "79",
@@ -44,7 +44,7 @@
             },
             "opera": [
               {
-                "version_added": false
+                "version_added": "75"
               },
               {
                 "version_added": "15",
@@ -89,7 +89,7 @@
             ],
             "webview_android": [
               {
-                "version_added": false
+                "version_added": "89"
               },
               {
                 "version_added": "1",


### PR DESCRIPTION
As of version 89 Chrome now supports the file-selector-button pseudo element. So I've added Chrome (desktop and Android), Edge and Android Webview support. As well as Opera (desktop only because the Android app didn't work with the jsfiddle)

Safari TP as of 119 also supports it: https://webkit.org/blog/11525/release-notes-for-safari-technology-preview-119/ however I don't think that TP features get added. Happy to update it if I'm wrong.

I tested with this jsfiddle: https://jsfiddle.net/jtcnurwo/

Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1086855

The commit from the listed bug in the release finder: https://storage.googleapis.com/chromium-find-releases-static/026.html#026588642150a261b2afee6e84073eba9299b24e
