### PR TITLE
The image-set type function is in Firefox 89

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2054,7 +2054,7 @@
               "firefox": {
                 "version_added": "88",
                 "notes": [
-                  "Prior to Firefox 89, the <code>type()</code> function was not supported as an argument to <code>image-set()</code>.",
+                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>.",
                   "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
                 ]
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2054,7 +2054,7 @@
               "firefox": {
                 "version_added": "88",
                 "notes": [
-                  "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>. See <a href='https://bugzil.la/1695404'>bug 1695404</a>.",
+                  "Prior to Firefox 89, the <code>type()</code> function was not supported as an argument to <code>image-set()</code>.",
                   "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
                 ]
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -2054,15 +2054,15 @@
               "firefox": {
                 "version_added": "88",
                 "notes": [
-                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>.",
-                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
+                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 ]
               },
               "firefox_android": {
                 "version_added": "88",
                 "notes": [
-                  "The <code>type()</code> function is not supported as an argument to <code>image-set()</code>. See <a href='https://bugzil.la/1695404'>bug 1695404</a>.",
-                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>."
+                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
+                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
                 ]
               },
               "ie": {


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/4306

The `type()` function is supported in `image-set()` as from Firefox 89. Updated the note.
