### PR TITLE
Remove api.HTMLMediaElement.initialTime

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1471,46 +1471,6 @@
           }
         }
       },
-      "initialTime": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/initialTime",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "9",
-              "version_removed": "23"
-            },
-            "firefox_android": {
-              "version_added": "9",
-              "version_removed": "23"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": "6",
-              "version_removed": "6.1"
-            },
-            "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "load": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/load",


### PR DESCRIPTION
The qualifies as an irrelevant feature:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features