### PR TITLE
Remove irrelevant all browsers flag data for display CSS property

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -52,91 +52,30 @@
         "contents": {
           "__compat": {
             "support": {
-              "chrome": [
-                {
-                  "version_added": "65"
-                },
-                {
-                  "version_added": "58",
-                  "version_removed": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "65"
-                },
-                {
-                  "version_added": "58",
-                  "version_removed": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "65"
+              },
+              "chrome_android": {
+                "version_added": "65"
+              },
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "37"
-                },
-                {
-                  "version_added": "36",
-                  "version_removed": "53",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.display-contents.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "37"
+              },
               "firefox_android": {
                 "version_added": "57"
               },
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "45",
-                  "version_removed": "52",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "47"
-                },
-                {
-                  "version_added": "43",
-                  "version_removed": "47",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "52"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
               "safari": {
                 "version_added": "11.1"
               },
@@ -161,10 +100,10 @@
               "description": "Specific behavior of unusual elements when <code>display: contents</code> is applied to them",
               "support": {
                 "chrome": {
-                  "version_added": "58"
+                  "version_added": "65"
                 },
                 "chrome_android": {
-                  "version_added": "58"
+                  "version_added": "65"
                 },
                 "edge": {
                   "version_added": "79"
@@ -179,10 +118,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "45"
+                  "version_added": "52"
                 },
                 "opera_android": {
-                  "version_added": "43"
+                  "version_added": "47"
                 },
                 "safari": {
                   "version_added": false

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -65,7 +65,7 @@
                 "version_added": "37"
               },
               "firefox_android": {
-                "version_added": "57"
+                "version_added": "37"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for all browsers for the `display` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
