### PR TITLE
Add spec URL from “Legacy RegExp features in JavaScript” spec

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1000,6 +1000,7 @@
           "__compat": {
             "description": "<code>RegExp.$1-$9</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
The `javascript.builtins.RegExp.n` feature is documented in MDN at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n and in https://github.com/tc39/proposal-regexp-legacy-features spec proposal — as well as being implemented in all browser engines. So this change adds a spec URL for it.