### PR TITLE
Load individual JSON files with fs instead of require()'ing

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function load() {
       extra = load(fp);
     } else if (path.extname(fp) === '.json') {
       try {
-        extra = require(fp);
+        extra = JSON.parse(fs.readFileSync(fp));
       } catch (e) {}
     }
 


### PR DESCRIPTION
This is slightly faster, probably mainly because it avoids the module
cache, which will hold onto the parsed result of each file individually.

The time to load was measured 10 times with and without flushing the
disk cache (using `purge` on macOS).

Before: 1.397-1.510s uncached, 0.641-0.695 cached

After: 1.163-1.397s uncached, 0.500-0.555s cached