### PR TITLE
ascent-override, descent-override, line-gap-override

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -286,7 +286,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "87"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -201,6 +201,104 @@
             }
           }
         },
+        "ascent-override": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/ascent-override",
+            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-ascent-override",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": {
+                "version_added": "87"
+              },
+              "edge": {
+                "version_added": "87"
+              },
+              "firefox": {
+                "version_added": "89"
+              },
+              "firefox_android": {
+                "version_added": "89"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "73"
+              },
+              "opera_android": {
+                "version_added": "62"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "87"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "descent-override": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/descent-override",
+            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-descent-override",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": {
+                "version_added": "87"
+              },
+              "edge": {
+                "version_added": "87"
+              },
+              "firefox": {
+                "version_added": "89"
+              },
+              "firefox_android": {
+                "version_added": "89"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "73"
+              },
+              "opera_android": {
+                "version_added": "62"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "87"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "font-display": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-display",
@@ -598,6 +696,55 @@
               },
               "webview_android": {
                 "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "line-gap-override": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/line-gap-override",
+            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-line-gap-override",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": {
+                "version_added": "87"
+              },
+              "edge": {
+                "version_added": "87"
+              },
+              "firefox": {
+                "version_added": "89"
+              },
+              "firefox_android": {
+                "version_added": "89"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "73"
+              },
+              "opera_android": {
+                "version_added": "62"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "87"
               }
             },
             "status": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -741,7 +741,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "87"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -237,7 +237,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "87"


### PR DESCRIPTION
Another set of `@font-face` descriptors, which have already shipped in Chromium, and are shipping in Firefox in 89.

- https://bugs.chromium.org/p/chromium/issues/detail?id=800693#c30
- https://bugzilla.mozilla.org/show_bug.cgi?id=1681691
- https://github.com/mdn/content/issues/4299
