### PR TITLE
Update Chrome_Android version in Manifest fields

### DIFF
--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -10,7 +10,7 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "88"
             },
             "edge": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -10,7 +10,7 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added":"88"
             },
             "edge": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -10,7 +10,7 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added":"88"
+              "version_added": "88"
             },
             "edge": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -10,7 +10,7 @@
               "version_added": null
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "88"
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)

Chrome for Android supports parsing of manifest categories, description and screenshots as of version 88: https://github.com/chromium/chromium/commit/dcbfc072ddc5dbf41fe405fed5187c80f740e516

Support for these was added to enable a richer PWA install UI: https://www.chromestatus.com/feature/6422599217184768 and https://bugs.chromium.org/p/chromium/issues/detail?id=1146450.
More detail about these can be found here: https://web.dev/add-manifest/#description