### PR TITLE
Remove irrelevant Chromium flag data for image CSS type

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -329,34 +329,12 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#conic-gradients",
               "support": {
-                "chrome": [
-                  {
-                    "version_added": "69"
-                  },
-                  {
-                    "version_added": "59",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": "69"
-                  },
-                  {
-                    "version_added": "59",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
+                "chrome": {
+                  "version_added": "69"
+                },
+                "chrome_android": {
+                  "version_added": "69"
+                },
                 "edge": {
                   "version_added": "79"
                 },
@@ -391,34 +369,12 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": [
-                  {
-                    "version_added": "56"
-                  },
-                  {
-                    "version_added": "46",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
-                "opera_android": [
-                  {
-                    "version_added": "48"
-                  },
-                  {
-                    "version_added": "43",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
+                "opera": {
+                  "version_added": "56"
+                },
+                "opera_android": {
+                  "version_added": "48"
+                },
                 "safari": {
                   "version_added": "12.1"
                 },
@@ -1216,34 +1172,12 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "support": {
-                "chrome": [
-                  {
-                    "version_added": "69"
-                  },
-                  {
-                    "version_added": "59",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": "69"
-                  },
-                  {
-                    "version_added": "59",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
+                "chrome": {
+                  "version_added": "69"
+                },
+                "chrome_android": {
+                  "version_added": "69"
+                },
                 "edge": {
                   "version_added": "79"
                 },
@@ -1278,34 +1212,12 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": [
-                  {
-                    "version_added": "56"
-                  },
-                  {
-                    "version_added": "46",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
-                "opera_android": [
-                  {
-                    "version_added": "48"
-                  },
-                  {
-                    "version_added": "43",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "Enable Experimental Web Platform Features"
-                      }
-                    ]
-                  }
-                ],
+                "opera": {
+                  "version_added": "56"
+                },
+                "opera_android": {
+                  "version_added": "48"
+                },
                 "safari": {
                   "version_added": "12.1"
                 },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `image` CSS type as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
