### PR TITLE
Add Edge versions for RTCCertificate API

### DIFF
--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -12,7 +12,7 @@
             "version_added": "49"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "42"
@@ -59,7 +59,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "42"
@@ -107,7 +107,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCCertificate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCCertificate
