### PR TITLE
<a> download attribute supported from iOS Safari 13.0

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -192,7 +192,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "1.0",


### PR DESCRIPTION
The "download" attribute on `<a>` elements has been supported on iOS Safari since 13.0.  
See https://bugs.webkit.org/show_bug.cgi?id=167341