### PR TITLE
Edge and Opera data border-radius logical props

### DIFF
--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -13,7 +13,7 @@
               "version_added": "89"
             },
             "edge": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "66"
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -13,7 +13,7 @@
               "version_added": "89"
             },
             "edge": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "66"
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -13,7 +13,7 @@
               "version_added": "89"
             },
             "edge": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "66"
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -13,7 +13,7 @@
               "version_added": "89"
             },
             "edge": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "66"
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Edge and Opera (desktop) now support the logical version of the border-radius longhands. I've tested these.
