### PR TITLE
Update FormData compat data for Safari

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -228,10 +228,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -276,10 +276,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -374,7 +374,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -419,10 +419,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -467,10 +467,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -515,10 +515,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -563,10 +563,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -611,10 +611,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -659,10 +659,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Most of the API was added in WebKit trunk version 605.1.6:
https://trac.webkit.org/changeset/221839/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=221839

This maps to Safari 11.1 / iOS 11.3.

Worker exposure happened later in WebKit trunk version 609.1.11:
https://trac.webkit.org/changeset/252349/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=252349

That maps to Safari 13.1 / iOS 13.4.

https://mdn-bcd-collector.appspot.com/tests/api/FormData was also tested
in Safari 11 + 11.1 and 13 + 13.1 on Sauce Labs to confirm.

Follow-up to https://github.com/mdn/browser-compat-data/issues/9425 + https://github.com/mdn/browser-compat-data/pull/9722.