### PR TITLE
Includes support for font-variant-caps in Safari

### DIFF
--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -57,10 +57,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
According to the [release notes](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html#//apple_ref/doc/uid/TP40014305-CH10-SW14), it is supported since version 9.1 on Safari and version 9.3 on Safari iOS.

Fixes **#9711**.