### PR TITLE
Move api.Navigator.geolocation.hid to api.Navigator.hid

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -839,55 +839,6 @@
             "deprecated": false
           }
         },
-        "hid": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/Navigator/hid",
-            "spec_url": "https://wicg.github.io/webhid/#dom-navigator-hid",
-            "support": {
-              "chrome": {
-                "version_added": "89"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "89"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "75"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "secure_context_required": {
           "__compat": {
             "description": "Secure context required",
@@ -1311,6 +1262,55 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "hid": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Navigator/hid",
+          "spec_url": "https://wicg.github.io/webhid/#dom-navigator-hid",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1267,7 +1267,7 @@
       },
       "hid": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Navigator/hid",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/hid",
           "spec_url": "https://wicg.github.io/webhid/#dom-navigator-hid",
           "support": {
             "chrome": {


### PR DESCRIPTION
Move `api.Navigator.geolocation.hid` to `api.Navigator.hid` beacuse it's actually accessed via `navigator.hid`. I think it was caused by a misplaced `}`.

While at it, fix MDN URL as well.

One example from [WebHID API](https://wicg.github.io/webhid/#dom-navigator-hid):
```
navigator.hid.addEventListener('connect', ({device}) => {
  console.log(`HID connected: ${device.productName}`);
});
```

Also, note that the relevant [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hid) uses the correct name `api.Navigator.hid` (so compat table is broken right now, but will be fixed by this PR).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
