### PR TITLE
Remove irrelevant "dom.image.srcset.enabled" flag

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -907,38 +907,12 @@
               "edge": {
                 "version_added": "≤18"
               },
-              "firefox": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "32",
-                  "version_removed": "52",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.srcset.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "version_added": "32",
-                  "version_removed": "52",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.image.srcset.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "38"
+              },
+              "firefox_android": {
+                "version_added": "38"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for `dom.image.srcset.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
