### PR TITLE
Remove irrelevant Firefox flag data for WEBGL_debug_renderer_info API

### DIFF
--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -13,22 +13,9 @@
           "edge": {
             "version_added": "≤18"
           },
-          "firefox": [
-            {
-              "version_added": "53"
-            },
-            {
-              "version_added": true,
-              "version_removed": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "webgl.enable-debug-renderer-info",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "53"
+          },
           "firefox_android": {
             "version_added": null
           },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `WEBGL_debug_renderer_info` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
