### PR TITLE
Remove irrelevant Firefox flag data for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4093,36 +4093,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.select_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.select_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": "5.5"
             },
@@ -4165,36 +4141,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.select_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.select_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": {
               "version_added": "4"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `GlobalEventHandlers` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
