### PR TITLE
updates Chromium size-adjust descriptor support

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -760,7 +760,7 @@
             "spec_url": "https://drafts.csswg.org/css-fonts-5/#size-adjust-desc",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "92"
               },
               "chrome_android": {
                 "version_added": false

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -763,10 +763,10 @@
                 "version_added": "92"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "edge": {
-                "version_added": false
+                "version_added": "92"
               },
               "firefox": {
                 "version_added": "89",
@@ -800,7 +800,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "92"
               }
             },
             "status": {


### PR DESCRIPTION
Chromium [intent to ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/1PVr94hZHjU/m/J0xT8-rlAQAJ) `size-adjust` in 92
