### PR TITLE
Safari class support update

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -533,10 +533,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -585,16 +585,28 @@
             "opera_android": {
               "version_added": "51"
             },
-            "safari": {
-              "version_added": "14",
-              "partial_implementation": true,
-              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
-            },
-            "safari_ios": {
-              "version_added": "14",
-              "partial_implementation": true,
-              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_removed": "14.1",
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
+              },
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_removed": "14.5",
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
+              },
+            ],
             "samsunginternet_android": {
               "version_added": false
             },
@@ -734,10 +746,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": [
               {
@@ -801,10 +813,10 @@
               "version_added": "51"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This updates the public/private field support for class in latest Safari and Safari on iOS.

All sources are linked here:  https://github.com/Fyrd/caniuse/pull/5858
