### PR TITLE
Add Edge versions for PerformanceNavigationTiming API

### DIFF
--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -405,7 +405,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "58"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PerformanceNavigationTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceNavigationTiming
