### PR TITLE
Update Edge data for api.Gamepad.displayId

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -351,9 +351,22 @@
               "version_removed": "80",
               "notes": "Currently supported only by Google Daydream."
             },
-            "edge": {
-              "version_added": "15"
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "version_removed": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "WebVR"
+                  }
+                ]
+              },
+              {
+                "version_added": "15",
+                "version_removed": "79"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "55",


### PR DESCRIPTION
This PR updates the Edge data to mirror Chrome's data better, including the removal of non-flagged support when transitioning from EdgeHTML to Blink, as well as the single Edge version which supported the feature behind a flag.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Gamepad/displayId
