### PR TITLE
Chrome 91 support for at-rule counter-style

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -8,10 +8,10 @@
           "spec_url": "https://drafts.csswg.org/css-counter-styles/#the-counter-style-rule",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
               "version_added": false
@@ -41,7 +41,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -57,10 +57,10 @@
             "description": "<code>additive-symbols</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -90,7 +90,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -107,10 +107,10 @@
             "description": "<code>fallback</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -140,7 +140,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -157,10 +157,10 @@
             "description": "<code>negative</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -190,7 +190,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -207,10 +207,10 @@
             "description": "<code>pad</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -240,7 +240,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -257,10 +257,10 @@
             "description": "<code>prefix</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -290,7 +290,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -307,10 +307,10 @@
             "description": "<code>range</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -340,7 +340,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -407,10 +407,10 @@
             "description": "<code>suffix</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -440,7 +440,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {
@@ -457,19 +457,23 @@
             "description": "<code>symbols</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91",
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91",
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": "33"
+                "version_added": "33",
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "firefox_android": {
-                "version_added": "33"
+                "version_added": "33",
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "ie": {
                 "version_added": false
@@ -490,7 +494,8 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91",
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               }
             },
             "status": {
@@ -507,10 +512,10 @@
             "description": "<code>system</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "91"
               },
               "edge": {
                 "version_added": false
@@ -540,7 +545,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "91"
               }
             },
             "status": {

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -458,10 +458,12 @@
             "support": {
               "chrome": {
                 "version_added": "91",
+                "partial_implementation": true,
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "chrome_android": {
                 "version_added": "91",
+                "partial_implementation": true,
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "edge": {
@@ -469,10 +471,12 @@
               },
               "firefox": {
                 "version_added": "33",
+                "partial_implementation": true,
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "firefox_android": {
                 "version_added": "33",
+                "partial_implementation": true,
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "ie": {
@@ -495,6 +499,7 @@
               },
               "webview_android": {
                 "version_added": "91",
+                "partial_implementation": true,
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               }
             },


### PR DESCRIPTION
Chrome 91 adds support for most of `@counter-style`, so I've updated BCD. Also clarified that no browser (including Firefox) implements `<image>` for the `symbols` descriptor.

https://chromestatus.com/features/5692693659254784
