### PR TITLE
Remove irrelevant Chromium flag data for custom-property CSS property

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -7,34 +7,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/--*",
           "spec_url": "https://drafts.csswg.org/css-variables/#defining-variables",
           "support": {
-            "chrome": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "49"
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -142,34 +120,12 @@
             "spec_url": "https://drafts.csswg.org/css-variables/#using-variables",
             "description": "<code>var()</code>",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "48",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
               "edge": {
                 "version_added": "15"
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `custom-property` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
