### PR TITLE
Firefox 89 enables `forced-colors` by default

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -634,18 +634,23 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "81",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.forced-colors.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "89"
+                },
+                {
+                  "version_added": "81",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.forced-colors.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "89"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/4302

Adding support for Firefox 89 for forced-colors.

https://bugzilla.mozilla.org/show_bug.cgi?id=1659511
