### PR TITLE
Remove irrelevant Firefox flag data for transform-origin CSS property

### DIFF
--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -182,42 +182,14 @@
               "edge": {
                 "version_added": "17"
               },
-              "firefox": [
-                {
-                  "version_added": "43",
-                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
-                },
-                {
-                  "version_added": "41",
-                  "version_removed": "43",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "svg.transform-origin.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "43",
-                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
-                },
-                {
-                  "version_added": "41",
-                  "version_removed": "43",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "svg.transform-origin.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
-                }
-              ],
+              "firefox": {
+                "version_added": "43",
+                "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
+              },
+              "firefox_android": {
+                "version_added": "43",
+                "notes": "Keywords and percentages refer to the canvas instead of the object itself. See <a href='https://bugzil.la/1209061'>bug 1209061</a>."
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `transform-origin` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
