### PR TITLE
Remove remaining cases of Firefox's full-screen-api.unprefix flag

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -33,17 +33,6 @@
                 "version_added": "64"
               },
               {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "9",
                 "version_removed": "65",
                 "alternative_name": ":-moz-full-screen"
@@ -52,17 +41,6 @@
             "firefox_android": [
               {
                 "version_added": "64"
-              },
-              {
-                "version_added": "47",
-                "version_removed": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "full-screen-api.unprefix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "version_added": "9",


### PR DESCRIPTION
The other cases were recently removed:
https://github.com/mdn/browser-compat-data/pull/9721
https://github.com/mdn/browser-compat-data/pull/9727

Allowed by this guidline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data