### PR TITLE
Remove irrelevant all browsers flag data for Response API

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -4,96 +4,30 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
         "support": {
-          "chrome": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "42"
+          },
+          "chrome_android": {
+            "version_added": "42"
+          },
           "edge": {
             "version_added": "14"
           },
-          "firefox": [
-            {
-              "version_added": "39"
-            },
-            {
-              "version_added": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.fetch.enabled"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "39"
-            },
-            {
-              "version_added": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.fetch.enabled"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "39"
+          },
+          "firefox_android": {
+            "version_added": "39"
+          },
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            }
-          ],
+          "opera": {
+            "version_added": "29"
+          },
+          "opera_android": {
+            "version_added": "29"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -118,85 +52,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/Response",
           "description": "<code>Response()</code> constructor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": true
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -317,74 +196,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -457,74 +292,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": false
             },
@@ -549,74 +340,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": "42"
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -737,74 +484,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/status",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -829,74 +532,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/statusText",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": false
             },
@@ -921,74 +580,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": false
             },
@@ -1013,74 +628,30 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/url",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "42"
+            },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "39"
-              },
-              {
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fetch.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "39"
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for all browsers for the `Response` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.

Paired with #9751 and #9916.