### PR TITLE
Add Edge versions for PushSubscriptionOptions API

### DIFF
--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "17"
+            "version_added": "16"
           },
           "firefox": {
             "version_added": true

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `PushSubscriptionOptions` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushSubscriptionOptions
