### PR TITLE
Add Edge versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -12,7 +12,7 @@
             "version_added": "29"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -74,7 +74,7 @@
               "version_added": "29"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "18"
@@ -123,7 +123,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "18"
@@ -229,7 +229,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -278,7 +278,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -427,7 +427,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -476,7 +476,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -525,7 +525,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -574,7 +574,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -673,7 +673,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "68"
@@ -724,7 +724,7 @@
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "firefox": {
@@ -778,7 +778,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -876,7 +876,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -925,7 +925,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -974,7 +974,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -1073,7 +1073,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -1170,7 +1170,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -1219,7 +1219,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -1267,7 +1267,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1364,7 +1364,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCDataChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannel
