### PR TITLE
Remove irrelevant "dom.webcomponents.shadowdom.enabled" flag

### DIFF
--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -18,70 +18,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "59",
-                "version_removed": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "version_removed": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "dom.webcomponents.shadowdom.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -122,70 +64,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "59",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": true,
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.enabled",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "59",
-                  "version_removed": "63",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": true,
-                  "version_removed": "59",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.enabled",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "dom.webcomponents.shadowdom.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for `dom.webcomponents.shadowdom.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
