### PR TITLE
Don't let compare-versions cover up schema errors

### DIFF
--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -52,13 +52,19 @@ function isValidVersion(browserIdentifier, version) {
  * @returns {boolean}
  */
 function removedAfterAdded(statement) {
-  return compareVersions.compare(
-    statement.version_added.startsWith('≤')
-      ? '0' // 0 was chosen as it's a number lower than any possible browser version
-      : statement.version_added,
-    statement.version_removed.replace('≤', ''),
-    '>=',
-  );
+  try {
+    return compareVersions.compare(
+      statement.version_added.startsWith('≤')
+        ? '0' // 0 was chosen as it's a number lower than any possible browser version
+        : statement.version_added,
+      statement.version_removed.replace('≤', ''),
+      '>=',
+    );
+  } catch (err) {
+    if (err.message === 'Invalid argument not valid semver') {
+      return null;
+    }
+  }
 }
 
 /**

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -52,20 +52,22 @@ function isValidVersion(browserIdentifier, version) {
  * @returns {boolean}
  */
 function removedAfterAdded(statement) {
+  const { version_added, version_removed } = statement;
+
   if (
     !(
-      compareVersions.validate(statement.version_added.replace('≤', '')) &&
-      compareVersions.validate(statement.version_removed.replace('≤', ''))
+      compareVersions.validate(version_added.replace('≤', '')) &&
+      compareVersions.validate(version_removed.replace('≤', ''))
     )
   ) {
     return null;
   }
 
   return compareVersions.compare(
-    statement.version_added.startsWith('≤')
+    version_added.startsWith('≤')
       ? '0' // 0 was chosen as it's a number lower than any possible browser version
-      : statement.version_added,
-    statement.version_removed.replace('≤', ''),
+      : version_added,
+    version_removed.replace('≤', ''),
     '>=',
   );
 }

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -52,19 +52,22 @@ function isValidVersion(browserIdentifier, version) {
  * @returns {boolean}
  */
 function removedAfterAdded(statement) {
-  try {
-    return compareVersions.compare(
-      statement.version_added.startsWith('≤')
-        ? '0' // 0 was chosen as it's a number lower than any possible browser version
-        : statement.version_added,
-      statement.version_removed.replace('≤', ''),
-      '>=',
-    );
-  } catch (err) {
-    if (err.message === 'Invalid argument not valid semver') {
-      return null;
-    }
+  if (
+    !(
+      compareVersions.validate(statement.version_added.replace('≤', '')) &&
+      compareVersions.validate(statement.version_removed.replace('≤', ''))
+    )
+  ) {
+    return null;
   }
+
+  return compareVersions.compare(
+    statement.version_added.startsWith('≤')
+      ? '0' // 0 was chosen as it's a number lower than any possible browser version
+      : statement.version_added,
+    statement.version_removed.replace('≤', ''),
+    '>=',
+  );
 }
 
 /**


### PR DESCRIPTION
I'm not completely sure sure why (the code we had before was hard to understand) but the improved code in #5576 prevents the friendlier error messages from showing when you enter an unsanctioned version string. This PR catches a likely error thrown by `compare-versions`.

Right now, you get something like

```
Problems in 1 file:
✖ css/selectors/-webkit-details-marker.json
Error: Invalid argument not valid semver ('test' received)
    <ugly traceback here>
```

Instead of the previous:

```
Problems in 1 file:
✖ css/selectors/-webkit-details-marker.json
  Versions – 9 errors:
  → css.selectors.-webkit-details-marker - version_added: "test" is NOT a valid version number for chrome
    Valid chrome versions are: <a bunch of valid versions>
```

Since I think the latter is nicer to look at, I've added a `try … catch` to allow this to happen again.