### PR TITLE
Remove irrelevant "layout.css.prefixes.webkit" flag

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -37,17 +37,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -59,17 +48,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -2114,72 +2114,14 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+              },
+              "firefox_android": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -2224,72 +2166,14 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+              },
+              "firefox_android": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -2334,72 +2218,14 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "49",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                },
-                {
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.device-pixel-ratio-webkit",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
+              },
+              "firefox_android": {
+                "version_added": "63",
+                "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -2502,36 +2328,12 @@
                 "version_added": "12",
                 "version_removed": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "46",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "46",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-webkit-text-stroke-width.json
+++ b/css/properties/-webkit-text-stroke-width.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/-webkit-text-stroke.json
+++ b/css/properties/-webkit-text-stroke.json
@@ -15,36 +15,12 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -37,17 +37,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -59,17 +48,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -42,17 +42,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -42,17 +42,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -42,17 +42,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -42,17 +42,6 @@
                 "prefix": "-webkit-"
               },
               {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -42,17 +42,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -42,17 +42,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -42,17 +42,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -42,17 +42,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "5"
               }
@@ -64,17 +53,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "44",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -49,18 +49,6 @@
                 "version_added": "64",
                 "partial_implementation": true,
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "62",
-                "partial_implementation": true,
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.webkit-appearance.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -76,18 +64,6 @@
                 "version_added": "64",
                 "partial_implementation": true,
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "62",
-                "partial_implementation": true,
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.webkit-appearance.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "45",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -43,17 +43,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "alternative_name": "-moz-border-radius-bottomleft",
                 "version_added": "1",
                 "version_removed": "12"
@@ -67,17 +56,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "alternative_name": "-moz-border-radius-bottomleft",

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -43,17 +43,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "alternative_name": "-moz-border-radius-bottomright",
                 "version_added": "1",
                 "version_removed": "12"
@@ -67,17 +56,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "alternative_name": "-moz-border-radius-bottomright",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -47,17 +47,6 @@
                 "version_added": "3.5",
                 "prefix": "-moz-",
                 "notes": "An earlier version of the specification was implemented, prefixed, in Firefox versions prior to 15."
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -74,17 +63,6 @@
                 "version_added": "4",
                 "prefix": "-moz-",
                 "notes": "An earlier version of the specification was implemented, prefixed, in Firefox versions prior to 15."
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -43,17 +43,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "alternative_name": "-moz-border-radius-topleft",
                 "version_added": "1",
                 "version_removed": "12"
@@ -67,17 +56,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topleft",

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -43,17 +43,6 @@
                 "version_added": "49"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "alternative_name": "-moz-border-radius-topright",
                 "version_added": "1",
                 "version_removed": "12"
@@ -67,17 +56,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               },
               {
                 "alternative_name": "-moz-border-radius-topright",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -42,17 +42,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -47,17 +47,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -72,17 +61,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -46,7 +46,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-                  }
+              }
             ],
             "firefox_android": [
               {
@@ -66,7 +66,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-                  }
+              }
             ],
             "ie": {
               "version_added": false,

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -46,18 +46,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "46",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
                   }
-                ]
-              }
             ],
             "firefox_android": [
               {
@@ -77,18 +66,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "46",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
                   }
-                ]
-              }
             ],
             "ie": {
               "version_added": false,

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "45",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "45",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {
@@ -191,17 +169,6 @@
                 {
                   "version_added": "49",
                   "prefix": "-webkit-"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "firefox_android": [
@@ -215,17 +182,6 @@
                 {
                   "version_added": "49",
                   "prefix": "-webkit-"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "45",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.prefixes.webkit",
-                      "value_to_set": "true"
-                    }
-                  ]
                 }
               ],
               "ie": {

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "45",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "45",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -44,17 +44,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -44,17 +44,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -43,17 +43,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -63,17 +52,6 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -44,17 +44,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -68,17 +57,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -49,17 +49,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -78,17 +67,6 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": [

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -55,17 +55,6 @@
               {
                 "prefix": "-moz-",
                 "version_added": "4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -45,17 +45,6 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -530,17 +530,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "firefox_android": [
@@ -559,17 +548,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "ie": {
@@ -906,17 +884,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "firefox_android": [
@@ -932,17 +899,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "ie": {
@@ -1048,17 +1004,6 @@
                     {
                       "prefix": "-webkit-",
                       "version_added": "49"
-                    },
-                    {
-                      "prefix": "-webkit-",
-                      "version_added": "44",
-                      "flags": [
-                        {
-                          "type": "preference",
-                          "name": "layout.css.prefixes.webkit",
-                          "value_to_set": "true"
-                        }
-                      ]
                     }
                   ],
                   "firefox_android": [
@@ -1367,17 +1312,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "firefox_android": [
@@ -1396,17 +1330,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "ie": {
@@ -1745,17 +1668,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "firefox_android": [
@@ -1771,17 +1683,6 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "49"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "44",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.prefixes.webkit",
-                        "value_to_set": "true"
-                      }
-                    ]
                   }
                 ],
                 "ie": {
@@ -1886,17 +1787,6 @@
                     {
                       "prefix": "-webkit-",
                       "version_added": "49"
-                    },
-                    {
-                      "prefix": "-webkit-",
-                      "version_added": "44",
-                      "flags": [
-                        {
-                          "type": "preference",
-                          "name": "layout.css.prefixes.webkit",
-                          "value_to_set": "true"
-                        }
-                      ]
                     }
                   ],
                   "firefox_android": [
@@ -1912,17 +1802,6 @@
                     {
                       "prefix": "-webkit-",
                       "version_added": "49"
-                    },
-                    {
-                      "prefix": "-webkit-",
-                      "version_added": "44",
-                      "flags": [
-                        {
-                          "type": "preference",
-                          "name": "layout.css.prefixes.webkit",
-                          "value_to_set": "true"
-                        }
-                      ]
                     }
                   ],
                   "ie": {


### PR DESCRIPTION
This PR removes irrelevant flag data for `layout.css.prefixes.webkit` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
