### PR TITLE
Remove irrelevant Chromium flag data for PublicKeyCredential API

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -4,22 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential",
         "support": {
-          "chrome": [
-            {
-              "version_added": "67"
-            },
-            {
-              "version_added": "65",
-              "notes": "Only supports USB U2F tokens.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "value_to_set": "Enabled",
-                  "name": "Web Authentication API"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "67"
+          },
           "chrome_android": {
             "version_added": "70"
           },
@@ -66,22 +53,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },
@@ -129,22 +103,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },
@@ -192,22 +153,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/rawId",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },
@@ -255,22 +203,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/response",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67"
-              },
-              {
-                "version_added": "65",
-                "notes": "Only supports USB U2F tokens.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "value_to_set": "Enabled",
-                    "name": "Web Authentication API"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "67"
+            },
             "chrome_android": {
               "version_added": "70"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PublicKeyCredential` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
