### PR TITLE
Update various spec urls

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -137,7 +137,7 @@
       "get": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/get",
-          "spec_url": "https://www.w3.org/TR/IndexedDB/#dom-idbindex-get",
+          "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-get",
           "support": {
             "chrome": {
               "version_added": "23"

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -100,7 +100,7 @@
       "firesTouchEvents": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceCapabilities/firesTouchEvents",
-          "spec_url": "https://wicg.github.io/InputDeviceCapabilities/#dom-inputdevicecapabilities-firestouchevents",
+          "spec_url": "https://wicg.github.io/input-device-capabilities/#dom-inputdevicecapabilities-firestouchevents",
           "support": {
             "chrome": {
               "version_added": "47"

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -3,10 +3,7 @@
     "MediaStreamTrack": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack",
-        "spec_url": [
-          "https://w3c.github.io/mediacapture-main/#mediastreamtrack",
-          "https://w3c.github.io/webrtc-identity/#isolated-track"
-        ],
+        "spec_url": "https://w3c.github.io/mediacapture-main/#mediastreamtrack",
         "support": {
           "chrome": {
             "version_added": "29"

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -112,7 +112,7 @@
             "shared": {
               "__compat": {
                 "description": "<code>shared</code> flag",
-                "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#webassemblymemory-constructor",
+                "spec_url": "https://webassembly.github.io/threads/js-api/index.html#dom-memorydescriptor-shared",
                 "support": {
                   "chrome": {
                     "version_added": "74"

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1936,10 +1936,7 @@
         "overflow": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/overflow",
-            "spec_url": [
-              "https://www.w3.org/TR/CSS2/visufx.html#overflow",
-              "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties"
-            ],
+            "spec_url": "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties",
             "support": {
               "chrome": {
                 "version_added": null
@@ -3076,10 +3073,7 @@
         "visibility": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/visibility",
-            "spec_url": [
-              "https://www.w3.org/TR/CSS2/visufx.html#visibility",
-              "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
-            ],
+            "spec_url": "https://svgwg.org/svg2-draft/render.html#VisibilityControl",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/marker.json
+++ b/svg/elements/marker.json
@@ -4,7 +4,7 @@
       "marker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/marker",
-          "spec_url": "https://svgwg.org/specs/markers/#MarkerElement",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerElement",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -4,7 +4,7 @@
       "path": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/path",
-          "spec_url": "https://svgwg.org/specs/paths/#PathElement",
+          "spec_url": "https://svgwg.org/svg2-draft/paths.html#PathElement",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
https://www.w3.org/TR/IndexedDB -> https://w3c.github.io/IndexedDB
https://wicg.github.io/InputDeviceCapabilities -> https://wicg.github.io/input-device-capabilities

https://w3c.github.io/webrtc-identity -> https://w3c.github.io/webrtc-identity/identity.html (given that's in browser-specs)

https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#webassemblymemory-constructor ->
https://webassembly.github.io/threads/js-api/index.html#dom-memorydescriptor-shared (the actual rendered spec, not in browser-specs yet, though. Will ask for inclusion).

Removal of https://www.w3.org/TR/CSS2.

https://svgwg.org/specs/markers/ and https://svgwg.org/specs/paths aren't in browser-specs, so I removed them.
This PR https://github.com/w3c/browser-specs/pull/253 says "incomplete draft not being maintained, should be classified only as rough proposal".   