### PR TITLE
Remove irrelevant "dom.image.picture.enabled" flag

### DIFF
--- a/html/elements/picture.json
+++ b/html/elements/picture.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "38"
-              },
-              {
-                "version_added": "32",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.image.picture.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
             "ie": {
               "version_added": false
             },

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -124,36 +124,12 @@
               "edge": {
                 "version_added": "≤18"
               },
-              "firefox": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "33",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.picture.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "33",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.picture.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "38"
+              },
+              "firefox_android": {
+                "version_added": "38"
+              },
               "ie": {
                 "version_added": null
               },
@@ -298,36 +274,12 @@
               "edge": {
                 "version_added": "≤18"
               },
-              "firefox": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "33",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.picture.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "33",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.picture.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "38"
+              },
+              "firefox_android": {
+                "version_added": "38"
+              },
               "ie": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for `dom.image.picture.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
