### PR TITLE
Spec URL normalization: HTMLTemplateElement to MimeTypeArray

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -51,7 +51,7 @@
       "content": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/content",
-          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-content",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-content-dev",
           "support": {
             "chrome": {
               "version_added": "26"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -429,7 +429,7 @@
       "labels": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/labels",
-          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels-dev",
           "support": {
             "chrome": {
               "version_added": "6"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -1020,7 +1020,7 @@
       "videoHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/videoHeight",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1069,7 +1069,7 @@
       "videoWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/videoWidth",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -51,7 +51,7 @@
       "newURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/newURL",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-newurl",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-newurl-dev",
           "support": {
             "chrome": {
               "version_added": true
@@ -100,7 +100,7 @@
       "oldURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/oldURL",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-oldurl",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-oldurl-dev",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -3,7 +3,7 @@
     "ImageBitmap": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageBitmap",
-        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#imagebitmap",
+        "spec_url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap",
         "support": {
           "chrome": {
             "version_added": "50"

--- a/api/Location.json
+++ b/api/Location.json
@@ -3,7 +3,7 @@
     "Location": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location",
-        "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#the-location-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-location-interface",
         "support": {
           "chrome": {
             "version_added": "1"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -54,7 +54,7 @@
       "MessageEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MessageEvent/MessageEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/#dom-event-constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface:dom-event-constructor",
           "description": "<code>MessageEvent()</code> constructor",
           "support": {
             "chrome": {

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -3,7 +3,7 @@
     "MimeType": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeType",
-        "spec_url": "https://html.spec.whatwg.org/multipage/#mimetype",
+        "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#mimetype",
         "support": {
           "chrome": {
             "version_added": "1"

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -3,7 +3,7 @@
     "MimeTypeArray": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MimeTypeArray",
-        "spec_url": "https://html.spec.whatwg.org/multipage/#mimetypearray",
+        "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#mimetypearray",
         "support": {
           "chrome": {
             "version_added": "1"


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/10090

---

This is the last batch for the api directory tree. There are some remaining ones in the css, html, http, and svg trees that I’ll raise PRs for next.