### PR TITLE
Fix Node.js version for publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release package
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
 
 jobs:
   build:
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        node-version: 10.x
+        node-version: 14.x
         registry-url: "https://registry.npmjs.org/"
     - run: npm install
     - run: npm test


### PR DESCRIPTION
The most recent release failed to publish, because the publishing workflow uses an older version of Node.js that doesn't support the `rmdir` equivalent. I should've noticed that before, based on https://github.com/mdn/browser-compat-data/pull/7398#discussion_r613404327, but somehow failed to make the connection.

I'm going to merge this fix, publish the package with the "edited" target, then follow-up with a removal of the "edited" target.