### PR TITLE
Remove irrelevant "extensions.webextensions.tabhide.enabled" flag

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2261,22 +2261,9 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "61"
-                },
-                {
-                  "version_added": "59",
-                  "version_removed": "61",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "extensions.webextensions.tabhide.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "61"
+              },
               "firefox_android": {
                 "version_added": false
               },
@@ -3875,22 +3862,9 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "61"
-                },
-                {
-                  "version_added": "59",
-                  "version_removed": "61",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "extensions.webextensions.tabhide.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "61"
+              },
               "firefox_android": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for `extensions.webextensions.tabhide.enabled` as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
