### PR TITLE
Remove irrelevant "media.mediasource.enabled" flag

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -27,23 +27,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "25",
-              "version_removed": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.mediasource.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-            }
-          ],
+          "firefox": {
+            "version_added": "42"
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -112,23 +98,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -175,23 +147,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -330,23 +288,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -393,23 +337,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -548,23 +478,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -602,57 +518,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/changeType",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "MediaSourceExperimental",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "69",
-                "version_removed": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "MediaSourceExperimental",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.experimental.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -698,23 +575,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -758,23 +621,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -815,23 +664,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -872,23 +707,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -929,23 +750,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -986,23 +793,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -1046,23 +839,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -1214,23 +993,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -1313,23 +1078,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -20,22 +20,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "25",
-              "version_removed": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.mediasource.enabled"
-                }
-              ],
-              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-            }
-          ],
+          "firefox": {
+            "version_added": "42"
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -81,22 +68,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -143,22 +117,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -205,22 +166,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -267,22 +215,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -189,15 +189,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25",
-              "version_removed": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.mediasource.enabled"
-                }
-              ],
-              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -10,22 +10,9 @@
           "edge": {
             "version_added": "12"
           },
-          "firefox": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "25",
-              "version_removed": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.mediasource.enabled"
-                }
-              ],
-              "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-            }
-          ],
+          "firefox": {
+            "version_added": "42"
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -68,23 +55,10 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42",
-                "version_removed": "73"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42",
+              "version_removed": "73"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -128,22 +102,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -184,22 +145,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -291,22 +239,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled"
-                  }
-                ],
-                "notes": "Limited support to an allowed list of sites, for example YouTube, Netflix, and other popular streaming sites. The limitation was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": "42"
+            },
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for `media.mediasource.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
