### PR TITLE
Remove irrelevant "media.webspeech.synth.enabled" flag

### DIFF
--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -16,22 +16,9 @@
           "firefox": {
             "version_added": "49"
           },
-          "firefox_android": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.synth.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "62"
+          },
           "ie": {
             "version_added": false
           },
@@ -77,22 +64,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -138,22 +112,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -199,22 +160,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -261,24 +209,10 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62",
+              "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
+            },
             "ie": {
               "version_added": false
             },
@@ -325,22 +259,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -386,22 +307,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -447,22 +355,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -508,22 +403,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -569,22 +451,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -631,22 +500,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -16,22 +16,9 @@
           "firefox": {
             "version_added": "49"
           },
-          "firefox_android": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.synth.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "62"
+          },
           "ie": {
             "version_added": false
           },
@@ -77,22 +64,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -16,22 +16,9 @@
           "firefox": {
             "version_added": "49"
           },
-          "firefox_android": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.synth.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "62"
+          },
           "ie": {
             "version_added": false
           },
@@ -77,22 +64,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -138,22 +112,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -199,22 +160,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -260,22 +208,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -16,22 +16,9 @@
           "firefox": {
             "version_added": "49"
           },
-          "firefox_android": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.synth.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "62"
+          },
           "ie": {
             "version_added": false
           },
@@ -78,22 +65,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -142,22 +116,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -204,22 +165,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -266,22 +214,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -327,22 +262,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -389,22 +311,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -452,22 +361,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -513,22 +409,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -574,22 +457,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -635,22 +505,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -696,22 +553,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -757,22 +601,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -818,22 +649,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -880,22 +698,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -941,22 +746,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1002,22 +794,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1064,22 +843,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1126,22 +892,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1187,22 +940,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1248,22 +988,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -1309,22 +1036,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -16,22 +16,9 @@
           "firefox": {
             "version_added": "49"
           },
-          "firefox_android": [
-            {
-              "version_added": "62"
-            },
-            {
-              "version_added": "61",
-              "version_removed": "62",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.webspeech.synth.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "62"
+          },
           "ie": {
             "version_added": false
           },
@@ -77,22 +64,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -138,22 +112,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -199,22 +160,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -260,22 +208,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -321,22 +256,9 @@
             "firefox": {
               "version_added": "49"
             },
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webspeech.synth.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for `media.webspeech.synth.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
