### PR TITLE
Add Edge versions for RTCDataChannelEvent API

### DIFF
--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -12,7 +12,7 @@
             "version_added": "28"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "22"
@@ -61,7 +61,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -110,7 +110,7 @@
               "version_added": "28"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1072,7 +1072,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCDataChannelEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannelEvent
