### PR TITLE
Add `::-webkit-details-marker`

### DIFF
--- a/css/selectors/-webkit-details-marker.json
+++ b/css/selectors/-webkit-details-marker.json
@@ -1,0 +1,59 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-details-marker": {
+        "__compat": {
+          "description": "<code>::-webkit-details-marker</code>",
+          "support": {
+            "chrome": {
+              "version_added": "12",
+              "version_removed": "89"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "89"
+            },
+            "edge": {
+              "version_added": "79",
+              "version_removed": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "75"
+            },
+            "opera_android": {
+              "version_added": "≤14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "version_removed": "89"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes #9869.

The values here are either from testing (or mirroring from test browsers), with the exception of one point: support for this appearing in Chrome 12. I couldn't actually test this that far back. From testing, I could only show ≤15, but based on Safari and the `<details>` element appearing in Chrome 12, I'd guess that this landed at some point between 12 and 15. I figured it didn't matter that much where specifically, since it's on its way out of Chrome.