### PR TITLE
Drop mdn_url for the appcache "manifest" attribute

### DIFF
--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -51,7 +51,6 @@
         },
         "manifest": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Using_the_application_cache",
             "support": {
               "chrome": {
                 "version_added": "4"


### PR DESCRIPTION
https://github.com/mdn/content/commit/80f1176 removed the https://developer.mozilla.org/docs/Web/HTML/Using_the_application_cache article from MDN.

(That article isn’t 404 yet because there’s a lag between when the source gets removed from the repo and when it goes away in production.)