### PR TITLE
updates backdrop-filter for Opera

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -59,15 +59,20 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "opera_android": [
               {
                 "version_added": "54"


### PR DESCRIPTION
Raised in https://github.com/mdn/content/issues/3059

Opera has support for `backdrop-filter`. Assumed Opera 63 from Chromium version and also tested that which showed support.

Fixes #9812