### PR TITLE
Add Edge versions for PerformanceObserverEntryList API

### DIFF
--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -12,7 +12,7 @@
             "version_added": "52"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "57"
@@ -64,7 +64,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"
@@ -116,7 +116,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"
@@ -168,7 +168,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PerformanceObserverEntryList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserverEntryList
