### PR TITLE
Add more CSS* API spec URLs

### DIFF
--- a/api/CSSFontFaceRule.json
+++ b/api/CSSFontFaceRule.json
@@ -3,6 +3,7 @@
     "CSSFontFaceRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule",
+        "spec_url": "https://drafts.csswg.org/css-fonts/#om-fontface",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -50,6 +51,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style",
+          "spec_url": "https://drafts.csswg.org/css-fonts/#dom-cssfontfacerule-style",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -3,6 +3,7 @@
     "CSSImportRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule",
+        "spec_url": "https://drafts.csswg.org/cssom/#cssimportrule",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -50,6 +51,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/href",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssimportrule-href",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -98,6 +100,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/media",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssimportrule-media",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -146,6 +149,7 @@
       "styleSheet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/styleSheet",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssimportrule-stylesheet",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -129,6 +129,7 @@
       "keyText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/keyText",
+          "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframerule-keytext",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -177,6 +178,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/style",
+          "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframerule-style",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -139,6 +139,7 @@
       "appendRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/appendRule",
+          "spec_url": "https://drafts.csswg.org/css-animations/#interface-csskeyframesrule-appendrule",
           "support": {
             "chrome": [
               {
@@ -263,6 +264,7 @@
       "cssRules": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/cssRules",
+          "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-cssrules",
           "support": {
             "chrome": {
               "version_added": "44"
@@ -311,6 +313,7 @@
       "deleteRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/deleteRule",
+          "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-deleterule",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -359,6 +362,7 @@
       "findRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/findRule",
+          "spec_url": "https://drafts.csswg.org/css-animations/#interface-csskeyframesrule-findrule",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -407,6 +411,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/name",
+          "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name",
           "support": {
             "chrome": {
               "version_added": "44"

--- a/api/CSSMathProduct.json
+++ b/api/CSSMathProduct.json
@@ -3,6 +3,7 @@
     "CSSMathProduct": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathProduct",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathproduct",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMathProduct": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathProduct/CSSMathProduct",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathproduct-cssmathproduct",
           "description": "<code>CSSMathProduct()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathProduct/values",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathproduct-values",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMathSum.json
+++ b/api/CSSMathSum.json
@@ -51,6 +51,7 @@
       "CSSMathSum": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathSum/CSSMathSum",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathsum",
           "description": "<code>CSSMathSum()</code> constructor",
           "support": {
             "chrome": {
@@ -100,6 +101,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathSum/values",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathsum-values",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMatrixComponent.json
+++ b/api/CSSMatrixComponent.json
@@ -3,6 +3,7 @@
     "CSSMatrixComponent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMatrixComponent",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmatrixcomponent",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMatrixComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMatrixComponent/CSSMatrixComponent",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmatrixcomponent-cssmatrixcomponent",
           "description": "<code>CSSMatrixComponent()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "matrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMatrixComponent/matrix",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmatrixcomponent-cssmatrixcomponent-matrix-options-matrix",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -53,6 +53,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule/media",
+          "spec_url": "https://drafts.csswg.org/css-conditional/#dom-cssmediarule-media",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -242,6 +242,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/length",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericarray-length",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -51,6 +51,7 @@
       "selectorText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPageRule/selectorText",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-csspagerule-selectortext",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -99,6 +100,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPageRule/style",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylerule-style",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSPerspective.json
+++ b/api/CSSPerspective.json
@@ -3,6 +3,7 @@
     "CSSPerspective": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPerspective",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssperspective",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSPerspective": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPerspective/CSSPerspective",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssperspective",
           "description": "<code>CSSPerspective()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPerspective/length",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssperspective-length",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -50,6 +50,7 @@
       "inherits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/inherits",
+          "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#dom-csspropertyrule-inherits",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -98,6 +99,7 @@
       "initialValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/initialValue",
+          "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#dom-csspropertyrule-initialvalue",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -146,6 +148,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/name",
+          "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#dom-csspropertyrule-name",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -194,6 +197,7 @@
       "syntax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPropertyRule/syntax",
+          "spec_url": "https://drafts.css-houdini.org/css-properties-values-api/#dom-csspropertyrule-syntax",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/api/CSSRotate.json
+++ b/api/CSSRotate.json
@@ -50,6 +50,7 @@
       "CSSRotate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/CSSRotate",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssrotate",
           "description": "<code>CSSRotate()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +100,7 @@
       "angle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/angle",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-angle",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -147,6 +149,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/x",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-x",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -195,6 +198,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/y",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-y",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -243,6 +247,7 @@
       "z": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/z",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-z",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -101,6 +101,7 @@
       "parentRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRule/parentRule",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssrule-parentstylesheet",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -198,6 +199,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRule/type",
+          "spec_url": "https://drafts.csswg.org/cssom/#concept-css-rule-type",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSScale.json
+++ b/api/CSSScale.json
@@ -50,6 +50,7 @@
       "CSSScale": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSScale/CSSScale",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-cssscale",
           "description": "<code>CSSScale()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +100,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSScale/x",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-x",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -147,6 +149,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSScale/y",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-y",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -195,6 +198,7 @@
       "z": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSScale/z",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-z",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSSkew.json
+++ b/api/CSSSkew.json
@@ -3,6 +3,7 @@
     "CSSSkew": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkew",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssskew",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSSkew": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkew/CSSSkew",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskew-cssskew",
           "description": "<code>CSSSkew()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "ax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkew/ax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskew-ax",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -147,6 +150,7 @@
       "ay": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkew/ay",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskew-ay",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSSkewX.json
+++ b/api/CSSSkewX.json
@@ -3,6 +3,7 @@
     "CSSSkewX": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewX",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssskewx",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSSkewX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewX/CSSSkewX",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskewx-cssskewx",
           "description": "<code>CSSSkewX()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "ax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewX/ax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskewx-ax",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSSkewY.json
+++ b/api/CSSSkewY.json
@@ -3,6 +3,7 @@
     "CSSSkewY": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewY",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssskewy",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSSkewY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewY/CSSSkewY",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskewy-cssskewy",
           "description": "<code>CSSSkewY()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "ay": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSkewY/ay",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssskewy-ay",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -51,6 +51,7 @@
       "cssFloat": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/cssFloat",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-cssfloat",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSTransformComponent.json
+++ b/api/CSSTransformComponent.json
@@ -3,6 +3,7 @@
     "CSSTransformComponent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformComponent",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#csstransformcomponent",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "is2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformComponent/is2D",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformcomponent-is2d",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -98,6 +100,7 @@
       "toMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformComponent/toMatrix",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformcomponent-tomatrix",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -3,6 +3,7 @@
     "CSSTransformValue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#csstransformvalue",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -195,6 +196,7 @@
       "is2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/is2D",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-is2d",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -291,6 +293,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/length",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-length",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -339,6 +342,7 @@
       "toMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/toMatrix",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-tomatrix",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSTranslate.json
+++ b/api/CSSTranslate.json
@@ -50,6 +50,7 @@
       "CSSTranslate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTranslate/CSSTranslate",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstranslate-csstranslate",
           "description": "<code>CSSTranslate()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +100,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTranslate/x",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstranslate-x",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -147,6 +149,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTranslate/y",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstranslate-y",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -195,6 +198,7 @@
       "z": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTranslate/z",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstranslate-z",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -50,6 +50,7 @@
       "appendData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/appendData",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-appenddata",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -98,6 +99,7 @@
       "data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/data",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-data",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -146,6 +148,7 @@
       "deleteData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/deleteData",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-deletedata",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -194,6 +197,7 @@
       "insertData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/insertData",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-insertdata",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -242,6 +246,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/length",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-length",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -386,6 +391,7 @@
       "replaceData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/replaceData",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-replacedata",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -434,6 +440,7 @@
       "substringData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/substringData",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-characterdata-substringdata",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
These are some additional spec URLs that didn’t get added in the first pass for the CSS* part of the API tree because the MDN articles are relatively recent.