### PR TITLE
Remove irrelevant Firefox flag data for SubtleCrypto API

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -14,38 +14,12 @@
             "version_added": "12",
             "partial_implementation": true
           },
-          "firefox": [
-            {
-              "version_added": "34"
-            },
-            {
-              "version_added": "32",
-              "version_removed": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcrypto.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "34"
-            },
-            {
-              "version_added": "32",
-              "version_removed": "34",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcrypto.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "34"
+          },
+          "firefox_android": {
+            "version_added": "34"
+          },
           "ie": {
             "version_added": "11",
             "partial_implementation": true
@@ -105,38 +79,12 @@
               "partial_implementation": true,
               "notes": "Not supported: AES-CTR."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -189,38 +137,12 @@
                 "Not supported: HKDF, PBKDF2."
               ]
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },
@@ -275,38 +197,12 @@
                 "Not supported: HKDF, PBKDF2."
               ]
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": false
             },
@@ -358,38 +254,12 @@
               "partial_implementation": true,
               "notes": "Not supported: SHA-1."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -439,38 +309,12 @@
               "partial_implementation": true,
               "notes": "Not supported: AES-CTR."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -523,38 +367,12 @@
                 "Not supported: AES-CTR."
               ]
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -612,38 +430,12 @@
                 "Not supported: AES-CTR."
               ]
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -700,38 +492,12 @@
                 "Not supported: AES-CTR, HKDF, PBKDF2."
               ]
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -837,38 +603,12 @@
               "partial_implementation": true,
               "notes": "Not supported: RSA-PSS, ECDSA."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -919,38 +659,12 @@
               "partial_implementation": true,
               "notes": "Not supported: AES-CTR."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -1001,38 +715,12 @@
               "partial_implementation": true,
               "notes": "Not supported: RSA-PSS, ECDSA."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,
@@ -1116,38 +804,12 @@
               "partial_implementation": true,
               "notes": "Not supported: AES-CTR."
             },
-            "firefox": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcrypto.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
             "ie": {
               "version_added": "11",
               "partial_implementation": true,


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `SubtleCrypto` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
