### PR TITLE
Add Edge versions for api.IDBTransaction.objectStoreNames

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -640,7 +640,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `objectStoreNames` member of the `IDBTransaction` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBTransaction/objectStoreNames
