### PR TITLE
Remove irrelevant "media.webvtt.enabled" flag

### DIFF
--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -16,38 +16,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "50",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "31"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "50",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.webvtt.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -90,38 +64,12 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -163,38 +111,12 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -236,38 +158,12 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -309,38 +205,12 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -432,38 +302,12 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "31"
-                },
-                {
-                  "version_added": "24",
-                  "version_removed": "50",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.webvtt.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": {
+                "version_added": "31"
+              },
               "ie": {
                 "version_added": "10"
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for `media.webvtt.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
