### PR TITLE
Update Edge versions for PerformanceEventTiming API

### DIFF
--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -12,7 +12,7 @@
             "version_added": "77"
           },
           "edge": {
-            "version_added": "80"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -155,7 +155,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -250,7 +250,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `PerformanceEventTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEventTiming
