### PR TITLE
Update Chromium version for ping content attributes

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -451,10 +451,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "12"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "17"
@@ -484,10 +484,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6"
@@ -496,10 +496,10 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -524,10 +524,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "12"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "17"
@@ -557,10 +557,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6"
@@ -569,10 +569,10 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
Chrome 12 is inferred from WebKit trunk version 534.27.0 when the IDL
attribute was added:
https://github.com/mdn/browser-compat-data/pull/9470#issuecomment-817091562

That came after the content attribute, but that behavior was behind a
preference, so this could still be slightly wrong.

However, support for the network requests was confirmed in Chrome 15, so
at most this could be wrong in a range between Chrome 12-15.