### PR TITLE
Mark originAgentCluster as shipped in Edge and WebView 90

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5932,7 +5932,7 @@
               "version_added": "88"
             },
             "edge": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox": {
               "version_added": false
@@ -5959,7 +5959,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/8891.