### PR TITLE
Add Edge versions for InputDeviceInfo API

### DIFF
--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -58,7 +58,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `InputDeviceInfo` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/InputDeviceInfo
