### PR TITLE
Fix mis-typed tag in URL for changes in v3.2.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ April 8, 2021
 
 ### Statistics
 
-- 11 contributors have changed 59 files with 863 additions and 4,322 deletions in 41 commits [`v3.2.3...v3.2.4`](https://github.com/mdn/browser-compat-data/compare/v3.2.3...v2.3.4)
+- 11 contributors have changed 59 files with 863 additions and 4,322 deletions in 41 commits [`v3.2.3...v3.2.4`](https://github.com/mdn/browser-compat-data/compare/v3.2.3...v3.2.4)
 - 13,029 total features
 - 766 total contributors
 - 3,309 total stargazers


### PR DESCRIPTION
This typo is also present in [the release notes in the GitHub release](https://github.com/mdn/browser-compat-data/releases/tag/v3.2.4).