### PR TITLE
FF89 removal DeviceLightEvent and Window.ondevicelight

### DIFF
--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -24,8 +24,7 @@
                   "name": "device.sensors.ambientLight.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+              ]
             },
             {
               "version_added": "22",
@@ -43,8 +42,7 @@
                   "name": "device.sensors.ambientLight.enabled",
                   "value_to_set": "true"
                 }
-              ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+              ]
             },
             {
               "version_added": "15",
@@ -102,8 +100,7 @@
                     "name": "device.sensors.ambientLight.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+                ]
               },
               {
                 "version_added": "22",
@@ -121,8 +118,7 @@
                     "name": "device.sensors.ambientLight.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+                ]
               },
               {
                 "version_added": "15",

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -17,6 +17,7 @@
           "firefox": [
             {
               "version_added": "62",
+              "version_removed": "89",
               "flags": [
                 {
                   "type": "preference",
@@ -24,7 +25,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
             },
             {
               "version_added": "22",
@@ -35,6 +36,7 @@
           "firefox_android": [
             {
               "version_added": "62",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -42,7 +44,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+              "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
             },
             {
               "version_added": "15",
@@ -79,7 +81,6 @@
       },
       "value": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceLightEvent/value",
           "support": {
             "chrome": {
               "version_added": false
@@ -94,6 +95,7 @@
             "firefox": [
               {
                 "version_added": "62",
+                "version_removed": "89",
                 "flags": [
                   {
                     "type": "preference",
@@ -101,7 +103,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
               },
               {
                 "version_added": "22",
@@ -112,6 +114,7 @@
             "firefox_android": [
               {
                 "version_added": "62",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",
@@ -119,7 +122,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>."
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
               },
               {
                 "version_added": "15",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4443,8 +4443,7 @@
                     "name": "device.sensors.ambientLight.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+                ]
               },
               {
                 "version_added": "22",
@@ -4462,8 +4461,7 @@
                     "name": "device.sensors.ambientLight.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+                ]
               },
               {
                 "version_added": "15",

--- a/api/Window.json
+++ b/api/Window.json
@@ -4433,12 +4433,43 @@
               "version_added": "13",
               "version_removed": "79"
             },
-            "firefox": {
-              "version_added": "15"
-            },
-            "firefox_android": {
-              "version_added": "15"
-            },
+            "firefox": [
+              {
+                "version_added": "62",
+                "version_removed": "89",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.ambientLight.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+              },
+              {
+                "version_added": "22",
+                "version_removed": "61",
+                "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "62",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "device.sensors.ambientLight.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1462308'>bug 1462308</a>, <a href='https://bugzil.la/1701824'>bug 1701824</a>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "61"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This is just like #10103 (removal of UserProximityEvent). As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1701824#c5 the API is intended to be removed in FF89. There has been a preference and there is still a preference, however the intent is that this not be re-enabled on android. It is ONLY present because KaiOS still uses this.

I have documented so that android is shown as removing support in FF79 (https://github.com/mdn/browser-compat-data/issues/9679) and desktop goes in FF89. I don't talk about KaiOS. The window versions have been matched to the event versions for firefox. This makes sense because if the event can't fire unless the preference is enabled, then IMO the API has the same versioning as the event even if it was not explicitly disabled in the same versions.

I also removed the docs links for the sub-feature, as will be removing that file from MDN.

Docs tracking for this is https://github.com/mdn/content/issues/4308
