### PR TITLE
Add Edge versions for OfflineAudioContext API

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -131,7 +131,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53"
@@ -418,7 +418,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": false
@@ -578,7 +578,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `OfflineAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioContext
