### PR TITLE
Remove irrelevant Firefox flag data for will-change CSS property

### DIFF
--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -15,40 +15,14 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "36",
-                "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
-              },
-              {
-                "version_added": "31",
-                "version_removed": "36",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.will-change.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "36",
-                "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
-              },
-              {
-                "version_added": "31",
-                "version_removed": "36",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.will-change.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "36",
+              "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+            },
+            "firefox_android": {
+              "version_added": "36",
+              "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -16,12 +16,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "36",
-              "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": "36",
-              "notes": "Before Firefox 43, Firefox supported <code>will-change: will-change</code>, which is invalid by the specification."
+              "version_added": "36"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `will-change` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
