### PR TITLE
Remove irrelevant Chromium flag data for FeaturePolicy (and fix Opera Android data)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4861,62 +4861,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/featurePolicy",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "73",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "73",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -4958,44 +4908,11 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "56",
-                "version_removed": "60",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "62"
+            },
             "opera_android": {
-              "version_added": "48",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "safari": {
               "version_added": false

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -4,62 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy",
         "support": {
-          "chrome": [
-            {
-              "version_added": "74"
-            },
-            {
-              "version_added": "73",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "69",
-              "version_removed": "73",
-              "alternative_name": "Policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "74"
-            },
-            {
-              "version_added": "73",
-              "version_removed": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "69",
-              "version_removed": "73",
-              "alternative_name": "Policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "74"
+          },
+          "chrome_android": {
+            "version_added": "74"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -88,44 +38,11 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "60",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "version_removed": "60",
-              "alternative_name": "Policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "62"
+          },
           "opera_android": {
-            "version_added": "48",
-            "alternative_name": "Policy",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-productivity-features",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -150,38 +67,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowedFeatures",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -208,31 +99,11 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "56",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "62"
+            },
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -258,38 +129,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowsFeature",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -316,31 +161,11 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "56",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "62"
+            },
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -421,38 +246,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/getAllowlistForFeature",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -479,31 +278,11 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "56",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "62"
+            },
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -415,62 +415,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/featurePolicy",
           "support": {
-            "chrome": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "73",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "74"
-              },
-              {
-                "version_added": "73",
-                "version_removed": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "69",
-                "version_removed": "73",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -512,44 +462,11 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "56",
-                "version_removed": "60",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "62"
+            },
             "opera_android": {
-              "version_added": "48",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-productivity-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "53"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FeaturePolicy` API, along with other APIs containing a `featurePolicy` member (`Document`, `HTMLIFrameElement`...) as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.

Additionally, this PR fixes an issue with the Opera Android data, where it was indicated `FeaturePolicy` was only available behind a flag.  Running a [quick test](https://mdn-bcd-collector.appspot.com/tests/api/Document/featurePolicy) on the almost-latest Opera Android showed normal support.  I'm certain it was introduced at the same time as Chrome Android, so I set the version number to the equivalent version.