### PR TITLE
Update forced-color-adjust for Edge

### DIFF
--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -24,10 +24,15 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "79",
-              "alternative_name": "-ms-high-contrast-adjust"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "-ms-high-contrast-adjust"
+              }
+            ],
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
These tests were run on Edge 18 and 79 on Sauce:
https://mdn-bcd-collector.appspot.com/tests/css/properties/forced-color-adjust
https://mdn-bcd-collector.appspot.com/tests/css/properties/-ms-high-contrast-adjust

Only -ms-high-contrast-adjust is supported in Edge 18, but both are
supported in Edge 79. This is seemingly the only -ms-prefixed CSS
property still supported in Chromium-based Edge, and has also been
confirmed to still be in Edge 89 on macOS.