### PR TITLE
Update Firefox data for `supports` CSS at-rule

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -66,12 +66,16 @@
               "edge": {
                 "version_added": "83"
               },
-              "firefox": [
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": [
                 {
-                  "version_added": "69"
+                  "version_added": "79"
                 },
                 {
                   "version_added": "64",
+                  "version_removed": "79",
                   "flags": [
                     {
                       "type": "preference",
@@ -81,16 +85,6 @@
                   ]
                 }
               ],
-              "firefox_android": {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.supports-selector.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates the Firefox data for the `supports` at-rule by doing the following:
- Removes the now-irrelevant flag that enables the feature
- Fixes the Firefox Android data to say that it is now supported in Fenix (confirmed by testing via https://mdn-bcd-collector.appspot.com)