### PR TITLE
Remove irrelevant Chromium flag data for color CSS type

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -106,34 +106,12 @@
               "regex_token": "^#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?$"
             },
             "support": {
-              "chrome": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "52",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "62"
-                },
-                {
-                  "version_added": "52",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "62"
+              },
+              "chrome_android": {
+                "version_added": "62"
+              },
               "edge": {
                 "version_added": "79"
               },
@@ -146,34 +124,12 @@
               "ie": {
                 "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "49"
-                },
-                {
-                  "version_added": "39",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "47"
-                },
-                {
-                  "version_added": "41",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ],
+              "opera": {
+                "version_added": "49"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
               "safari": {
                 "version_added": "9.1"
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `color` CSS type as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
