### PR TITLE
Mark `Notification` constructor as never supported on Chrome for Android

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -82,7 +82,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "≤18"


### PR DESCRIPTION
A partial fix toward #7923 (see specifically https://github.com/mdn/browser-compat-data/issues/7923#issuecomment-778359481). This is the most glaring problem in that issue (and doubly raised by #9766).