### PR TITLE
Add Edge versions for PresentationConnection API

### DIFF
--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -12,7 +12,7 @@
             "version_added": "48"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "51",
@@ -76,7 +76,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -141,7 +141,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -206,7 +206,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -270,7 +270,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -334,7 +334,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -398,7 +398,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -462,7 +462,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -527,7 +527,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -592,7 +592,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -657,7 +657,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -722,7 +722,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PresentationConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationConnection
