### PR TITLE
Add Edge versions for PresentationRequest API

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -12,7 +12,7 @@
             "version_added": "48"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "51",
@@ -77,7 +77,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -142,7 +142,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -207,7 +207,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -272,7 +272,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -387,7 +387,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",
@@ -451,7 +451,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -451,7 +451,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "51",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PresentationRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationRequest
