### PR TITLE
    Remove StaticRange.p.toRange

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -336,55 +336,6 @@
             "deprecated": false
           }
         }
-      },
-      "toRange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/toRange",
-          "description": "<code>toRange()</code>",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": "18"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
`StaticRange.p.toRange` isn’t part of any spec, was only ever implemented in Chrome — but way back at Chrome 60. So this change removes it, per https://github.com/mdn/browser-compat-data/pull/10288#issuecomment-832610787

Related MDN change: https://github.com/mdn/content/pull/4723