### PR TITLE
"transform-origin" is partially supported in Safari #9834

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2954,12 +2954,12 @@
               "safari": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://bugs.webkit.org/show_bug.cgi?id=201854'>bug 201854</a>"
+                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://webkit.org/b/201854'>bug 201854</a>"
               },
               "safari_ios": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://bugs.webkit.org/show_bug.cgi?id=201854'>bug 201854</a>"
+                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://webkit.org/b/201854'>bug 201854</a>"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2952,10 +2952,14 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://bugs.webkit.org/show_bug.cgi?id=201854'>bug 201854</a>"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Does not work with <code>transform</code> SVG presentation attribute. Only works with <code>transform</code> CSS property. See <a href='https://bugs.webkit.org/show_bug.cgi?id=201854'>bug 201854</a>"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
`transform-origin` SVG presentation attribute is only partially supported in Safari.
It doesn't properly work in desktop Safari versions 12.1.2, 13.1.2, 14.0.3, and iOS Safari 12, 13, 14 (didn't test in earlier versions).
`transform-origin` SVG attribute value is applied only to transformations defined in `transform` CSS property, but not in `transform` SVG attribute.
WebKit [bug 201854](https://bugs.webkit.org/show_bug.cgi?id=201854)
