### PR TITLE
Edge 90 is released

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -119,19 +119,26 @@
         "89": {
           "release_date": "2021-03-04",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-89077445-march-4",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
         },
         "90": {
-          "status": "beta",
+          "release_date": "2021-04-15",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-90081839-april-15",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "91"
+        },
+        "92": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "92"
         }
       }
     }


### PR DESCRIPTION
Microsoft Edge released v90 a few days after Chrome had their v90 release.  This PR updates our data accordingly.