### PR TITLE
Remove irrelevant flags in Firefox for PositionSensorVRDevice API

### DIFF
--- a/api/PositionSensorVRDevice.json
+++ b/api/PositionSensorVRDevice.json
@@ -25,22 +25,10 @@
               }
             ]
           },
-          "firefox_android": [
-            {
-              "version_added": "39",
-              "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.vr*"
-                }
-              ]
-            },
-            {
-              "version_added": "44",
-              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-            }
-          ],
+          "firefox_android": {
+            "version_added": "44",
+            "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+          },
           "ie": {
             "version_added": false
           },
@@ -94,22 +82,10 @@
                 }
               ]
             },
-            "firefox_android": [
-              {
-                "version_added": "39",
-                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.vr*"
-                  }
-                ]
-              },
-              {
-                "version_added": "44",
-                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
             "ie": {
               "version_added": false
             },
@@ -164,22 +140,10 @@
                 }
               ]
             },
-            "firefox_android": [
-              {
-                "version_added": "39",
-                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.vr*"
-                  }
-                ]
-              },
-              {
-                "version_added": "44",
-                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
             "ie": {
               "version_added": false
             },
@@ -234,22 +198,10 @@
                 }
               ]
             },
-            "firefox_android": [
-              {
-                "version_added": "39",
-                "notes": "The support for this feature is currently disabled by default in Firefox. To enable WebVR support in Firefox Nightly/Developer Edition, you can go to <code>about:config</code> and enable the <code>dom.vr*</code> prefs. A better option however is to install the <a href='http://www.mozvr.com/downloads/webvr-addon-0.1.0.xpi'>WebVR Enabler Add-on</a>, which does this for you and sets up other necessary parts of the <a href='https://developer.mozilla.org/docs/Web/API/WebVR_API/WebVR_environment_setup'>environment</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.vr*"
-                  }
-                ]
-              },
-              {
-                "version_added": "44",
-                "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "44",
+              "notes": "The <code>dom.vr*</code> prefs are enabled by default at this point, in Nightly/Aurora editions."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `PositionSensorVRDevice` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
