### PR TITLE
Add Edge versions for PushMessageData API

### DIFF
--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -12,7 +12,7 @@
             "version_added": "50"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -62,7 +62,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -112,7 +112,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -162,7 +162,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -212,7 +212,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PushMessageData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushMessageData
