### PR TITLE
Add Edge versions for MIDIInputMap API

### DIFF
--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -12,7 +12,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MIDIInputMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MIDIInputMap
