### PR TITLE
Add Edge versions for LockManager API

### DIFF
--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -12,7 +12,7 @@
             "version_added": "69"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -60,7 +60,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -109,7 +109,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `LockManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/LockManager
