### PR TITLE
Add Edge versions for RTCPeerConnectionIceErrorEvent API

### DIFF
--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": "79"
           },
           "firefox": {
             "version_added": null
@@ -59,7 +59,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -107,7 +107,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -155,7 +155,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -203,7 +203,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCPeerConnectionIceErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnectionIceErrorEvent
