### PR TITLE
Add Edge versions for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -710,7 +710,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -896,7 +896,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "35"

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -977,7 +977,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Performance` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Performance
