### PR TITLE
Prepare release v3.2.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## [v3.2.4](https://github.com/mdn/browser-compat-data/releases/tag/v3.2.3)
+
+April 8, 2021
+
+### Statistics
+
+- 11 contributors have changed 59 files with 863 additions and 4,322 deletions in 41 commits [`v3.2.3...v3.2.4`](https://github.com/mdn/browser-compat-data/compare/v3.2.3...v2.3.4)
+- 13,029 total features
+- 766 total contributors
+- 3,309 total stargazers
+
 ## [v3.2.3](https://github.com/mdn/browser-compat-data/releases/tag/v3.2.3)
 
 April 1, 2021

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/browser-compat-data",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This release is a bit unusual: no notable changes. Routine data updates only.