### PR TITLE
Update aspect-ratio.json with added support in Safari TP R123

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -66,7 +66,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "TP"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Safari Technical Preview release 123 includes support for the CSS aspect-ratio property by default, per https://developer.apple.com/safari/technology-preview/release-notes/