### PR TITLE
AbortSignal is not experimental

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -45,7 +45,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -95,7 +95,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -147,7 +147,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -198,7 +198,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -249,7 +249,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This changes AbortSignal and subfeatures from experimental "true" to "false". As discussed in https://github.com/mdn/browser-compat-data/pull/9648#issuecomment-809968402 the feature is supported across more than 3 browser engines.