### PR TITLE
`api.Animation.updatePlaybackRate` - add Chrome support

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -1219,10 +1219,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-updateplaybackrate",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -1252,7 +1252,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {

--- a/api/Animation.json
+++ b/api/Animation.json
@@ -1225,7 +1225,7 @@
               "version_added": "76"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "60"
@@ -1237,10 +1237,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -1249,7 +1249,7 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": "76"


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/6703.
   
Source: https://chromestatus.com/feature/6276633918963712
    
Confirmed by test with: https://mdn-bcd-collector.appspot.com/tests/api/Animation/updatePlaybackRate

Mirrored from Chrome to Edge, Opera, etc.
