### PR TITLE
Mark ShadowRoot.p.delegatesFocus standard & undeprecated

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -89,9 +89,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
https://github.com/whatwg/dom/pull/974 added `ShadowRoot.prototype.delegatesFocus` to the DOM spec (see https://github.com/whatwg/dom/commit/f346858). And per https://github.com/whatwg/dom/issues/931#issuecomment-827075191 (https://trac.webkit.org/r276585) it’s been implemented in WebKit.

So given that it’s now part of the DOM standard, and implemented in multiple browsers, this changes resets the BCD status flags for it.

Related MDN change: https://github.com/mdn/content/pull/4508
