### PR TITLE
Fix spec URL for threaded WebAssembly JS API

### DIFF
--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -112,7 +112,7 @@
             "shared": {
               "__compat": {
                 "description": "<code>shared</code> flag",
-                "spec_url": "https://webassembly.github.io/threads/js-api/index.html#dom-memorydescriptor-shared",
+                "spec_url": "https://webassembly.github.io/threads/js-api/#dom-memorydescriptor-shared",
                 "support": {
                   "chrome": {
                     "version_added": "74"


### PR DESCRIPTION
The `index.html` part of the spec URL isn’t needed.