### PR TITLE
Remove irrelevant Firefox flag data for WEBGL_draw_buffers API

### DIFF
--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -13,23 +13,9 @@
           "edge": {
             "version_added": "17"
           },
-          "firefox": [
-            {
-              "prefix": "MOZ_",
-              "version_added": true,
-              "version_removed": "28",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "webgl.enable-draft-extensions",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "28"
-            }
-          ],
+          "firefox": {
+            "version_added": "28"
+          },
           "firefox_android": {
             "version_added": null
           },
@@ -74,23 +60,9 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "prefix": "MOZ_",
-                "version_added": true,
-                "version_removed": "28",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "webgl.enable-draft-extensions",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "28"
-              }
-            ],
+            "firefox": {
+              "version_added": "28"
+            },
             "firefox_android": {
               "version_added": null
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `WEBGL_draw_buffers` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
