### PR TITLE
Remove irrelevant Firefox flag data for StorageManager API (and fix FxA data)

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -13,23 +13,9 @@
           "edge": {
             "version_added": "≤79"
           },
-          "firefox": [
-            {
-              "version_added": "57"
-            },
-            {
-              "version_added": "51",
-              "version_removed": "57",
-              "notes": "See <a href='https://bugzil.la/1304966'>bug 1304966</a> and <a href='https://bugzil.la/1399038'>bug 1399038</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storageManager.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "57"
+          },
           "firefox_android": {
             "version_added": "51",
             "notes": "See <a href='https://bugzil.la/1304966'>bug 1304966</a> and <a href='https://bugzil.la/1399038'>bug 1399038</a>.",
@@ -83,7 +69,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "57"
             },
             "firefox_android": {
               "version_added": "51"
@@ -192,7 +178,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "firefox_android": {
               "version_added": "55"
@@ -268,7 +254,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "firefox_android": {
               "version_added": "55"

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -17,15 +17,7 @@
             "version_added": "57"
           },
           "firefox_android": {
-            "version_added": "51",
-            "notes": "See <a href='https://bugzil.la/1304966'>bug 1304966</a> and <a href='https://bugzil.la/1399038'>bug 1399038</a>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.storageManager.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "57"
           },
           "ie": {
             "version_added": false
@@ -72,7 +64,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "57"
             },
             "ie": {
               "version_added": false
@@ -181,7 +173,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "ie": {
               "version_added": false
@@ -257,7 +249,7 @@
               "version_added": "57"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "57"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `StorageManager` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.

Additionally, this PR resolves issues with the Firefox Android data.  It was determined that this API is indeed supported in Firefox Android, and since the same bugs were linked for both Firefox Desktop and Android, I feel it's safe to say that it was supported in the same version.