### PR TITLE
Update api.Response.headers for Safari

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -526,10 +526,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Reported in #9512 and confirmed by testing with https://mdn-bcd-collector.appspot.com/tests/api/Response/headers.

Fixes https://github.com/mdn/browser-compat-data/issues/9512.