### PR TITLE
Add Edge versions for OES_standard_derivatives API

### DIFF
--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `OES_standard_derivatives` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_standard_derivatives
