### PR TITLE
Fix api.HTMLAnchorElement.pathname.__compat.mdn_url

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -296,7 +296,7 @@
       },
       "pathname": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHyperlinkElementUtils/pathname",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/pathname",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The old URL redirects to this new URL. The new URL is consistent with broader MDN URL convention.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
