### PR TITLE
Remove irrelevant "layout.css.shape-outside.enabled" flag

### DIFF
--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -15,38 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "61",
-                "version_removed": "62",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
             "ie": {
               "version_added": false
             },
@@ -89,38 +63,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },
@@ -165,38 +113,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },
@@ -241,38 +163,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },
@@ -316,38 +212,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },
@@ -391,38 +261,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },
@@ -467,39 +311,13 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "62",
-                  "version_removed": "70"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "61",
-                  "version_removed": "62",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.shape-outside.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "62",
+                "version_removed": "70"
+              },
+              "firefox_android": {
+                "version_added": "62"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -316,7 +316,8 @@
                 "version_removed": "70"
               },
               "firefox_android": {
-                "version_added": "62"
+                "version_added": "62",
+                "version_removed": "79"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for `layout.css.shape-outside.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
