### PR TITLE
Fix data for badging API.

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2406,6 +2406,7 @@
             },
             "edge": {
               "version_added": "83",
+              "partial_implementation": true,
               "notes": "Windows and Mac only."
             },
             "firefox": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -386,10 +386,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "81"
+              "version_added": "83",
+              "notes": "Windows and Mac only."
             },
             "chrome_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "edge": {
               "version_added": "81"
@@ -419,7 +420,7 @@
               "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": "81"
+              "version_added": false
             }
           },
           "status": {
@@ -2395,13 +2396,15 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "81"
+              "version_added": "83",
+              "notes": "Windows and Mac only."
             },
             "chrome_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "edge": {
-              "version_added": "81"
+              "version_added": "83",
+              "notes": "Windows and Mac only."
             },
             "firefox": {
               "version_added": false
@@ -2428,7 +2431,7 @@
               "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": "81"
+              "version_added": false
             }
           },
           "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2397,6 +2397,7 @@
           "support": {
             "chrome": {
               "version_added": "83",
+              "partial_implementation": true,
               "notes": "Windows and Mac only."
             },
             "chrome_android": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -387,6 +387,7 @@
           "support": {
             "chrome": {
               "version_added": "83",
+              "partial_implementation": true,
               "notes": "Windows and Mac only."
             },
             "chrome_android": {


### PR DESCRIPTION
I had a email exchange with one of the Chrome engineers who worked on this. 

>It shipped in 83. That was on Windows and Mac. It has never shipped on Linux, Android or Chrome OS (due to lack of support for badging for native apps on those platforms). It is coming to Chrome OS in 91.