### PR TITLE
Add more Bluetooth* and BarcodeDetector spec URLs

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -3,6 +3,7 @@
     "BarcodeDetector": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector",
+        "spec_url": "https://wicg.github.io/shape-detection-api/#barcodedetector",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -50,6 +51,7 @@
       "BarcodeDetector": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector/BarcodeDetector",
+          "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-barcodedetector",
           "description": "<code>BarcodeDetector()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "detect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector/detect",
+          "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-detect",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -147,6 +150,7 @@
       "getSupportedFormats": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector/getSupportedFormats",
+          "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-getsupportedformats",
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -105,6 +105,7 @@
       "getAvailability": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability",
           "support": {
             "chrome": [
               {
@@ -284,6 +285,7 @@
       "onavailabilitychanged": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/onavailabilitychanged",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetooth",
           "support": {
             "chrome": [
               {
@@ -386,6 +388,7 @@
       "referringDevice": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/referringDevice",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-referringdevice",
           "support": {
             "chrome": [
               {

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -105,6 +105,7 @@
       "authenticatedSignedWrites": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/authenticatedSignedWrites",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites",
           "support": {
             "chrome": [
               {
@@ -207,6 +208,7 @@
       "broadcast": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/broadcast",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-broadcast",
           "support": {
             "chrome": [
               {
@@ -309,6 +311,7 @@
       "indicate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/indicate",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-indicate",
           "support": {
             "chrome": [
               {
@@ -411,6 +414,7 @@
       "notify": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/notify",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-notify",
           "support": {
             "chrome": [
               {
@@ -513,6 +517,7 @@
       "read": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/read",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-read",
           "support": {
             "chrome": [
               {
@@ -615,6 +620,7 @@
       "reliableWrite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/reliableWrite",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-reliablewrite",
           "support": {
             "chrome": [
               {
@@ -819,6 +825,7 @@
       "write": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/write",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-write",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
These are some additional spec URLs that didn’t get added in the first pass for the B part of the API tree because the MDN articles are relatively recent.