### PR TITLE
Remove irrelevant Chromium flag data for text-align-last CSS property

### DIFF
--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -6,38 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-align-last",
           "spec_url": "https://drafts.csswg.org/css-text/#text-align-last-property",
           "support": {
-            "chrome": [
-              {
-                "version_added": "47"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "47",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "47"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "47",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": {
+              "version_added": "47"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -69,38 +43,12 @@
                 "The <code>start</code> and <code>end</code> values are not supported."
               ]
             },
-            "opera": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "23",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "34"
-              },
-              {
-                "version_added": "24",
-                "version_removed": "34",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable Experimental Web Platform Features",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "34"
+            },
+            "opera_android": {
+              "version_added": "34"
+            },
             "safari": {
               "version_added": false,
               "notes": "See WebKit <a href='https://webkit.org/b/76173'>bug 76173</a>."


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `text-align-last` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
