### PR TITLE
Remove irrelevant "layout.css.masking.enabled" flag

### DIFF
--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -18,38 +18,12 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -21,38 +21,12 @@
               "version_added": "79",
               "notes": "The <code>margin-box</code> value is unsupported."
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -80,7 +80,8 @@
                 "version_removed": "70"
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": "53",
+                "version_removed": "79"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -17,38 +17,12 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
             "ie": {
               "version_added": false
             },
@@ -101,39 +75,13 @@
                 "version_added": "18",
                 "version_removed": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "53",
-                  "version_removed": "70"
-                },
-                {
-                  "version_added": "20",
-                  "version_removed": "53",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.masking.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "53"
-                },
-                {
-                  "version_added": "20",
-                  "version_removed": "53",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.masking.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "53",
+                "version_removed": "70"
+              },
+              "firefox_android": {
+                "version_added": "53"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -17,38 +17,12 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -17,38 +17,12 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "20",
-                "version_removed": "52",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.masking.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "35"
+            },
+            "firefox_android": {
+              "version_added": "35"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for `layout.css.masking.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
