### PR TITLE
Update Edge versions for LargestContentfulPaint API

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -12,7 +12,7 @@
             "version_added": "77"
           },
           "edge": {
-            "version_added": "80"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -155,7 +155,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -203,7 +203,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -251,7 +251,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -299,7 +299,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -347,7 +347,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `LargestContentfulPaint` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/LargestContentfulPaint
