### PR TITLE
Fix some broken CSS spec URLs

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>calc()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc()",
-          "spec_url": "https://drafts.csswg.org/css-values/#calc-function",
+          "spec_url": "https://drafts.csswg.org/css-values/#calc-func",
           "support": {
             "chrome": [
               {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -53,7 +53,7 @@
         "cross-fade": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade()",
-            "spec_url": "https://drafts.csswg.org/css-images/#cross-fade-function",
+            "spec_url": "https://drafts.csswg.org/css-images-4/#cross-fade-function",
             "description": "<code>cross-fade()</code>",
             "support": {
               "chrome": {
@@ -133,7 +133,7 @@
         "element": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element()",
-            "spec_url": "https://drafts.csswg.org/css-images/#element-notation",
+            "spec_url": "https://drafts.csswg.org/css-images-4/#element-notation",
             "description": "<code>element()</code>",
             "support": {
               "chrome": {
@@ -327,7 +327,7 @@
             "__compat": {
               "description": "<code>conic-gradient()</code>",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient()",
-              "spec_url": "https://drafts.csswg.org/css-images/#conic-gradients",
+              "spec_url": "https://drafts.csswg.org/css-images-4/#conic-gradients",
               "support": {
                 "chrome": {
                   "version_added": "69"
@@ -1981,7 +1981,7 @@
         "image": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image()",
-            "spec_url": "https://drafts.csswg.org/css-images/#image-notation",
+            "spec_url": "https://drafts.csswg.org/css-images-4/#image-notation",
             "description": "<code>image()</code>",
             "support": {
               "chrome": {
@@ -2036,7 +2036,7 @@
         "image-set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set()",
-            "spec_url": "https://drafts.csswg.org/css-images/#image-set-notation",
+            "spec_url": "https://drafts.csswg.org/css-images-4/#image-set-notation",
             "description": "<code>image-set()</code>",
             "support": {
               "chrome": {


### PR DESCRIPTION
* We added several CSS Images spec URLs with anchors that don’t exist in CSS Images 3 spec, so this change replaces those with URLs for the CSS Images 4 spec, where those anchors do exist.

* We added a spec URL for CSS `calc()` with a `#calc-function` anchor that doesn’t exist in the CSS Values spec — so this change replaces that with a #calW`func anchor, with does exist.