### PR TITLE
Update Edge versions for LayoutShift API

### DIFF
--- a/api/LayoutShift.json
+++ b/api/LayoutShift.json
@@ -12,7 +12,7 @@
             "version_added": "77"
           },
           "edge": {
-            "version_added": "80"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -202,7 +202,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -250,7 +250,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `LayoutShift` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/LayoutShift
