### PR TITLE
Mark most -ms-prefixed CSS properties as removed in Edge 79

### DIFF
--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -40,6 +40,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "alternative_name": "-ms-grid-columns"
               }
             ],

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -40,6 +40,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "alternative_name": "-ms-grid-rows"
               }
             ],

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -35,6 +35,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "alternative_name": "-ms-text-combine-horizontal"
               }
             ],
@@ -208,6 +209,7 @@
                 },
                 {
                   "version_added": "12",
+                  "version_removed": "79",
                   "alternative_name": "-ms-text-combine-horizontal"
                 }
               ],


### PR DESCRIPTION
These were confirmed supported in Edge 18 but not supported in Edge 80
on BrowserStack:
https://mdn-bcd-collector.appspot.com/tests/css/properties/-ms-grid-columns
https://mdn-bcd-collector.appspot.com/tests/css/properties/-ms-grid-rows
https://mdn-bcd-collector.appspot.com/tests/css/properties/-ms-text-combine-horizontal

Edge 79 (not available on BrowserStack) was assumed to match.

Note that -ms-high-contrast-adjust remains in Chromium-based Edge and is
not updated here.