### PR TITLE
Add api.ServiceWorkerGlobalScope.periodicsync_event

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1422,6 +1422,55 @@
           }
         }
       },
+      "periodicsync_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/periodicsync_event",
+          "description": "<code>periodicsync</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": "57"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "push_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/push_event",


### PR DESCRIPTION
This creates subfeature `ServiceWorkerGlobalScope.periodicsync_event`, copying the compatibility from `onperiodicsync`. This was discussed with @ddbeck in https://github.com/mdn/content/pull/4057/files#r612190663