### PR TITLE
Drop unnecessary spec URL for CSS viewport-fit

### DIFF
--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -5,10 +5,7 @@
         "__compat": {
           "description": "<code>@viewport</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@viewport",
-          "spec_url": [
-            "https://drafts.csswg.org/css-round-display/#extending-viewport-rule",
-            "https://drafts.csswg.org/css-device-adapt/#atviewport-rule"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-device-adapt/#atviewport-rule",
           "support": {
             "chrome": {
               "version_removed": "84",


### PR DESCRIPTION
In https://github.com/mdn/browser-compat-data/pull/7514 (https://github.com/mdn/browser-compat-data/commit/c0e0e2b) we removed data for the viewport-fit descriptor from BCD.  So this change drops corresponding spec URL for the definition of the viewport-fit descriptor in the CSS Round Display spec.