### PR TITLE
Update storage_event and onstorage with real values

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -9390,7 +9390,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "45"
@@ -9399,7 +9399,7 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"

--- a/api/Window.json
+++ b/api/Window.json
@@ -9408,10 +9408,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -640,7 +640,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "45"
@@ -649,7 +649,7 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -658,10 +658,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Fixes #9558.

For Safari, it's in the [Safari 4 release notes](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_4_0.html), but I tested it manually before noticing that. 🙄

Since I had a test case, I decided to fill in IE and Edge too. Interestingly, they work in IE 9+, but break for the
first few releases of Edge before returning again. 🤷 