### PR TITLE
Remove irrelevant "dom.moduleScripts.enabled" flag

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -306,38 +306,12 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "60"
-                },
-                {
-                  "version_added": "55",
-                  "version_removed": "60",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "60"
-                },
-                {
-                  "version_added": "55",
-                  "version_removed": "60",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.moduleScripts.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
               "ie": {
                 "version_added": false
               },
@@ -575,38 +549,12 @@
                     "version_removed": "79"
                   }
                 ],
-                "firefox": [
-                  {
-                    "version_added": "60"
-                  },
-                  {
-                    "version_added": "54",
-                    "version_removed": "60",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "dom.moduleScripts.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "version_added": "60"
-                  },
-                  {
-                    "version_added": "54",
-                    "version_removed": "60",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "dom.moduleScripts.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
This PR removes irrelevant flag data for `dom.moduleScripts.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
