### PR TITLE
Fix presentation API removal back to FF88

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1897,7 +1897,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -78,7 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -142,7 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -78,7 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -142,7 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -78,7 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -142,7 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -206,7 +206,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -270,7 +270,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -334,7 +334,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -398,7 +398,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -462,7 +462,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -526,7 +526,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -590,7 +590,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -654,7 +654,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -718,7 +718,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -79,7 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -143,7 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -79,7 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -143,7 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -207,7 +207,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -78,7 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -142,7 +142,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -78,7 +78,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "51",
-            "version_removed": "61",
+            "version_removed": "88",
             "flags": [
               {
                 "type": "preference",
@@ -79,7 +79,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -143,7 +143,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -207,7 +207,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -271,7 +271,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -385,7 +385,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",
@@ -449,7 +449,7 @@
             },
             "firefox": {
               "version_added": "51",
-              "version_removed": "61",
+              "version_removed": "88",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Fixes up error introduced in #9670 (testing shows feature was removed FF88 while issue shows FF61 - based on a bug report).

FYI @ddbeck 