### PR TITLE
Add Edge versions for PeriodicWave API

### DIFF
--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -12,7 +12,7 @@
             "version_added": "30"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "25"
@@ -63,7 +63,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PeriodicWave` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PeriodicWave
