### PR TITLE
Updates for Safari 14.1 on macOS and Safari on iOS 14.5

### DIFF
--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -31,10 +31,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -80,10 +80,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -180,10 +180,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -230,10 +230,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -280,10 +280,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -373,10 +373,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -83,10 +83,10 @@
               "notes": "The <code>context</code> parameter was supported up until version 44, but has now been removed."
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -134,10 +134,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -183,10 +183,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -183,10 +183,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -57,14 +57,24 @@
               "prefix": "webkit"
             }
           ],
-          "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
-          },
-          "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "6",
+              "prefix": "webkit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "14.5"
+            },
+            {
+              "version_added": "6",
+              "prefix": "webkit"
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "3.0"
@@ -166,14 +176,24 @@
                 "prefix": "webkit"
               }
             ],
-            "safari": {
-              "version_added": "6.1",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": "6.1",
-              "prefix": "webkit"
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "6.1",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "6.1",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
@@ -336,10 +356,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -632,10 +652,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -84,10 +84,12 @@
               "version_removed": "43"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤10.3",
+              "version_removed": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -137,10 +139,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -188,10 +190,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -239,10 +241,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -290,10 +292,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -341,10 +343,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -392,10 +394,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -544,10 +546,12 @@
               "version_removed": "43"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "≤10.3",
+              "version_removed": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -597,10 +601,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -648,10 +652,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -699,10 +703,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -80,7 +80,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -126,10 +126,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -29,10 +29,10 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -76,10 +76,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -124,10 +124,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -172,10 +172,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -220,10 +220,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -268,10 +268,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -316,10 +316,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -364,10 +364,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -77,10 +77,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -128,10 +128,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -177,10 +177,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -226,10 +226,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -85,16 +85,26 @@
               "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
             }
           ],
-          "safari": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
-          },
-          "safari_ios": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "14.5"
+            },
+            {
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "The <code>BaseAudioContext</code> interface itself is not present, but many of the methods are available on the <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/OfflineAudioContext'><code>OfflineAudioContext</code></a> interfaces."
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "6.0"
@@ -154,10 +164,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -497,10 +507,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -742,10 +752,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1059,10 +1069,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -83,10 +83,10 @@
               "notes": "Before Opera 46, the default values were not supported."
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -134,7 +134,7 @@
               "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -310,10 +310,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -363,7 +363,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/BlobEvent.json
+++ b/api/BlobEvent.json
@@ -30,10 +30,10 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -79,10 +79,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -177,10 +177,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -85,10 +85,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -30,10 +30,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -79,10 +79,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -128,10 +128,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -81,10 +81,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -31,7 +31,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -317,10 +317,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.2"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -558,10 +558,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -30,7 +30,7 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false
@@ -81,7 +81,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false
@@ -132,7 +132,7 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -29,10 +29,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "12.0"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -44,10 +44,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -93,10 +93,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -142,10 +142,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -191,10 +191,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -240,10 +240,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -289,10 +289,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -31,12 +31,26 @@
           "opera_android": {
             "version_added": "36"
           },
-          "safari": {
-            "version_added": "14"
-          },
-          "safari_ios": {
-            "version_added": "14"
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "14.0.2",
+              "partial_implementation": true,
+              "notes": "Does not include support of pause and resume."
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "14.5"
+            },
+            {
+              "version_added": "14.3",
+              "partial_implementation": true,
+              "notes": "Does not include support of pause and resume."
+            }
+          ],
           "samsunginternet_android": {
             "version_added": "5.0"
           },
@@ -81,10 +95,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -128,10 +142,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": "14"
+                "version_added": "14.0.2"
               },
               "safari_ios": {
-                "version_added": "14"
+                "version_added": "14.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -178,10 +192,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -228,10 +242,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -331,10 +345,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -397,10 +411,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -454,10 +468,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -503,10 +517,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -650,10 +664,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -699,10 +713,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -797,10 +811,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -846,10 +860,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -895,10 +909,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -944,10 +958,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1009,10 +1023,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1066,10 +1080,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1131,10 +1145,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14.0.2"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1180,10 +1194,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": false,
@@ -93,7 +93,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false,
@@ -148,7 +148,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false,

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -41,10 +41,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": false

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -56,14 +56,26 @@
               "prefix": "webkit"
             }
           ],
-          "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
-          },
-          "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "6",
+              "version_removed": "14.1",
+              "prefix": "webkit"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "14.5"
+            },
+            {
+              "version_added": "6",
+              "version_removed": "14.5",
+              "prefix": "webkit"
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "3.0"
@@ -148,14 +160,26 @@
                 "prefix": "webkit"
               }
             ],
-            "safari": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": "6",
-              "prefix": "webkit"
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "14.1",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "14.5",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "3.0"
@@ -212,10 +236,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -310,10 +334,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -453,12 +477,26 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": null
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "14.1",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "≤10.3",
+                "version_removed": "14.5",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "1.5"
             },
@@ -501,10 +539,10 @@
                 "version_added": "29"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
@@ -550,10 +588,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -79,7 +79,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -28,9 +28,16 @@
           "opera_android": {
             "version_added": "14"
           },
-          "safari": {
-            "version_added": "6"
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "6",
+              "version_removed": "14.1",
+              "prefix": "webkit"
+            }
+          ],
           "safari_ios": {
             "version_added": "6"
           },
@@ -79,7 +86,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false
@@ -369,10 +376,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -417,10 +424,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -465,10 +472,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -561,10 +568,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -609,10 +616,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -657,10 +664,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -904,10 +911,12 @@
               "version_removed": "43"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "14.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "1.0",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -1230,10 +1230,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -79,10 +79,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -126,10 +126,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -78,10 +78,10 @@
               "version_added": "56"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -29,10 +29,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -126,10 +126,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -29,10 +29,10 @@
             "version_added": "44"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "8.0"

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -134,10 +134,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -230,10 +230,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -278,10 +278,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -326,10 +326,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -374,10 +374,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -422,10 +422,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -470,10 +470,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -518,10 +518,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -662,10 +662,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -758,10 +758,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -806,10 +806,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2715,7 +2715,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3852,10 +3852,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -32,7 +32,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -79,7 +79,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -476,10 +476,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -35,10 +35,12 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "prefix": "webkit",
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "prefix": "webkit",
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -93,10 +95,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "prefix": "webkit",
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "prefix": "webkit",
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "prefix": "webkit",
@@ -148,10 +152,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -199,10 +203,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -248,10 +252,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -299,10 +303,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -350,10 +354,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -399,10 +403,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -503,10 +507,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -556,10 +560,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -609,10 +613,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -660,10 +664,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -711,10 +715,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -764,10 +768,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -817,10 +821,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -870,10 +874,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -923,10 +927,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -976,10 +980,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1029,10 +1033,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1082,10 +1086,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1135,10 +1139,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1188,10 +1192,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1241,10 +1245,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1292,10 +1296,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1394,10 +1398,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1443,10 +1447,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1492,10 +1496,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1541,10 +1545,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1592,10 +1596,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -1643,10 +1647,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1694,10 +1698,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": true,
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -137,10 +137,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -45,10 +45,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": [
             {
@@ -108,10 +108,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -156,10 +156,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -35,10 +35,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
@@ -195,10 +195,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -248,10 +248,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": true,
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -137,10 +137,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -190,10 +190,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": true,
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -137,10 +137,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -29,7 +29,7 @@
             "version_added": "28"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false
@@ -79,7 +79,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false
@@ -129,7 +129,7 @@
               "version_added": "28"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/TextDecoderStream.json
+++ b/api/TextDecoderStream.json
@@ -29,10 +29,10 @@
             "version_added": "50"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -77,10 +77,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -125,10 +125,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -173,10 +173,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -221,10 +221,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -269,10 +269,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -317,10 +317,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -265,10 +265,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/TextEncoderStream.json
+++ b/api/TextEncoderStream.json
@@ -29,10 +29,10 @@
             "version_added": "50"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -77,10 +77,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -125,10 +125,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -173,10 +173,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -221,10 +221,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -29,10 +29,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -77,10 +77,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -125,10 +125,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -173,10 +173,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -29,10 +29,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -76,10 +76,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -124,10 +124,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -172,10 +172,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -220,10 +220,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -365,10 +365,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -413,10 +413,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -79,10 +79,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0",

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -5687,7 +5687,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -29,10 +29,10 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -29,10 +29,10 @@
             "version_added": "44"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -125,10 +125,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -172,10 +172,10 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -220,10 +220,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -268,10 +268,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -29,10 +29,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -29,10 +29,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -125,10 +125,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -173,10 +173,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -221,10 +221,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -269,10 +269,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -317,10 +317,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -365,10 +365,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -413,10 +413,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/_mixins/ParentNode__Document.json
+++ b/api/_mixins/ParentNode__Document.json
@@ -431,7 +431,7 @@
               "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/_mixins/ParentNode__DocumentFragment.json
+++ b/api/_mixins/ParentNode__DocumentFragment.json
@@ -431,7 +431,7 @@
               "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/_mixins/ParentNode__Element.json
+++ b/api/_mixins/ParentNode__Element.json
@@ -438,7 +438,7 @@
               "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "14"
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -173,6 +173,19 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"
+        },
+        "14.0.2": {
+          "release_date": "2020-12-14",
+          "release_notes": "https://support.apple.com/en-us/HT212007",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "610.3.7.1.9"
+        },
+        "14.1": {
+          "release_date": "2020-04-26",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "611.1.21.161.3"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -158,8 +158,18 @@
           "engine": "WebKit",
           "engine_version": "610.1.28"
         },
