### PR TITLE
Remove irrelevant Firefox flag data for SecurityPolicyViolationEvent API

### DIFF
--- a/api/SecurityPolicyViolationEvent.json
+++ b/api/SecurityPolicyViolationEvent.json
@@ -13,36 +13,12 @@
           "edge": {
             "version_added": "≤18"
           },
-          "firefox": [
-            {
-              "version_added": "63"
-            },
-            {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "security.csp.enable_violation_events",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "63"
-            },
-            {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "security.csp.enable_violation_events",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "63"
+          },
+          "firefox_android": {
+            "version_added": "63"
+          },
           "ie": {
             "version_added": false
           },
@@ -85,36 +61,12 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -157,36 +109,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -229,36 +157,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -301,36 +205,12 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -373,36 +253,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -445,36 +301,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -517,36 +349,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -589,36 +397,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -661,36 +445,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -733,36 +493,12 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -805,36 +541,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -877,36 +589,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -949,36 +637,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -1021,36 +685,12 @@
             "edge": {
               "version_added": "≤18"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.csp.enable_violation_events",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `SecurityPolicyViolationEvent` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
