### PR TITLE
Remove irrelevant Firefox flag data for transform-box CSS property

### DIFF
--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -15,58 +15,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "svg.transform-box.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "41",
-                "version_removed": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "svg.transform-origin.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "svg.transform-box.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "41",
-                "version_removed": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "svg.transform-origin.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "55"
+            },
+            "firefox_android": {
+              "version_added": "55"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `transform-box` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
