### PR TITLE
Add spec URLs for assorted Media* APIs

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -3,6 +3,7 @@
     "MediaCapabilities": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities",
+        "spec_url": "https://w3c.github.io/media-capabilities/#media-capabilities-interface",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "decodingInfo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo",
+          "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-decodinginfo",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -98,6 +100,7 @@
       "encodingInfo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo",
+          "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-encodinginfo",
           "support": {
             "chrome": {
               "version_added": "67",

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -3,6 +3,7 @@
     "MediaCapabilitiesInfo": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilitiesInfo",
+        "spec_url": "https://w3c.github.io/media-capabilities/#media-capabilities-info",
         "support": {
           "chrome": {
             "version_added": "66"

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -3,6 +3,7 @@
     "MediaDeviceInfo": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo",
+        "spec_url": "https://w3c.github.io/mediacapture-main/#device-info",
         "support": {
           "chrome": {
             "version_added": "55"
@@ -50,6 +51,7 @@
       "deviceId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/deviceId",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-deviceid",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -98,6 +100,7 @@
       "groupId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/groupId",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-groupid",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -148,6 +151,7 @@
       "kind": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/kind",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-kind",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -196,6 +200,7 @@
       "label": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/label",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-label",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -3,6 +3,7 @@
     "MediaDevices": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices",
+        "spec_url": "https://w3c.github.io/mediacapture-main/#mediadevices",
         "support": {
           "chrome": {
             "version_added": "47"
@@ -51,6 +52,7 @@
         "__compat": {
           "description": "<code>devicechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/devicechange_event",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#event-mediadevices-devicechange",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -99,6 +101,7 @@
       "enumerateDevices": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadevices-enumeratedevices",
           "support": {
             "chrome": {
               "version_added": "47"
@@ -173,6 +176,7 @@
       "getDisplayMedia": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia",
+          "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediadevices-getdisplaymedia",
           "description": "<code>getDisplayMedia()</code>",
           "support": {
             "chrome": {
@@ -288,6 +292,7 @@
       "getSupportedConstraints": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getSupportedConstraints",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getsupportedconstraints",
           "support": {
             "chrome": {
               "version_added": "53"
@@ -336,6 +341,7 @@
       "getUserMedia": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia",
           "support": {
             "chrome": {
               "version_added": "53",
@@ -448,6 +454,7 @@
       "ondevicechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/ondevicechange",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadevices-ondevicechange",
           "support": {
             "chrome": {
               "version_added": "57"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -3,6 +3,7 @@
     "MediaElementAudioSourceNode": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode",
+        "spec_url": "https://webaudio.github.io/web-audio-api/#MediaElementAudioSourceNode",
         "support": {
           "chrome": {
             "version_added": "14"
@@ -50,6 +51,7 @@
       "MediaElementAudioSourceNode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode",
           "description": "<code>MediaElementAudioSourceNode()</code> constructor",
           "support": {
             "chrome": {
@@ -103,6 +105,7 @@
       "mediaElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/mediaElement",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelement",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -3,6 +3,7 @@
     "MediaError": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError",
+        "spec_url": "https://html.spec.whatwg.org/multipage/media.html#mediaerror",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -57,6 +58,7 @@
       "code": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError/code",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-mediaerror-code-dev",
           "support": {
             "chrome": {
               "version_added": true
@@ -105,6 +107,7 @@
       "message": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaError/message",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-mediaerror-message-dev",
           "support": {
             "chrome": {
               "version_added": "59"

--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -3,6 +3,7 @@
     "MediaList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaList",
+        "spec_url": "https://drafts.csswg.org/cssom/#the-medialist-interface",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -242,6 +243,7 @@
       "mediaText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaList/mediaText",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-medialist-mediatext",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -3,6 +3,7 @@
     "MediaMetadata": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata",
+        "spec_url": "https://w3c.github.io/mediasession/#the-mediametadata-interface",
         "support": {
           "chrome": {
             "version_added": "57"
@@ -65,6 +66,7 @@
         "__compat": {
           "description": "<code>MediaMetadata()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/MediaMetadata",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -113,6 +115,7 @@
       "album": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/album",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-album",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -161,6 +164,7 @@
       "artist": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artist",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-artist",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -209,6 +213,7 @@
       "artwork": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/artwork",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-artwork",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -257,6 +262,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaMetadata/title",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediametadata-title",
           "support": {
             "chrome": {
               "version_added": "57"

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -3,6 +3,7 @@
     "MediaQueryList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList",
+        "spec_url": "https://drafts.csswg.org/cssom-view/#the-mediaquerylist-interface",
         "support": {
           "chrome": {
             "version_added": "9"
@@ -148,6 +149,7 @@
       "addListener": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/addListener",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-addlistener",
           "description": "<code>addListener()</code>",
           "support": {
             "chrome": {
@@ -199,6 +201,7 @@
       "matches": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/matches",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-matches",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -247,6 +250,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/media",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-media",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -295,6 +299,7 @@
       "onchange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/onchange",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-onchange",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -343,6 +348,7 @@
       "removeListener": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList/removeListener",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-removelistener",
           "description": "<code>removeListener()</code>",
           "support": {
             "chrome": {

--- a/api/MediaQueryListEvent.json
+++ b/api/MediaQueryListEvent.json
@@ -3,6 +3,7 @@
     "MediaQueryListEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent",
+        "spec_url": "https://drafts.csswg.org/cssom-view/#mediaquerylistevent",
         "support": {
           "chrome": {
             "version_added": "39"
@@ -50,6 +51,7 @@
       "MediaQueryListEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/MediaQueryListEvent",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent",
           "description": "<code>MediaQueryListEvent()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "matches": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/matches",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-matches",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -147,6 +150,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent/media",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-media",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -3,6 +3,7 @@
     "MediaSession": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession",
+        "spec_url": "https://w3c.github.io/mediasession/#the-mediasession-interface",
         "support": {
           "chrome": {
             "version_added": "73"
@@ -64,6 +65,7 @@
       "metadata": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/metadata",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-metadata",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -126,6 +128,7 @@
       "playbackState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/playbackState",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-playbackstate",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -188,6 +191,7 @@
       "setActionHandler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setActionHandler",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-setactionhandler",
           "description": "<code>setActionHandler()</code>",
           "support": {
             "chrome": {
@@ -251,6 +255,7 @@
       "setPositionState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setPositionState",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate",
           "description": "<code>setPositionState()</code>",
           "support": {
             "chrome": {

--- a/api/MediaSessionAction.json
+++ b/api/MediaSessionAction.json
@@ -3,6 +3,7 @@
     "MediaSessionAction": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction",
+        "spec_url": "https://w3c.github.io/mediasession/#enumdef-mediasessionaction",
         "description": "Media Session action types",
         "support": {
           "chrome": {
@@ -65,6 +66,7 @@
       "nexttrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#nexttrack",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-nexttrack",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -127,6 +129,7 @@
       "pause": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#pause",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-pause",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -189,6 +192,7 @@
       "play": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#play",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-play",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -251,6 +255,7 @@
       "previoustrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#previoustrack",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-previoustrack",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -313,6 +318,7 @@
       "seekbackward": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#seekbackward",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-seekbackward",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -375,6 +381,7 @@
       "seekforward": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#seekforward",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-seekforward",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -437,6 +444,7 @@
       "seekto": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#seekto",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-seekto",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -499,6 +507,7 @@
       "skipad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#skipad",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-skipad",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -561,6 +570,7 @@
       "stop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionAction#stop",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-stop",
           "support": {
             "chrome": {
               "version_added": "73"

--- a/api/MediaSessionActionDetails.json
+++ b/api/MediaSessionActionDetails.json
@@ -3,6 +3,7 @@
     "MediaSessionActionDetails": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionActionDetails",
+        "spec_url": "https://w3c.github.io/mediasession/#the-mediasessionactiondetails-dictionary",
         "support": {
           "chrome": {
             "version_added": "73"
@@ -64,6 +65,7 @@
       "action": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionActionDetails/action",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-action",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -126,6 +128,7 @@
       "fastSeek": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionActionDetails/fastSeek",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-fastseek",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -174,6 +177,7 @@
       "seekOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionActionDetails/seekOffset",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-seekoffset",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -236,6 +240,7 @@
       "seekTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSessionActionDetails/seekTime",
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-seektime",
           "support": {
             "chrome": {
               "version_added": "73"

--- a/api/MediaSettingsRange.json
+++ b/api/MediaSettingsRange.json
@@ -3,6 +3,7 @@
     "MediaSettingsRange": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSettingsRange",
+        "spec_url": "https://w3c.github.io/mediacapture-image/#mediasettingsrange-section",
         "support": {
           "chrome": {
             "version_added": "59"
@@ -50,6 +51,7 @@
       "max": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSettingsRange/max",
+          "spec_url": "https://w3c.github.io/mediacapture-image/#dom-mediasettingsrange-max",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -98,6 +100,7 @@
       "min": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSettingsRange/min",
+          "spec_url": "https://w3c.github.io/mediacapture-image/#dom-mediasettingsrange-min",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -146,6 +149,7 @@
       "step": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSettingsRange/step",
+          "spec_url": "https://w3c.github.io/mediacapture-image/#dom-mediasettingsrange-step",
           "support": {
             "chrome": {
               "version_added": "59"


### PR DESCRIPTION
This change adds spec URLs for all Media\* APIs for which spec URLs were not added in previous commits.