### PR TITLE
Add Edge versions for FetchEvent API

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -12,7 +12,7 @@
             "version_added": "40"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -62,7 +62,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -160,7 +160,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "45",
@@ -406,7 +406,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44"
@@ -457,7 +457,7 @@
               "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "17",
               "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
             },
             "firefox": [


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FetchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.0).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent
