### PR TITLE
Add safari support for flex gap

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -37,10 +37,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -33,10 +33,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -33,10 +33,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Added safari version with flex gap support. I tested it using the following Testcase on Safari 14.1 on macOS 10.15.7 and on iOS 14.5.

Testcase: https://codepen.io/manuelmeister/pen/zYNbVGK?editors=1100
Release Notes: https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release_notes
TP Release Notes: https://developer.apple.com/safari/technology-preview/release-notes/#r115
Bug: https://bugs.webkit.org/show_bug.cgi?id=206767