### PR TITLE
Add Safari 14.1 support for input type, date, datetime-local and time.

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -170,6 +170,13 @@
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
+        },
+        "14.1": {
+          "release_date": "2021-04-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -33,8 +33,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/119175'>bug 119175</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": "5"

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -34,8 +34,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": true

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -33,8 +33,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": true


### PR DESCRIPTION
Safari 14.1 has added support for input type, date, datetime-local and time. Tested on Safari Version 14.1 (16611.1.21.161.3) on macOS 11.3.

Also added Safari 14.1 to the Safari versions. However, I'm unable to find the webkit version, and no release notes have been published yet so I'm leaving them the same as Safari 14.