### PR TITLE
Add Edge versions for MIDIMessageEvent API

### DIFF
--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -12,7 +12,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -108,7 +108,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MIDIMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MIDIMessageEvent
