### PR TITLE
Add `text-decoration-thickness` to Chromium `text-decoration` shorthand

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -168,13 +168,13 @@
             "description": "<code>text-decoration-thickness</code> included in shorthand",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "87"
               },
               "edge": {
-                "version_added": false
+                "version_added": "87"
               },
               "firefox": {
                 "version_added": "70"
@@ -186,7 +186,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "73"
               },
               "opera_android": {
                 "version_added": false
@@ -201,7 +201,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "87"
               }
             },
             "status": {


### PR DESCRIPTION
It looks like Chromium 87+ (Chrome 87, Edge 87 and Opera 73) supports text-decoration-thickness in shorthand, as tested using:

```
text-decoration: solid underline 15px red;
```

([CodePen](https://codepen.io/36degrees/pen/qBRxwWL))

## Chrome 87
![Screenshot 2021-04-12 at 14 35 58](https://user-images.githubusercontent.com/121939/114404010-37024b00-9b9d-11eb-9189-b7bf23840e57.png)

## Edge 87
![Screenshot 2021-04-12 at 14 37 23](https://user-images.githubusercontent.com/121939/114404009-3669b480-9b9d-11eb-944f-ff858026ea85.png)

## Opera 73
![Screenshot 2021-04-12 at 14 38 11](https://user-images.githubusercontent.com/121939/114404007-35d11e00-9b9d-11eb-8ee2-bd02513a5960.png)


A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
