### PR TITLE
Set Edge to false for unsupported SVG API features

### DIFF
--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGColorProfileElement.json
+++ b/api/SVGColorProfileElement.json
@@ -12,7 +12,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": null

--- a/api/SVGExternalResourcesRequired.json
+++ b/api/SVGExternalResourcesRequired.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": null

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -14,7 +14,7 @@
             "version_removed": "45"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGSolidcolorElement.json
+++ b/api/SVGSolidcolorElement.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -14,7 +14,7 @@
             "version_removed": "31"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/SVGURIReference.json
+++ b/api/SVGURIReference.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": null

--- a/api/SVGURIReference.json
+++ b/api/SVGURIReference.json
@@ -12,7 +12,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": false
+            "version_added": null
           },
           "firefox": {
             "version_added": null

--- a/api/SVGVKernElement.json
+++ b/api/SVGVKernElement.json
@@ -14,7 +14,7 @@
             "version_removed": "40"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false


### PR DESCRIPTION
This PR changes Microsoft Edge from `null` -> `false` for various SVG APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVG*

