### PR TITLE
Mark webkitOfflineAudioContext supported in Safari / iOS 6

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -167,11 +167,11 @@
               }
             ],
             "safari": {
-              "version_added": "6.1",
+              "version_added": "6",
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": "6.1",
+              "version_added": "6",
               "prefix": "webkit"
             },
             "samsunginternet_android": [


### PR DESCRIPTION
The existing data was highly implausible, with most of the Web Audio
API marked as shipping in 6, but the entry point in 6.1.

Confirmed with http://mdn-bcd-collector.appspot.com/tests/api/webkitOfflineAudioContext
on Safari 6.0.5 on macOS and Safari for iOS 6.0.