### PR TITLE
Drop "edited" as a release event for the publishing workflow (retry)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release package
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
This is a companion to #9877 and undoes a change I made trying to fix an earlier mistake. This returns us to the status quo ante, where only published releases trigger the release workflow.
