### PR TITLE
Add summary display: list-item support on Chrome, Edge and Opera

### DIFF
--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -55,15 +55,15 @@
             "support": {
               "chrome": {
                 "version_added": "89",
-                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
+                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
               },
               "chrome_android": {
                 "version_added": "89",
-                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
+                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
               },
               "edge": {
-                "version_added": false,
-                "notes": "Edge currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Edge. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
+                "version_added": "89",
+                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
               },
               "firefox": {
                 "version_added": "49"
@@ -76,7 +76,7 @@
               },
               "opera": {
                 "version_added": "75",
-                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
+                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
               },
               "opera_android": {
                 "version_added": false

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -54,12 +54,12 @@
             "description": "<code>display: list-item</code>",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
+                "version_added": "89",
+                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
               },
               "chrome_android": {
-                "version_added": false,
-                "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webkit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>bug 590014</a> for details."
+                "version_added": "89",
+                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
               },
               "edge": {
                 "version_added": false,
@@ -75,7 +75,8 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "75",
+                "notes": "The pseudo-element <code>::-webkit-details-marker</code> is deprecated."
               },
               "opera_android": {
                 "version_added": false

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -54,16 +54,13 @@
             "description": "<code>display: list-item</code>",
             "support": {
               "chrome": {
-                "version_added": "89",
-                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
+                "version_added": "89"
               },
               "chrome_android": {
-                "version_added": "89",
-                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
+                "version_added": "89"
               },
               "edge": {
-                "version_added": "89",
-                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
+                "version_added": "89"
               },
               "firefox": {
                 "version_added": "49"
@@ -75,8 +72,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "75",
-                "notes": "<code>::-webkit-details-marker</code> pseudo element selector is deprecated. Please use <code>::marker</code> instead."
+                "version_added": "75"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
https://chromestatus.com/feature/6730096436051968#details
- `display: list-item` is now by default for element `<summary>`.
- `::-webkit-details-marker` pseudo element selector is deprecated. Please use `::marker` instead.
- Tested on Chrome 89 Desktop, Chrome 89 Android, Edge 89 Desktop and Opera 75 Desktop.
- Not yet implemented on Opera 62 Android.

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [X] Link to related issues or pull requests, if any
