### PR TITLE
Add opera support for aspect-ratio

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -60,7 +60,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "74"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
Updated aspect-ratio support in Opera.

Opera Desktop v74 is based on Chromium 88 which is where support was added.
