### PR TITLE
Add Edge versions for RTCDTMFSender API

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -12,7 +12,7 @@
             "version_added": "27"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "52"
@@ -59,7 +59,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -108,7 +108,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"
@@ -157,7 +157,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"
@@ -206,7 +206,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCDTMFSender` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDTMFSender
