### PR TITLE
update fx browsers post 88 release

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -630,68 +630,69 @@
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
-          "release_date": "2021-04-20",
+          "release_date": "2021-04-19",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "88"
         },
         "89": {
-          "release_date": "2021-05-18",
+          "release_date": "2021-06-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/89",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "89"
         },
         "90": {
-          "release_date": "2021-06-15",
-          "status": "planned",
+          "release_date": "2021-06-29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/90",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "90"
         },
         "91": {
-          "release_date": "2021-07-13",
+          "release_date": "2021-07-27",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "91"
         },
         "92": {
-          "release_date": "2021-08-10",
+          "release_date": "2021-08-24",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "92"
         },
         "93": {
-          "release_date": "2021-09-07",
+          "release_date": "2021-09-21",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
-          "release_date": "2021-10-05",
+          "release_date": "2021-10-19",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "94"
         },
         "95": {
-          "release_date": "2021-11-02",
+          "release_date": "2021-11-16",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
-          "release_date": "2021-12-07",
+          "release_date": "2021-12-14",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
-          "release_date": "2022-01-11",
+          "release_date": "2022-01-25",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "97"

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -497,68 +497,69 @@
         "87": {
           "release_date": "2021-03-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/87",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "87"
         },
         "88": {
-          "release_date": "2021-04-20",
+          "release_date": "2021-04-19",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/88",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "88"
         },
         "89": {
-          "release_date": "2021-05-18",
+          "release_date": "2021-06-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/89",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "89"
         },
         "90": {
-          "release_date": "2021-06-15",
-          "status": "planned",
+          "release_date": "2021-06-29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/90",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "90"
         },
         "91": {
-          "release_date": "2021-07-13",
+          "release_date": "2021-07-27",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "91"
         },
         "92": {
-          "release_date": "2021-08-10",
+          "release_date": "2021-08-24",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "92"
         },
         "93": {
-          "release_date": "2021-09-07",
+          "release_date": "2021-09-21",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
-          "release_date": "2021-10-05",
+          "release_date": "2021-10-19",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "94"
         },
         "95": {
-          "release_date": "2021-11-02",
+          "release_date": "2021-11-16",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
-          "release_date": "2021-12-07",
+          "release_date": "2021-12-14",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
-          "release_date": "2022-01-11",
+          "release_date": "2022-01-25",
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "97"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes

I've updated the fx/fxa browser files to:

* correctly mark the nightly/beta/release/etc. status now that Fx88 has been released
* Add the Firefox 90 rel notes URL, now it exists
* Update all the release dates of the future Fx versions, which changed recently.

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

https://wiki.mozilla.org/Release_Management/Calendar#Future_branch_dates


