### PR TITLE
Mark ServiceWorkerContainer.p.onerror deprecated

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -338,8 +338,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/ServiceWorker/commit/c240d9d (https://github.com/w3c/ServiceWorker/issues/912) dropped `ServiceWorkerContainer.p.onerror` from the spec. So this change marks it deprecated and standard_track:false.

Related MDN change: https://github.com/mdn/content/pull/4703