### PR TITLE
Remove irrelevant Firefox flag data for touch-action CSS property

### DIFF
--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -18,38 +18,13 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "52",
-                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.touch_action.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.touch_action.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "52",
+              "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -97,38 +72,13 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "52",
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "52",
+                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
               "ie": [
                 {
                   "version_added": "11"
@@ -230,38 +180,13 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "52",
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "52",
+                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
               "ie": [
                 {
                   "version_added": "11"
@@ -309,38 +234,13 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "52",
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "29",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.touch_action.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "52",
+                "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
               "ie": [
                 {
                   "version_added": "11"


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `touch-action` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
