### PR TITLE
Remove irrelevant Firefox flag data for text-justify CSS property

### DIFF
--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -32,36 +32,12 @@
               "version_added": "12",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-justify.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-justify.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": "11",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `text-justify` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
