### PR TITLE
Fix PerformanceElementTiming.p.rendertime spec URL

### DIFF
--- a/api/PerformanceElementTiming.json
+++ b/api/PerformanceElementTiming.json
@@ -394,7 +394,7 @@
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming/renderTime",
-          "spec_url": "https://wicg.github.io/element-timing/#ref-for-dom-performanceelementtiming-rendertime%E2%91%A0",
+          "spec_url": "https://wicg.github.io/element-timing/#ref-for-dom-performanceelementtiming-rendertime①",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
For linting purposes, the fragment part of the URL needs to have `ref-for-dom-performanceelementtiming-rendertime①`, with a U+2460 CIRCLED DIGIT ONE character, rather than the percent-encoded equivalent.