### PR TITLE
Add opera support for ::marker

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -59,10 +59,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "version_added": "11.1",
@@ -143,10 +143,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "72"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
Updated `::marker` support in Opera and Opera Android.

Opera Desktop v72 is based on Chromium 86 which is where support was added. https://blogs.opera.com/desktop/changelog-for-72/#b3779.0

Opera Android v61 is also based on Chromium 86. https://forums.opera.com/post/235956 

I've checked and Samsung internet still doesn't support this.
