### PR TITLE
Add spec URLs for “trailing commas” feature

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -946,6 +946,18 @@
         "__compat": {
           "description": "Trailing commas",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Trailing_commas",
+          "spec_url": [
+            "https://tc39.es/ecma262/#prod-Elision",
+            "https://tc39.es/ecma262/#prod-ObjectLiteral",
+            "https://tc39.es/ecma262/#prod-ArrayLiteral",
+            "https://tc39.es/ecma262/#prod-Arguments",
+            "https://tc39.es/ecma262/#prod-FormalParameters",
+            "https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList",
+            "https://tc39.es/ecma262/#prod-NamedImports",
+            "https://tc39.es/ecma262/#prod-NamedExports",
+            "https://tc39.es/ecma262/#prod-QuantifierPrefix",
+            "https://tc39.es/ecma262/#prod-annexB-InvalidBracedQuantifier"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
There isn’t a single place in the ES spec that states where trailing commas are allowed in JavaScript — instead there are currently 10 places. So this change adds spec URLs for all 10 of them.

---

To determine which productions allowed trailing commas, I found the productions at the 10 URLs in this patch by using the following regular expression:

```
,<\/emu-t>\n\s\+(<emu-t>.<\/emu-t>\n\s\+)?<\/emu-rhs>
```