### PR TITLE
Remove irrelevant Chromium flag data for is CSS selector

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -24,19 +24,6 @@
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
-                "version_added": "66",
-                "version_removed": "71",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
                 "version_added": "12",
                 "alternative_name": ":-webkit-any()",
                 "notes": "Doesn't support combinators."
@@ -45,19 +32,6 @@
             "chrome_android": [
               {
                 "version_added": "88"
-              },
-              {
-                "version_added": "66",
-                "version_removed": "71",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "18",
@@ -131,19 +105,6 @@
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
-                "version_added": "53",
-                "version_removed": "58",
-                "alternative_name": ":matches()",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
                 "version_added": "15",
                 "alternative_name": ":-webkit-any()",
                 "notes": "Doesn't support combinators."
@@ -152,19 +113,6 @@
             "opera_android": [
               {
                 "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
-              },
-              {
-                "version_added": "47",
-                "version_removed": "50",
-                "alternative_name": ":matches()",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `is` CSS selector as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
