### PR TITLE
Add Edge versions for RTCPeerConnectionIceEvent API

### DIFF
--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -26,7 +26,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": true
@@ -89,7 +89,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCPeerConnectionIceEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnectionIceEvent
