### PR TITLE
Add opera support for :focus-visible

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -73,26 +73,36 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "54",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "54",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "61"
+              },
+              {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
Updated :focus-visible support in Opera and Opera Android.

Opera Desktop v72 is based on Chromium 86 which is where support was added. https://blogs.opera.com/desktop/changelog-for-72/#b3779.0

Opera Android v61 is also based on Chromium 86. https://forums.opera.com/post/235956