### PR TITLE
Mark moz-prefixed fullscreen APIs as still shipping in Firefox

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4550,7 +4550,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozCancelFullScreen"
               }
             ],
@@ -4560,7 +4559,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozCancelFullScreen"
               }
             ],
@@ -5302,7 +5300,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreen"
               }
             ],
@@ -5312,7 +5309,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreen"
               }
             ],
@@ -5403,7 +5399,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenchange"
               }
             ],
@@ -5413,7 +5408,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenchange"
               }
             ],
@@ -5484,7 +5478,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreenEnabled"
               }
             ],
@@ -5494,7 +5487,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreenEnabled"
               }
             ],
@@ -5574,7 +5566,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenerror"
               }
             ],
@@ -5584,7 +5575,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "mozfullscreenerror"
               }
             ],
@@ -7510,7 +7500,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenchange"
               }
             ],
@@ -7520,7 +7509,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenchange"
               }
             ],
@@ -7593,7 +7581,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenerror"
               }
             ],
@@ -7603,7 +7590,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenerror"
               }
             ],

--- a/api/Element.json
+++ b/api/Element.json
@@ -3034,7 +3034,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenchange"
               }
             ],
@@ -3044,7 +3043,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenchange"
               }
             ],
@@ -3115,7 +3113,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenerror"
               }
             ],
@@ -3125,7 +3122,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "64",
                 "alternative_name": "mozfullscreenerror"
               }
             ],
@@ -5751,7 +5747,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenchange"
               }
             ],
@@ -5761,7 +5756,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenchange"
               }
             ],
@@ -5831,7 +5825,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenerror"
               }
             ],
@@ -5841,7 +5834,6 @@
               },
               {
                 "version_added": "10",
-                "version_removed": "65",
                 "alternative_name": "onmozfullscreenerror"
               }
             ],
@@ -6549,7 +6541,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or <code>&lt;object&gt;</code> element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code>&lt;iframe&gt;</code> element with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
@@ -6560,7 +6551,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozRequestFullScreen",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -254,7 +254,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreenElement"
               }
             ],
@@ -264,7 +263,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": "mozFullScreenElement"
               }
             ],

--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -216,12 +216,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "64"
-            },
-            "firefox_android": {
-              "version_added": "64"
-            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "63",
+                "alternative_name": "mozFullScreenElement"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "63",
+                "alternative_name": "mozFullScreenElement"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -34,7 +34,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": ":-moz-full-screen"
               }
             ],
@@ -44,7 +43,6 @@
               },
               {
                 "version_added": "9",
-                "version_removed": "65",
                 "alternative_name": ":-moz-full-screen"
               }
             ],


### PR DESCRIPTION
Relevant tests:
https://mdn-bcd-collector.appspot.com/tests/api/Document/mozCancelFullScreen
https://mdn-bcd-collector.appspot.com/tests/api/Document/mozFullScreen
https://mdn-bcd-collector.appspot.com/tests/api/Document/mozFullScreenElement
https://mdn-bcd-collector.appspot.com/tests/api/Document/mozFullScreenEnabled
https://mdn-bcd-collector.appspot.com/tests/api/Document/onmozfullscreenchange
https://mdn-bcd-collector.appspot.com/tests/api/Document/onmozfullscreenerror
https://mdn-bcd-collector.appspot.com/tests/api/Element/mozRequestFullScreen
https://mdn-bcd-collector.appspot.com/tests/api/Element/onmozfullscreenchange
https://mdn-bcd-collector.appspot.com/tests/api/Element/onmozfullscreenerror
https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/onmozfullscreenchange
https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/onmozfullscreenerror
https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot/mozFullScreenElement

All of these except Element.onmozfullscreenchange/onmozfullscreenerror
were confirmed to still pass in Firefox 87.

Not covered by tests are the events themselves and the :-moz-full-screen
pseudo-class. Both are still in Gecko source, however:
https://github.com/mozilla/gecko-dev/blob/d7e344e956d9da2808ea33e1fe0f963ed10c142d/dom/events/EventListenerManager.cpp#L1134-L1137
https://github.com/mozilla/gecko-dev/blob/d7e344e956d9da2808ea33e1fe0f963ed10c142d/servo/components/style/gecko/selector_parser.rs#L102

Finally, mozFullScreenElement on ShadowRoot was missing from the data.
The test was used to confirm it was shipped in Firefox 63, the same as
ShadowRoot itself.

This mostly reverts https://github.com/mdn/browser-compat-data/pull/3346.