### PR TITLE
Add opera support for :where()

### DIFF
--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "74"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Updated :where() support in Opera.

Opera Desktop v74 is based on Chromium 88 which is where support was added.
