### PR TITLE
Remove irrelevant Opera flag data for api.MediaDevices.getDisplayMedia

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -207,23 +207,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "57",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Opera 57 and 58."
-              }
-            ],
+            "opera": {
+              "version_added": "60"
+            },
             "opera_android": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Opera and Opera Android for the `getDisplayMedia` member of the `MediaDevices` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
