### PR TITLE
Remove irrelevant "layout.css.text-emphasis.enabled" flag

### DIFF
--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -18,38 +18,12 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -18,38 +18,12 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -18,38 +18,12 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -18,38 +18,12 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "45",
-                "version_removed": "49",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-emphasis.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for `layout.css.text-emphasis.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
