### PR TITLE
Add Edge versions for PerformancePaintTiming API

### DIFF
--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -12,7 +12,7 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "84"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PerformancePaintTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformancePaintTiming
