### PR TITLE
Add Safari 14.1 support for Intl.DisplayNames

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -170,6 +170,12 @@
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
+        },
+        "14.1": {
+          "release_date": "2021-04-27",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "610.1.28"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -159,7 +159,10 @@
           "engine_version": "610.1.28"
         },
         "14.5": {
-          "status": "beta"
+          "release_date": "2021-04-26",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
         }
       }
     }

--- a/javascript/builtins/intl/DisplayNames.json
+++ b/javascript/builtins/intl/DisplayNames.json
@@ -35,10 +35,10 @@
                 "version_added": "58"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -87,10 +87,10 @@
                   "version_added": "58"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -139,10 +139,10 @@
                   "version_added": "58"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -191,10 +191,10 @@
                   "version_added": "58"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -243,10 +243,10 @@
                   "version_added": "58"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
Safari 14.1, which is released now on iOS 14.5 and macOS 11.3, adds support for `Intl.DisplayNames`.

Related Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=209779

I tested on both macOS and iOS Safari, works fine for me.
