### PR TITLE
Add Edge versions for HTMLKeygenElement API

### DIFF
--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -15,7 +15,7 @@
             "notes": "See <a href='https://www.chromestatus.com/features/5716060992962560'>Chrome Platform Status</a>."
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "1",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `HTMLKeygenElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLKeygenElement
