### PR TITLE
Add Edge versions for PresentationConnectionList API

### DIFF
--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -12,7 +12,7 @@
             "version_added": "51"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "51",
@@ -75,7 +75,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -139,7 +139,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PresentationConnectionList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationConnectionList
