### PR TITLE
Add Edge versions for LocalMediaStream API

### DIFF
--- a/api/LocalMediaStream.json
+++ b/api/LocalMediaStream.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "17",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `LocalMediaStream` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/LocalMediaStream
