### PR TITLE
Add Edge versions for ReadableStreamDefaultReader API

### DIFF
--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -12,7 +12,7 @@
             "version_added": "52"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "65"
@@ -61,7 +61,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -159,7 +159,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -208,7 +208,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -257,7 +257,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ReadableStreamDefaultReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableStreamDefaultReader
