### PR TITLE
Remove irrelevant Firefox flag data for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1002,36 +1002,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },
@@ -2092,38 +2068,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "66"
-              },
-              {
-                "version_added": "63",
-                "notes": "This was briefly enabled by default in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>).",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.window.event.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "66"
-              },
-              {
-                "version_added": "63",
-                "notes": "This was briefly enabled by default in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>).",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.window.event.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "66"
+            },
+            "firefox_android": {
+              "version_added": "66"
+            },
             "ie": {
               "version_added": "4"
             },
@@ -7192,38 +7142,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "55",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.requestIdleCallback.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `Window` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
