### PR TITLE
Update `html.elements.img.aspect_ratio_computed_from_attributes` to include information about Safari's implementation

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -187,12 +187,12 @@
               "safari": {
                 "version_added": "14",
                 "partial_implementation": true,
-                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://bugs.webkit.org/show_bug.cgi?id=224197"
+                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://webkit.org/b/224197"
               },
               "safari_ios": {
                 "version_added": "14",
                 "partial_implementation": true,
-                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://bugs.webkit.org/show_bug.cgi?id=224197"
+                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://webkit.org/b/224197"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -185,10 +185,14 @@
                 "version_added": "57"
               },
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://bugs.webkit.org/show_bug.cgi?id=224197"
               },
               "safari_ios": {
-                "version_added": "14"
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Safari's implementation does not yet work properly with lazy-loaded images. See: https://bugs.webkit.org/show_bug.cgi?id=224197"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"


### PR DESCRIPTION
Safari's implementation of `aspect_ratio_computed_from_attributes` currently does not work as intended with lazy-loaded images, per https://bugs.webkit.org/show_bug.cgi?id=224197. A fix has been committed and should be rolled out in a future release of Safari.