### PR TITLE
FF89 removal UserProximityEvent and Window.onuserproximity

### DIFF
--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -23,11 +23,10 @@
                   "name": "device.sensors.proximity.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              ]
             },
             {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "61"
             }
           ],
@@ -41,11 +40,10 @@
                   "name": "device.sensors.proximity.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              ]
             },
             {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "61"
             }
           ],
@@ -99,11 +97,10 @@
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "61"
               }
             ],
@@ -117,8 +114,7 @@
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -16,6 +16,7 @@
           "firefox": [
             {
               "version_added": "62",
+              "version_removed": "89",
               "flags": [
                 {
                   "type": "preference",
@@ -23,7 +24,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
             },
             {
               "version_added": true,
@@ -33,6 +34,7 @@
           "firefox_android": [
             {
               "version_added": "62",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -40,7 +42,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
             },
             {
               "version_added": true,
@@ -77,7 +79,6 @@
       },
       "near": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/UserProximityEvent/near",
           "support": {
             "chrome": {
               "version_added": false
@@ -91,6 +92,7 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
@@ -98,7 +100,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": true,
@@ -108,6 +110,7 @@
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
@@ -115,7 +118,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1699707'>bug 1699707</a>."
               },
               {
                 "version_added": "15",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4993,8 +4993,7 @@
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",
@@ -5011,8 +5010,7 @@
                     "name": "device.sensors.proximity.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+                ]
               },
               {
                 "version_added": "15",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4983,12 +4983,42 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "15"
-            },
-            "firefox_android": {
-              "version_added": "15"
-            },
+            "firefox": [
+              {
+                "version_added": "62",
+                "version_removed": "89",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "61"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "62",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.proximity.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1699707'>bug 1699707</a>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "61"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This API was previously under a preference and was supposed to be removed (along with `DeviceProximityEvent`) in FF89 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1699707#c15. Prior to that it was behind a preference, which effectively means that it was removed in FF79 on Android (see #9679).

However while `DeviceProximityEvent` was actually removed this was not, because it is still useful for KaiOS (only). However as per the [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1699707#c15) the INTENT is that this is off for Android and that a user will not turn it on.

So what I have done is make this match `DeviceProximityEvent` - it is shown as being removed in v89 for desktop and v79 for android. I also "rationalised" the windows event handler to match the versionining, because without the pref set you won't get an event. 

I do not mention KaiOS because we have no Firefox for KaiOS option.

Docs tracking for this is in https://github.com/mdn/content/issues/4308