### PR TITLE
Add Edge versions for ImageBitmapRenderingContext API

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -12,7 +12,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "46"
@@ -107,7 +107,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ImageBitmapRenderingContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageBitmapRenderingContext
