### PR TITLE
Fix Samsung Internet release dates

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -184,7 +184,7 @@
           "engine_version": "83"
         },
         "13.2": {
-          "release_date": "2020-11-26",
+          "release_date": "2021-01-20",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "83"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -190,7 +190,7 @@
           "engine_version": "83"
         },
         "14.0": {
-          "release_date": "2020-03-12",
+          "release_date": "2021-04-17",
           "status": "current",
           "engine": "Blink",
           "engine_version": "87"


### PR DESCRIPTION
The release date of Samsung Internet 14.0 and 13.2 are wrong. At first, I thought they were accidentally set to `2020` instead of `2021`, but the months also seem to be wrong. The new dates are set based on the Google Play release date and the date on [Samsung's own website](https://developer.samsung.com/internet/release-note.html).

CC @AdaRoseCannon (who added these dates in #9868), just in case you know something I don't :)