### PR TITLE
Update Edge versions for MediaMetadata API

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -12,7 +12,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -75,7 +75,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"
@@ -124,7 +124,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"
@@ -173,7 +173,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"
@@ -222,7 +222,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"
@@ -271,7 +271,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "71"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `MediaMetadata` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaMetadata
