### PR TITLE
Deprecate WEBGL_compressed_texture_atc

### DIFF
--- a/api/WEBGL_compressed_texture_atc.json
+++ b/api/WEBGL_compressed_texture_atc.json
@@ -55,8 +55,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       }
     }


### PR DESCRIPTION
WEBGL_compressed_texture_atc is listed in the Rejected section of https://www.khronos.org/registry/webgl/extensions/ and is already marked deprecated in MDN — https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_atc — so this change marks it deprecated and non-standard here.