### PR TITLE
Add Edge versions for Selection API

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -846,7 +846,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "4"
@@ -1298,7 +1298,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Selection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Selection
