### PR TITLE
Update Safari Service Worker Client/WindowClient support data

### DIFF
--- a/api/Client.json
+++ b/api/Client.json
@@ -31,10 +31,10 @@
             "version_added": "27"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -80,10 +80,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -130,10 +130,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -180,10 +180,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -229,10 +229,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -279,10 +279,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -273,10 +273,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Updates the browser compatibility data to show Safari mostly supports the Service Worker Client/WindowClient APIs.

It appears that support was included with the initial release of Service Workers support in macOS Safari 11.1 and iOS Safari 11.3 (Changeset: https://trac.webkit.org/changeset/224880/webkit)

Based on this line in one of the modified files, it does seem that this changeset was included in 11.1: https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2011.1/WebCore/workers/service/ServiceWorker.cpp#L38

iOS Safari 11.3: https://trac.webkit.org/browser/webkit/releases/Apple/iOS%2011.3/WebCore/workers/service/ServiceWorker.cpp#L38

### Testing

I was able to verify that it at least works in Safari 14.0.3 (macOS 11.2.3). Here's a screenshot of the dev tools showing a `WindowClient` object returned by `clients.matchAll` in the service worker.

<img width="433" alt="Screen Shot 2021-04-18 at 10 40 02 AM" src="https://user-images.githubusercontent.com/49615/115150650-54209900-a037-11eb-85b0-4ac510030b4c.png">

I was also able to send a message back to the client tab with `client.postMessage(...)`.

**Not marked as supported:** `.focus(...)` and `.navigate(...)` on WindowClient throw a "not implemented" exception. Everything else appears to work as expected.

I have not had a chance to dig up an older version (or test in iOS) to verify exactly when this started working. If that's a blocker I'll see what I can come up with.
