### PR TITLE
Update Chromium versions for DocumentTimeline API

### DIFF
--- a/api/DocumentTimeline.json
+++ b/api/DocumentTimeline.json
@@ -6,13 +6,13 @@
         "spec_url": "https://drafts.csswg.org/web-animations/#the-documenttimeline-interface",
         "support": {
           "chrome": {
-            "version_added": "54"
+            "version_added": "84"
           },
           "chrome_android": {
-            "version_added": "54"
+            "version_added": "84"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "84"
           },
           "firefox": [
             {
@@ -50,10 +50,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "70"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "60"
           },
           "safari": {
             "version_added": "13.1"
@@ -62,10 +62,10 @@
             "version_added": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "54"
+            "version_added": "84"
           }
         },
         "status": {
@@ -81,13 +81,13 @@
           "description": "<code>DocumentTimeline()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "84"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "84"
             },
             "firefox": [
               {
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "13.1"
@@ -137,10 +137,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DocumentTimeline` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DocumentTimeline

Additional context:
While updating Edge's data to remove ranged versions, I noticed an inconsistency between the Chrome data and Edge.  After further review, I found that the data for this API was inaccurate, and that the API wasn't introduced before Chrome 84.  The original data seems to have come from #1023, which was a part of the wiki migration.

My best guess is that when the data was first added, the user that added it had a flag enabled which enabled the feature.  Since we're already working to remove flag data, I didn't bother to try to track down the flag.