### PR TITLE
Update Edge versions for BackgroundFetch* API

### DIFF
--- a/api/BackgroundFetchEvent.json
+++ b/api/BackgroundFetchEvent.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/BackgroundFetchManager.json
+++ b/api/BackgroundFetchManager.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/BackgroundFetchRecord.json
+++ b/api/BackgroundFetchRecord.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -202,7 +202,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -250,7 +250,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -298,7 +298,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -346,7 +346,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -394,7 +394,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -442,7 +442,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -490,7 +490,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -538,7 +538,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -586,7 +586,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/BackgroundFetchUpdateUIEvent.json
+++ b/api/BackgroundFetchUpdateUIEvent.json
@@ -11,7 +11,7 @@
             "version_added": "74"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `BackgroundFetch*` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/API/BackgroundFetchEvent
https://mdn-bcd-collector.appspot.com/tests/API/BackgroundFetchManager
https://mdn-bcd-collector.appspot.com/tests/API/BackgroundFetchRecord
https://mdn-bcd-collector.appspot.com/tests/API/BackgroundFetchRegistration
https://mdn-bcd-collector.appspot.com/tests/API/BackgroundFetchUpdateUIEvent
