### PR TITLE
Add Edge versions for CloseEvent API constructor

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -65,7 +65,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "8"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `CloseEvent` API's constructor, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent
