### PR TITLE
Chrome 90 removed CSP directive 'plugin-types'

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -817,13 +817,16 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types",
               "support": {
                 "chrome": {
-                  "version_added": "40"
+                  "version_added": "40",
+                  "version_removed": "90"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": true,
+                  "version_removed": "90"
                 },
                 "edge": {
-                  "version_added": "15"
+                  "version_added": "15",
+                  "version_removed": "90"
                 },
                 "firefox": {
                   "version_added": false
@@ -835,7 +838,8 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "27"
+                  "version_added": "27",
+                  "version_removed": "76"
                 },
                 "opera_android": {
                   "version_added": null
@@ -850,7 +854,8 @@
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": true,
+                  "version_removed": "90"
                 }
               },
               "status": {


### PR DESCRIPTION
Chrome 90 removed non-standard CSP directive 'plugin-types' because it is no longer useful after global removal of Adobe Flash. It was used in the past to restrict Flash content loaded in `<embed>` and `<object>` tags.

Chrome platform status entry:
https://chromestatus.com/feature/5742693948850176

Other browsers are mirorred from Chrome 90 based on `/browsers/`.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
