### PR TITLE
Document bugs linked to lack of support for non-MediaStream values of srcObject

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3805,7 +3805,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la/886194'>bug 886194</a>."
+                "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://bugzil.la/886194'>bug 886194</a>)."
               },
               {
                 "version_added": "18",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3819,7 +3819,7 @@
             "opera": {
               "version_added": "39",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "opera_android": {
               "version_added": "41",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3787,7 +3787,7 @@
             "edge": {
               "version_added": "12",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "firefox": [
               {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3777,7 +3777,7 @@
             "chrome": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "chrome_android": {
               "version_added": "52",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3782,7 +3782,7 @@
             "chrome_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "edge": {
               "version_added": "12",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3835,7 +3835,7 @@
             "samsunginternet_android": {
               "partial_implementation": true,
               "version_added": "6.0",
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "webview_android": {
               "version_added": "52",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3793,7 +3793,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la/886194'>bug 886194</a>."
+                "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://bugzil.la/886194'>bug 886194</a>)."
               },
               {
                 "version_added": "18",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3840,7 +3840,7 @@
             "webview_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>."
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3777,12 +3777,12 @@
             "chrome": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             },
             "chrome_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             },
             "edge": {
               "version_added": "12",
@@ -3793,7 +3793,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects."
+                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la.mozilla.org/886194'>bug 886194</a>."
               },
               {
                 "version_added": "18",
@@ -3805,7 +3805,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects."
+                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la.mozilla.org/886194'>bug 886194</a>."
               },
               {
                 "version_added": "18",
@@ -3819,12 +3819,12 @@
             "opera": {
               "version_added": "39",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             },
             "opera_android": {
               "version_added": "41",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             },
             "safari": {
               "version_added": "11"
@@ -3835,12 +3835,12 @@
             "samsunginternet_android": {
               "partial_implementation": true,
               "version_added": "6.0",
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             },
             "webview_android": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects."
+              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3824,7 +3824,7 @@
             "opera_android": {
               "version_added": "41",
               "partial_implementation": true,
-              "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://crbug.com/506273'>issue </a>."
+              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
             },
             "safari": {
               "version_added": "11"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3793,7 +3793,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la.mozilla.org/886194'>bug 886194</a>."
+                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la/886194'>bug 886194</a>."
               },
               {
                 "version_added": "18",
@@ -3805,7 +3805,7 @@
               {
                 "version_added": "42",
                 "partial_implementation": true,
-                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la.mozilla.org/886194'>bug 886194</a>."
+                "notes": "Currently only supports <code>MediaStream</code> objects - see <a href='https://bugzil.la/886194'>bug 886194</a>."
               },
               {
                 "version_added": "18",


### PR DESCRIPTION
Triggered by review of https://github.com/mdn/content/issues/1704
