### PR TITLE
Add Edge versions for NotificationEvent API

### DIFF
--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -12,7 +12,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -63,7 +63,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -113,7 +113,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -163,7 +163,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `NotificationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NotificationEvent
