### PR TITLE
Adopt new definition and guideline for experimental status

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -280,3 +280,23 @@ Members of this mixin are available to `HTMLAnchorElement` and `HTMLAreaElement`
    ```
 
 This guideline was proposed in [#8929](https://github.com/mdn/browser-compat-data/issues/8929), based in part on previous discussion in [#472](https://github.com/mdn/browser-compat-data/issues/472).
+
+## Choosing an experimental status
+
+Generally, when a feature is supported by one and only one browser engine, set `experimental` to `true`. When a feature is supported by two or more engines, then set `experimental` to `false`. Some exceptions apply, however, for long-standing features and features behind flags and prefixes.
+
+If a feature is supported behind flags only, no matter how many engines, then set `experimental` to `true`.
+
+If a feature is supported behind incompatible prefixes only (such as `-webkit-` in one engine and `-moz-` in another), no matter how many engines support the feature overall, then set `experimental` to `true`. If two or more engines support a feature behind a common prefix (such as `-webkit-` only), then set `experimental` to `false`.
+
+If a feature has been supported by one and only one engine without major changes for two or more years (relative to the most-recent browser release introducing support for the feature, or the most-recent browser release since the last major change) , then `experimental` may be set to `false`.
+
+| Example                                                                     | Experimental |
+| --------------------------------------------------------------------------- | ------------ |
+| An API supported in Chrome and Firefox, without flags or prefixes.          | No           |
+| A CSS property supported in Chrome and Firefox, with the `-webkit-` prefix. | No           |
+| An HTTP header supported in Chrome and Firefox, behind flags.               | Yes          |
+| A CSS value supported in Safari, released last week.                        | Yes          |
+| An API supported in Firefox, released three years ago.                      | No           |
+
+This guideline was proposed in [#6905](https://github.com/mdn/browser-compat-data/issues/6905) and adopted in [#TK]().

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -447,10 +447,12 @@ A `matches` object contains hints to help automatically detect whether source co
 The mandatory status property contains information about stability of the feature. It is
 an object named `status` and has three mandatory properties:
 
-- `experimental`: a `boolean` value that indicates this functionality is
-  intended to be an addition to the Web platform. Some features are added to
-  conduct tests. Set to `false`, it means the functionality is mature, and no
-  significant incompatible changes are expected in the future.
+- `experimental`: a `boolean` value.
+
+  If `experimental` is `true`, it means that Web developers should experiment with this feature and provide feedback to browser vendors and standards authors about this feature. It also means that Web developers _should not_ rely on the feature's continued existence in its current (or potentially any) form in future browser releases.
+
+  If `experimental` is `false`, it means the functionality is mature and no significant changes are expected in the future.
+
 - `standard_track`: a `boolean` value indicating if the feature is part of an
   active specification or specification process.
 - `deprecated`: a `boolean` value that indicates if the feature is no longer recommended.

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -453,10 +453,13 @@ an object named `status` and has three mandatory properties:
 
   If `experimental` is `false`, it means the functionality is mature and no significant changes are expected in the future.
 
-- `standard_track`: a `boolean` value indicating if the feature is part of an
-  active specification or specification process.
-- `deprecated`: a `boolean` value that indicates if the feature is no longer recommended.
-  It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality.
+- `standard_track`: a `boolean` value.
+
+  If `standard_track` is `true`, then the feature is part of an active specification or specification process.
+
+- `deprecated`: a `boolean` value.
+
+  If `deprecated` is `true`, then the feature is no longer recommended. It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality.
 
 ```json
 "__compat": {


### PR DESCRIPTION
This PR:

- Proposes a new, hopefully clearer definition of experimental in the schema docs, for consumers. This is less an attempt to change the definition, so much as to describe what it _actually_ is. It has an additional benefit of sidestepping standards questions.
- Proposes a guideline for setting and changing the `experimental` status, for contributors. This is an attempt to get consensus on how we set the status as PR authors and reviewers.
- Reformats the other status definitions in the schema docs for symmetry with the new definition.

That said, this is probably not complete. See my line comment on sunsetting experimental features. There's a wrinkle that I don't like and I'm not sure how to resolve it.

Fixes #6905.