### PR TITLE
Add Edge versions for SVG APIs

### DIFF
--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "30"

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -110,7 +110,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -159,7 +159,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5"
@@ -105,7 +105,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5"
@@ -152,7 +152,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5"
@@ -199,7 +199,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5"

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGPointList.json
+++ b/api/SVGPointList.json
@@ -291,7 +291,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "5"

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -295,7 +295,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "13"

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "9"

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3"

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "15"
@@ -60,7 +60,8 @@
               "version_removed": "56"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": true,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for various SVG APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVG*
