### PR TITLE
Remove irrelevant Firefox flag data for text-combine-upright CSS property

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -47,16 +47,6 @@
               {
                 "version_added": "48",
                 "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-combine-upright.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "firefox_android": [
@@ -67,16 +57,6 @@
               {
                 "version_added": "48",
                 "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-combine-upright.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
               }
             ],
             "ie": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -39,24 +39,15 @@
                 "alternative_name": "-ms-text-combine-horizontal"
               }
             ],
-            "firefox": [
-              {
-                "version_added": "81",
-                "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
-              },
-              {
-                "version_added": "48"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "81",
-                "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
-              },
-              {
-                "version_added": "48"
-              }
-            ],
+            "firefox": {
+              "version_added": "48",
+              "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
+            },
+
+            "firefox_android": {
+              "version_added": "48",
+              "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
+            },
             "ie": {
               "version_added": "11",
               "alternative_name": "-ms-text-combine-horizontal"

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -45,8 +45,7 @@
                 "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
               },
               {
-                "version_added": "48",
-                "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
+                "version_added": "48"
               }
             ],
             "firefox_android": [
@@ -55,8 +54,7 @@
                 "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
               },
               {
-                "version_added": "48",
-                "notes": "Before version 48, Firefox did not implement layout support for tate-chū-yoko."
+                "version_added": "48"
               }
             ],
             "ie": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -43,7 +43,6 @@
               "version_added": "48",
               "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."
             },
-
             "firefox_android": {
               "version_added": "48",
               "notes": "Before version 81, Firefox implemented the property as animatable. This was corrected to spec in 81."


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `text-combine-upright` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
