### PR TITLE
Remove irrelevant Firefox flag data for scope CSS selector

### DIFF
--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -16,39 +16,14 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "32",
-                "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
-              },
-              {
-                "version_added": "20",
-                "version_removed": "32",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scope-pseudo.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "32",
-                "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
-              },
-              {
-                "version_added": "20",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scope-pseudo.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "32",
+              "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
+            },
+            "firefox_android": {
+              "version_added": "32",
+              "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `scope` CSS selector as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
