### PR TITLE
Add Edge versions for ContentIndex[Event] API

### DIFF
--- a/api/ContentIndex.json
+++ b/api/ContentIndex.json
@@ -12,7 +12,7 @@
             "version_added": "84"
           },
           "edge": {
-            "version_added": "84"
+            "version_added": false
           },
           "firefox": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": "84"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -109,7 +109,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": "84"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -158,7 +158,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": "84"
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/api/ContentIndexEvent.json
+++ b/api/ContentIndexEvent.json
@@ -12,7 +12,7 @@
             "version_added": "84"
           },
           "edge": {
-            "version_added": "84"
+            "version_added": false
           },
           "firefox": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ContentIndex` and `ContentIndexEvent` APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/API/ContentIndex
https://mdn-bcd-collector.appspot.com/tests/API/ContentIndexEvent