+        "14.3": {
+          "release_date": "2020-12-14",
+          "release_notes": "https://support.apple.com/en-us/HT211808#143",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "610.3.7"
+        },
         "14.5": {
-          "status": "beta"
+          "release_date": "2021-04-26",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "611.1.21.161.6"
         }
       }
     }

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -69,7 +69,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -74,10 +74,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -86,10 +86,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -33,10 +33,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -95,10 +95,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -57,10 +57,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -81,10 +81,10 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -30,18 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-bottom",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-bottom",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-bottom",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-bottom",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -30,18 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-left",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-left",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-left",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-left",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -30,18 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-right",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-right",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-right",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-right",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -30,18 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-top",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-top",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-top",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin-top",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -30,18 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "alternative_name": "scroll-snap-margin",
+                "partial_implementation": true,
+                "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -33,8 +33,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/119175'>bug 119175</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": "5"

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -34,8 +34,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": false,
-                "notes": "The input type is recognized, but there is no date-specific control. See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": true

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -45,10 +45,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -108,10 +108,10 @@
                 "version_added": "60"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -171,10 +171,10 @@
                 "version_added": "60"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -234,10 +234,10 @@
                 "version_added": "60"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -45,10 +45,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -108,10 +108,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -171,10 +171,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -533,10 +533,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -585,16 +585,26 @@
             "opera_android": {
               "version_added": "51"
             },
-            "safari": {
-              "version_added": "14",
-              "partial_implementation": true,
-              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
-            },
-            "safari_ios": {
-              "version_added": "14",
-              "partial_implementation": true,
-              "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -21,7 +21,7 @@ const VERSION_RANGE_BROWSERS = {
   opera: ['≤12.1', '≤15'],
   opera_android: ['≤12.1', '≤14'],
   safari: ['≤4'],
-  safari_ios: ['≤3'],
+  safari_ios: ['≤3', '≤10.3'],
   webview_android: ['≤37'],
 };
 

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -79,8 +79,7 @@
                 "version_added": true
               },
               "safari": {
-                "notes": "Only persistent pages are supported.",
-                "partial_implementation": true,
+                "notes": "Support for non-persistent pages was added in 14.1.",
                 "version_added": "14"
               }
             }


### PR DESCRIPTION
This is a large update of features supported with the release of Safari 14.1 on macOS and Safari on iOS 14.5. The changes have been compiled using mdn-results-collector, a thorough review of changes by the WebKit engineering team at Apple, manual tests to verify results, and engineer submissions.