### PR TITLE
Add Edge versions for MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -65,7 +65,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent
