### PR TITLE
Remove irrelevant "dom.clearSiteData.enabled" flag

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -14,36 +14,12 @@
             "edge": {
               "version_added": "≤79"
             },
-            "firefox": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "62",
-                "flags": [
-                  {
-                    "name": "dom.clearSiteData.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "63"
-              },
-              {
-                "version_added": "62",
-                "flags": [
-                  {
-                    "name": "dom.clearSiteData.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
             "ie": {
               "version_added": false
             },
@@ -86,36 +62,12 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
               "ie": {
                 "version_added": false
               },
@@ -159,36 +111,12 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
               "ie": {
                 "version_added": false
               },
@@ -234,38 +162,14 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/898503'>bug 898503</a>."
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "version_removed": "68"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "version_removed": "68"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "version_removed": "68"
+              },
+              "firefox_android": {
+                "version_added": "63",
+                "version_removed": "68"
+              },
               "ie": {
                 "version_added": false
               },
@@ -357,36 +261,12 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "63"
-                },
-                {
-                  "version_added": "62",
-                  "flags": [
-                    {
-                      "name": "dom.clearSiteData.enabled",
-                      "type": "preference",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "63"
+              },
               "ie": {
                 "version_added": false
               },

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -213,10 +213,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "62"
+                "version_added": "63"
               },
               "firefox_android": {
-                "version_added": "62"
+                "version_added": "63"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for `dom.clearSiteData.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
