### PR TITLE
Fix spec URL for RegExp.p.hasIndices

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -430,7 +430,7 @@
         "hasIndices": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.hasIndices",
+            "spec_url": "https://tc39.es/proposal-regexp-match-indices/#sec-get-regexp.prototype.hasIndices",
             "support": {
               "chrome": {
                 "version_added": "90"


### PR DESCRIPTION
RegExp.p.hasIndices isn’t yet in the ES spec; instead it’s part of a stage 3 proposal at https://tc39.es/proposal-regexp-match-indices/