### PR TITLE
Add Edge + update IE versions for KeyboardEvent API

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -1175,7 +1175,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "31"
@@ -1470,7 +1470,7 @@
               "version_removed": "54"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -1621,7 +1621,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "28"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1630,7 +1630,7 @@
               "version_added": "28"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `KeyboardEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Additionally, this corrects some IE data.  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyboardEvent
