### PR TITLE
Remove irrelevant Firefox flag data for filter CSS property

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -33,30 +33,8 @@
                 "version_added": "35"
               },
               {
-                "partial_implementation": true,
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.filters.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "46",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -64,30 +42,8 @@
                 "version_added": "35"
               },
               {
-                "partial_implementation": true,
-                "version_added": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.filters.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "49"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "46",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `filter` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
