### PR TITLE
FF89 removal DeviceProximityEvent and Window.ondeviceproximityevent

### DIFF
--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -41,7 +41,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "version_removed": "89",
+              "version_removed": "79",
               "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
             },
             {

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -23,7 +23,8 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "version_removed": "89",
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
             },
             {
               "version_added": true,
@@ -40,7 +41,8 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "version_removed": "89",
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
             },
             {
               "version_added": "15",
@@ -98,7 +100,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": true,
@@ -115,7 +118,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": "15",
@@ -174,7 +178,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": true,
@@ -191,7 +196,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": "15",
@@ -250,7 +256,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": true,
@@ -267,7 +274,8 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": "15",

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -79,7 +79,6 @@
       },
       "max": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceProximityEvent/max",
           "support": {
             "chrome": {
               "version_added": false
@@ -157,7 +156,6 @@
       },
       "min": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceProximityEvent/min",
           "support": {
             "chrome": {
               "version_added": false
@@ -235,7 +233,6 @@
       },
       "value": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceProximityEvent/value",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -117,7 +117,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "version_removed": "89",
+                "version_removed": "79",
                 "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
@@ -194,7 +194,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "version_removed": "89",
+                "version_removed": "79",
                 "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
@@ -271,7 +271,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "version_removed": "89",
+                "version_removed": "79",
                 "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -16,33 +16,31 @@
           "firefox": [
             {
               "version_added": "62",
+              "version_removed": "89",
               "flags": [
                 {
                   "type": "preference",
                   "name": "device.sensors.proximity.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "version_removed": "89",
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              ]
             },
             {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "61"
             }
           ],
           "firefox_android": [
             {
               "version_added": "62",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
                   "name": "device.sensors.proximity.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "version_removed": "79",
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              ]
             },
             {
               "version_added": "15",
@@ -92,33 +90,31 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "89",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "61"
               }
             ],
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "79",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",
@@ -169,33 +165,31 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "89",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "61"
               }
             ],
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "79",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",
@@ -246,33 +240,31 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "89",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "61"
               }
             ],
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "79",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4625,14 +4625,44 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "15",
-              "version_removed": "89"
-            },
-            "firefox_android": {
-              "version_added": "15",
-              "version_removed": "89"
-            },
+            
+            
+            "firefox": [
+              {
+                "version_added": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              },
+              {
+                "version_added": true,
+                "version_removed": "61"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "62",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "version_removed": "89",
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "61"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -4626,10 +4626,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "89"
             },
             "firefox_android": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "89"
             },
             "ie": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -4625,8 +4625,6 @@
             "edge": {
               "version_added": false
             },
-            
-            
             "firefox": [
               {
                 "version_added": "62",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4628,33 +4628,31 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "89",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "61"
               }
             ],
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "version_removed": "89",
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",


### PR DESCRIPTION
- FF89 docs tracking: https://github.com/mdn/content/issues/4308
- Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1699707 

Essentially this event has been removed from firefox in FF89 (which was the last thing that supported it). Further, previously this was present behind a preference, so the Android removal is effectively FF79 - see https://github.com/mdn/browser-compat-data/issues/9679

For MDN I have removed the attribute docs (max, min, value) so these urls have also been removed from BCD