### PR TITLE
Remove irrelevant Firefox flag data for scrollbar-color CSS property

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -15,37 +15,13 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "64",
-                "notes": "On macOS, you need to set the <em>General</em> > <em>Show scroll bars</em> setting in System Preferences to \"Always\" for this property to have any effect."
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scrollbar-color.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "64"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scrollbar-color.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "64",
+              "notes": "On macOS, you need to set the <em>General</em> > <em>Show scroll bars</em> setting in System Preferences to \"Always\" for this property to have any effect."
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `scrollbar-color` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
