### PR TITLE
Fix the nesting of not_match_link features

### DIFF
--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -122,55 +122,55 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "not_match_link": {
-        "__compat": {
-          "description": "<code>:any-link</code> privacy: selector does not match <code>&lt;link&gt;</code> elements",
-          "support": {
-            "chrome": {
-              "version_added": "65"
+        },
+        "not_match_link": {
+          "__compat": {
+            "description": "<code>:any-link</code> privacy: selector does not match <code>&lt;link&gt;</code> elements",
+            "support": {
+              "chrome": {
+                "version_added": "65"
+              },
+              "chrome_android": {
+                "version_added": "65"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "87"
+              },
+              "firefox_android": {
+                "version_added": "87"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "52"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "65"
+              }
             },
-            "chrome_android": {
-              "version_added": "65"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "87"
-            },
-            "firefox_android": {
-              "version_added": "87"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "52"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false,
-              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
-            },
-            "safari_ios": {
-              "version_added": false,
-              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "65"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -52,55 +52,55 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "not_match_link": {
-        "__compat": {
-          "description": "<code>:link</code> privacy: selector does not match <code>&lt;link&gt;</code> elements",
-          "support": {
-            "chrome": {
-              "version_added": "1"
+        },
+        "not_match_link": {
+          "__compat": {
+            "description": "<code>:link</code> privacy: selector does not match <code>&lt;link&gt;</code> elements",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "87"
+              },
+              "firefox_android": {
+                "version_added": "87"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1.5"
+              }
             },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "87"
-            },
-            "firefox_android": {
-              "version_added": "87"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "3.5"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": false,
-              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
-            },
-            "safari_ios": {
-              "version_added": false,
-              "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1.5"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
These were accidentally both defining css.selectors.not_match_link,
merged together by `extend`.

This removes css.selectors.not_match_link and adds
css.selectors.any-link.not_match_link + css.selectors.link.not_match_link.

Note that a correctly nested css.selectors.visited.not_match_link
already existed.