### PR TITLE
Fix broken spec URLs for SVG xml:lang and <cursor> element

### DIFF
--- a/svg/attributes/core.json
+++ b/svg/attributes/core.json
@@ -203,7 +203,7 @@
           "__compat": {
             "description": "xml:lang",
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/xml:lang",
-            "spec_url": "https://svgwg.org/svg2-draft/struct.html#XMLLangAttribute",
+            "spec_url": "https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -4,7 +4,7 @@
       "cursor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/cursor",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#CursorElement",
+          "spec_url": "https://www.w3.org/TR/SVG11/interact.html#CursorElement",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
There’s no `#XMLLangAttribute` anchor in the SVG2 spec, so this change replaces that anchor with the correct SVG2 anchor, `#LangSpaceAttrs.`

Also, there’s no `<cursor>` element in SVG2 (it was dropped), and so no `#CursorElement` anchor — and so this change replaces the SVG2 spec URL with a URL for the SVG1.1 (where that `#CursorElement` anchor does exist).