### PR TITLE
Restore index.js entry point

### DIFF
--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -21,6 +21,12 @@ async function writeData() {
   await fs.writeFile(dest, data);
 }
 
+async function writeIndex() {
+  const dest = path.resolve(directory, 'index.js');
+  const content = `module.exports = require("./data.json");\n`;
+  await fs.writeFile(dest, content);
+}
+
 // Returns an array of promises for copying of all files that don't need transformation
 async function copyFiles() {
   for (const file of verbatimFiles) {
@@ -32,7 +38,7 @@ async function copyFiles() {
 
 function createManifest() {
   const full = require('../package.json');
-  const minimal = { main: 'data.json' };
+  const minimal = { main: 'index.js' };
 
   const minimalKeys = [
     'name',
@@ -80,6 +86,7 @@ async function main() {
 
   await writeManifest();
   await writeData();
+  await writeIndex();
   await copyFiles();
 
   console.log('Data bundle is ready');


### PR DESCRIPTION
This is required for ES module compatibility since it does not support JSON import.

If we don't want to do this then a major version bump should happen since #7398 was a breaking change.

Closes #9966 

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
