### PR TITLE
Add Edge versions for ProgressEvent API

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "22"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ProgressEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ProgressEvent
