### PR TITLE
Update Edge versions for api.AudioListener.setOrientation

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -422,7 +422,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "25"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `setOrientation` member of the `AudioListener` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/API/AudioListener/setOrientation
