### PR TITLE
aspect-ratio shipped in Firefox 89

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -29,6 +29,9 @@
             },
             "firefox": [
               {
+                "version_added": "89"
+              },
+              {
                 "version_added": "83",
                 "partial_implementation": true,
                 "notes": "Firefox 83 implements aspect-ratio for flex items.",


### PR DESCRIPTION
Firefox has now shipped aspect-ratio support on by default in FF 89, see https://bugzilla.mozilla.org/show_bug.cgi?id=1672073#c4.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
