### PR TITLE
Add Edge versions for FileSystemDirectoryReader API

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -64,7 +64,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileSystemDirectoryReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileSystemDirectoryReader
