### PR TITLE
Cascade Opera support for `:where()` to subfeature

### DIFF
--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -113,7 +113,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "74"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
I merged #9984 prematurely. That change ought to have cascaded down to the subfeature, since it does for Chrome.
