### PR TITLE
Mark AbstractRange supported in Chrome 90

### DIFF
--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -65,10 +65,15 @@
             "chrome_android": {
               "version_added": "90"
             },
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "69"
             },
@@ -115,10 +120,15 @@
             "chrome_android": {
               "version_added": "90"
             },
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "69"
             },
@@ -165,10 +175,15 @@
             "chrome_android": {
               "version_added": "90"
             },
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "69"
             },
@@ -215,10 +230,15 @@
             "chrome_android": {
               "version_added": "90"
             },
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "69"
             },
@@ -265,10 +285,15 @@
             "chrome_android": {
               "version_added": "90"
             },
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "69"
             },

--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -11,10 +11,15 @@
           "chrome_android": {
             "version_added": "90"
           },
-          "edge": {
-            "version_added": "18",
-            "version_removed": "79"
-          },
+          "edge": [
+            {
+              "version_added": "90"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "79"
+            }
+          ],
           "firefox": {
             "version_added": "69"
           },

--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -6,10 +6,10 @@
         "spec_url": "https://dom.spec.whatwg.org/#interface-abstractrange",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "90"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "90"
           },
           "edge": {
             "version_added": "18",
@@ -40,7 +40,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "90"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-collapsed①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
               "version_added": "18",
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {
@@ -105,10 +105,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-endcontainer①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
               "version_added": "18",
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {
@@ -155,10 +155,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-endoffset①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
               "version_added": "18",
@@ -189,7 +189,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {
@@ -205,10 +205,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-startcontainer①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
               "version_added": "18",
@@ -239,7 +239,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {
@@ -255,10 +255,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-range-startoffset①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
               "version_added": "18",
@@ -289,7 +289,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {


### PR DESCRIPTION
https://source.chromium.org/chromium/chromium/src/+/b95a3cd5c2cc3b47769022fbafd68440315df924 added support for AbstractRange in Blink.

Per https://storage.googleapis.com/chromium-find-releases-static/b95.html#b95a3cd that puts it in Chrome 90.

And per https://wpt.fyi/results/dom/idlharness.window.html%3Fexclude%3DNode, Chrome is passing the relevant WPT tests for AbstractRange support.