### PR TITLE
Normalize DOM spec URLs: AbortController to HTMLCollection, global_attributes

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -68,7 +68,7 @@
       "AbortController": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/AbortController",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortcontroller-abortcontroller",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
           "description": "<code>AbortController()</code> constructor",
           "support": {
             "chrome": {
@@ -135,7 +135,7 @@
       "abort": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/abort",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortcontroller-abort",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -201,7 +201,7 @@
       "signal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/signal",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortcontroller-signal",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-signal②",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -54,6 +54,7 @@
       "abort": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-abort①",
           "support": {
             "chrome": {
               "version_added": false
@@ -106,7 +107,7 @@
         "__compat": {
           "description": "<code>abort</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortsignal-onabort",
+          "spec_url": "https://dom.spec.whatwg.org/#eventdef-abortsignal-abort",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -158,7 +159,7 @@
       "aborted": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/aborted",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortsignal-onabort",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-aborted①",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -210,7 +211,7 @@
       "onabort": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/onabort",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortsignal-aborted",
+          "spec_url": "https://dom.spec.whatwg.org/#abortsignal-onabort",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -3,7 +3,7 @@
     "AbstractRange": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange",
-        "spec_url": "https://dom.spec.whatwg.org/#abstractrange",
+        "spec_url": "https://dom.spec.whatwg.org/#interface-abstractrange",
         "support": {
           "chrome": {
             "version_added": false
@@ -52,7 +52,7 @@
       "collapsed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/collapsed",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-range-collapsed",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-collapsed①",
           "support": {
             "chrome": {
               "version_added": false
@@ -102,7 +102,7 @@
       "endContainer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/endContainer",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-range-endcontainer",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-endcontainer①",
           "support": {
             "chrome": {
               "version_added": false
@@ -152,7 +152,7 @@
       "endOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/endOffset",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-range-endoffset",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-endoffset①",
           "support": {
             "chrome": {
               "version_added": false
@@ -202,7 +202,7 @@
       "startContainer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/startContainer",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-range-startcontainer",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-startcontainer①",
           "support": {
             "chrome": {
               "version_added": false
@@ -252,7 +252,7 @@
       "startOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/startOffset",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-range-startoffset",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-startoffset①",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -3,7 +3,7 @@
     "CharacterData": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData",
-        "spec_url": "https://dom.spec.whatwg.org/#characterdata",
+        "spec_url": "https://dom.spec.whatwg.org/#interface-characterdata",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -296,7 +296,7 @@
       "nextElementSibling": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/nextElementSibling",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-nondocumenttypechildnode-nextelementsibling②",
           "support": {
             "chrome": {
               "version_added": "29"
@@ -345,7 +345,7 @@
       "previousElementSibling": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CharacterData/previousElementSibling",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-nondocumenttypechildnode-previouselementsibling②",
           "support": {
             "chrome": {
               "version_added": "29"

--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -51,7 +51,7 @@
       "after": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChildNode/after",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-childnode-after",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-childnode-after①",
           "support": {
             "chrome": {
               "version_added": "54"
@@ -100,7 +100,7 @@
       "before": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChildNode/before",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-childnode-before",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-childnode-before①",
           "support": {
             "chrome": {
               "version_added": "54"
@@ -149,7 +149,7 @@
       "remove": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChildNode/remove",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-childnode-remove",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-childnode-remove①",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -198,7 +198,7 @@
       "replaceWith": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ChildNode/replaceWith",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-childnode-replacewith",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-childnode-replacewith①",
           "support": {
             "chrome": {
               "version_added": "54"

--- a/api/Comment.json
+++ b/api/Comment.json
@@ -3,7 +3,7 @@
     "Comment": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Comment",
-        "spec_url": "https://dom.spec.whatwg.org/#comment",
+        "spec_url": "https://dom.spec.whatwg.org/#interface-comment",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -51,7 +51,7 @@
       "Comment": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Comment/Comment",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-comment-comment",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-comment-comment①",
           "description": "<code>Comment()</code> constructor",
           "support": {
             "chrome": {

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -51,7 +51,7 @@
       "CustomEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomEvent/CustomEvent",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-customevent-customevent",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-customevent-customevent",
           "description": "<code>CustomEvent()</code> constructor",
           "support": {
             "chrome": {
@@ -101,7 +101,7 @@
       "detail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomEvent/detail",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-customevent-detail",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-customevent-detail②",
           "support": {
             "chrome": {
               "version_added": "15"

--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -3,7 +3,7 @@
     "DOMImplementation": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMImplementation",
-        "spec_url": "https://dom.spec.whatwg.org/#domimplementation",
+        "spec_url": "https://dom.spec.whatwg.org/#interface-domimplementation",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -51,7 +51,7 @@
       "createDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMImplementation/createDocument",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domimplementation-createdocument",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domimplementation-createdocument②",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -100,7 +100,7 @@
       "createDocumentType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMImplementation/createDocumentType",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domimplementation-createdocumenttype①",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -149,7 +149,7 @@
       "createHTMLDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domimplementation-createhtmldocument①",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -51,7 +51,7 @@
       "add": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/add",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-add",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-add①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -148,7 +148,7 @@
       "contains": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/contains",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-contains",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-contains①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -295,7 +295,7 @@
       "item": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/item",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-item",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-item①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -393,7 +393,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/length",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-length",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-length①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -442,7 +442,7 @@
       "remove": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/remove",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-remove",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-remove①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -588,7 +588,7 @@
       "replace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/replace",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-replace",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-replace①",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -733,7 +733,7 @@
       "toggle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/toggle",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-toggle",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-toggle①",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -879,7 +879,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/value",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-domtokenlist-value",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-domtokenlist-value②",
           "support": {
             "chrome": {
               "version_added": "50",

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -3,7 +3,7 @@
     "HTMLCollection": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection",
-        "spec_url": "https://dom.spec.whatwg.org/#htmlcollection",
+        "spec_url": "https://dom.spec.whatwg.org/#interface-htmlcollection",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -99,7 +99,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/length",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-htmlcollection-length",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-htmlcollection-length①",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1559,7 +1559,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/slot",
           "spec_url": [
             "https://html.spec.whatwg.org/multipage/dom.html#attr-slot",
-            "https://dom.spec.whatwg.org/#dom-element-slot"
+            "https://dom.spec.whatwg.org/#ref-for-dom-element-slot①"
           ],
           "support": {
             "chrome": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/10136

---

This is the final batch of normalization patches for the DOM spec URLs.