### PR TITLE
Add Edge versions for DocumentTimeline API

### DIFF
--- a/api/DocumentTimeline.json
+++ b/api/DocumentTimeline.json
@@ -12,7 +12,7 @@
             "version_added": "54"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "80"
           },
           "firefox": [
             {
@@ -87,7 +87,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "80"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `DocumentTimeline` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/API/DocumentTimeline
