### PR TITLE
Update some html/manifest spec URLs

### DIFF
--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -4,7 +4,7 @@
       "categories": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/categories",
-          "spec_url": "https://w3c.github.io/manifest/#categories-member",
+          "spec_url": "https://w3c.github.io/manifest-app-info/#categories-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -4,7 +4,7 @@
       "description": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/description",
-          "spec_url": "https://w3c.github.io/manifest/#description-member",
+          "spec_url": "https://w3c.github.io/manifest-app-info/#description-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -4,7 +4,7 @@
       "iarc_rating_id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/iarc_rating_id",
-          "spec_url": "https://w3c.github.io/manifest/#iarc_rating_id-member",
+          "spec_url": "https://w3c.github.io/manifest-app-info/#iarc_rating_id-member",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -4,7 +4,7 @@
       "screenshots": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/screenshots",
-          "spec_url": "https://w3c.github.io/manifest/#screenshots-member",
+          "spec_url": "https://w3c.github.io/manifest-app-info/#screenshots-member",
           "support": {
             "chrome": {
               "version_added": null


### PR DESCRIPTION
Per https://w3c.github.io/manifest/#application-information, the definitions of the manifest `categories`, `description`, `iarc_rating_id`, and `screenshots` members have moved to the https://w3c.github.io/manifest-app-info spec.