### PR TITLE
Add Edge versions for PerformanceServerTiming API

### DIFF
--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -12,7 +12,7 @@
             "version_added": "65"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "61"
@@ -60,7 +60,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "61"
@@ -109,7 +109,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "61"
@@ -158,7 +158,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "61"
@@ -207,7 +207,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "61"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PerformanceServerTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceServerTiming
