### PR TITLE
Add protocol_handlers subfeature ftp

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -499,7 +499,7 @@
               "firefox_android": [
                 {
                   "version_added": "56",
-                  "version_removed": "71"
+                  "version_removed": "79"
                 },
                 {
                   "alternative_name": "registerProxyScript",
@@ -565,7 +565,7 @@
               },
               "firefox_android": {
                 "version_added": "56",
-                "version_removed": "71"
+                "version_removed": "79"
               },
               "opera": {
                 "version_added": false

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -489,11 +489,12 @@
               "firefox": [
                 {
                   "version_added": "56",
-                  "version_removed": "71"
+                  "version_removed": "79"
                 },
                 {
                   "alternative_name": "registerProxyScript",
-                  "version_added": "55"
+                  "version_added": "55",
+                  "version_removed": "71"
                 }
               ],
               "firefox_android": [
@@ -503,7 +504,8 @@
                 },
                 {
                   "alternative_name": "registerProxyScript",
-                  "version_added": "55"
+                  "version_added": "55",
+                  "version_removed": "79"
                 }
               ],
               "opera": {
@@ -531,11 +533,8 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": [
-                  "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but it had a bug that made it mostly unusable.",
-                  "From version 88 the <code>ftp</code> setting has no effect, because FTP is not longer supported (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
-                ],
-                "version_added": "60"
+                "version_added": "60",
+                "notes": "From version 88, the <code>ftp</code> setting has no effect because FTP is no longer supported (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -530,7 +530,10 @@
                 "version_added": false
               },
               "firefox": {
-                "notes": "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but it had a bug that made it mostly unusable.",
+                "notes": [
+                  "In version 59, this property was listed as <code>proxyConfig</code> in the <code>browserSettings</code> namespace, but it had a bug that made it mostly unusable.",
+                  "From version 88 the <code>ftp</code> setting has no effect, because FTP is not longer supported (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
+                ],
                 "version_added": "60"
               },
               "firefox_android": {

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -498,7 +498,8 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "version_removed": "71"
                 },
                 {
                   "alternative_name": "registerProxyScript",
@@ -563,7 +564,8 @@
                 "version_removed": "71"
               },
               "firefox_android": {
-                "version_added": "56"
+                "version_added": "56",
+                "version_removed": "71"
               },
               "opera": {
                 "version_added": false

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -489,7 +489,7 @@
               "firefox": [
                 {
                   "version_added": "56",
-                  "version_removed": "79"
+                  "version_removed": "71"
                 },
                 {
                   "alternative_name": "registerProxyScript",

--- a/webextensions/manifest/protocol_handlers.json
+++ b/webextensions/manifest/protocol_handlers.json
@@ -73,6 +73,30 @@
             }
           }
         },
+        "ftp": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "88"
+              },
+              "firefox_android": {
+                "version_added": "88"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "gopher": {
           "__compat": {
             "support": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1626365#c10 FF88
- adds ftp to the list of protocol_handlers. Associated MDN page https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers.
- removes any action if you set FTP in the proxy settings (i.e. you can still set it but it has not effect)

This is part of FF88 removing support for FTP (doc tracking in https://github.com/mdn/content/issues/3462)
