### PR TITLE
Reconcile `css.properties.overflow-{x,y}.clip` with `css.properties.overflow.clip`

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -92,7 +92,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "76"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -60,13 +60,13 @@
             "description": "<code>clip</code> value",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "90"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "90"
               },
               "edge": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox": [
                 {
@@ -107,11 +107,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "90"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -92,7 +92,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "76"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -60,13 +60,13 @@
             "description": "<code>clip</code> value",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "90"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "90"
               },
               "edge": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox": [
                 {
@@ -107,11 +107,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "90"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -88,7 +88,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "76"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
This PR reconciles `css.properties.overflow-x.clip` and `css.properties.overflow-y.clip` with `css.properties.overflow.clip`, which ought to be the same for Chrome. While I was here, I mirrored to Opera.

Original source: https://www.chromestatus.com/feature/5638444178997248
    
Fixes https://github.com/mdn/browser-compat-data/issues/9635.