### PR TITLE
Add Edge versions for PresentationAvailability API

### DIFF
--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -12,7 +12,7 @@
             "version_added": "48"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "51",
@@ -76,7 +76,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -141,7 +141,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PresentationAvailability` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationAvailability
