### PR TITLE
Remove irrelevant Chromium flag data for nel HTTP feature

### DIFF
--- a/http/headers/nel.json
+++ b/http/headers/nel.json
@@ -6,21 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/NEL",
           "spec_url": "https://w3c.github.io/network-error-logging/#nel-response-header",
           "support": {
-            "chrome": [
-              {
-                "version_added": "71"
-              },
-              {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "Reporting",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "71"
+            },
             "chrome_android": {
               "version_added": "71"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `nel` HTTP feature as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
