### PR TITLE
Remove extend dependency, becoming a zero-dependency package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const extend = require('extend');
 
 function load() {
   // Recursively load one or more directories passed as arguments.
@@ -23,7 +22,7 @@ function load() {
 
     // The JSON data is independent of the actual file
     // hierarchy, so it is essential to extend "deeply".
-    result = extend(true, result, extra);
+    result = extend(result, extra);
   }
 
   for (dir of arguments) {
@@ -32,6 +31,29 @@ function load() {
   }
 
   return result;
+}
+
+function extend(a, b) {
+  // iterate over all direct and inherited enumerable properties
+  for (const name in b) {
+    let newValue = b[name];
+
+    // check if the new value is an object and its property exists on the former
+    if (typeof newValue === 'object' && newValue !== null && name in a) {
+      const oldValue = a[name];
+
+      // check if the former value is also an object
+      if (typeof oldValue === 'object' && oldValue !== null) {
+        // update the new value as a new object extended by the former and later
+        newValue = extend(extend({}, oldValue), newValue);
+      }
+    }
+
+    // update the object with the new value
+    a[name] = newValue;
+  }
+
+  return a;
 }
 
 module.exports = load(

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function load() {
 
     // The JSON data is independent of the actual file
     // hierarchy, so it is essential to extend "deeply".
-    result = extend(result, extra);
+    extend(result, extra);
   }
 
   for (dir of arguments) {
@@ -42,11 +42,11 @@ function extend(target, source) {
     throw new Error('Both target and source must be plain objects');
   }
 
-  // iterate over all enumerable properties
+  // iterate over own enumerable properties
   for (const [key, value] of Object.entries(source)) {
     // recursively extend if target has the same key, otherwise just assign
     if (Object.prototype.hasOwnProperty.call(target, key)) {
-      target[key] = extend(extend({}, target[key]), value);
+      extend(target[key], value);
     } else {
       target[key] = value;
     }

--- a/index.js
+++ b/index.js
@@ -51,8 +51,6 @@ function extend(target, source) {
       target[key] = value;
     }
   }
-
-  return target;
 }
 
 module.exports = load(

--- a/index.js
+++ b/index.js
@@ -33,27 +33,26 @@ function load() {
   return result;
 }
 
-function extend(a, b) {
-  // iterate over all direct and inherited enumerable properties
-  for (const name in b) {
-    let newValue = b[name];
+function isPlainObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
 
-    // check if the new value is an object and its property exists on the former
-    if (typeof newValue === 'object' && newValue !== null && name in a) {
-      const oldValue = a[name];
-
-      // check if the former value is also an object
-      if (typeof oldValue === 'object' && oldValue !== null) {
-        // update the new value as a new object extended by the former and later
-        newValue = extend(extend({}, oldValue), newValue);
-      }
-    }
-
-    // update the object with the new value
-    a[name] = newValue;
+function extend(target, source) {
+  if (!isPlainObject(target) || !isPlainObject(source)) {
+    throw new Error('Both target and source must be plain objects');
   }
 
-  return a;
+  // iterate over all enumerable properties
+  for (const [key, value] of Object.entries(source)) {
+    // recursively extend if target has the same key, otherwise just assign
+    if (Object.prototype.hasOwnProperty.call(target, key)) {
+      target[key] = extend(extend({}, target[key]), value);
+    } else {
+      target[key] = value;
+    }
+  }
+
+  return target;
 }
 
 module.exports = load(

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,11 +466,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.js",
   "types": "index.d.ts",
-  "dependencies": {
-    "extend": "3.0.2"
-  },
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
This PR replaces the lone `extend` dependency with an explicit function, possibly improving the readability <sup>[a]</sup> of `index.js`.

<sup>a:</sup> this package only extends plain objects, and it extends them in a unique way, where any two nested objects are merged into one new object, rather than continually merging into the former. This unique strategy seems useful to have in the open.