### PR TITLE
Add Edge versions for PresentationReceiver API

### DIFF
--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -12,7 +12,7 @@
             "version_added": "55"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "51",
@@ -75,7 +75,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PresentationReceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationReceiver
