### PR TITLE
Add Edge versions for SpeechSynthesisUtterance API

### DIFF
--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "49"
@@ -60,7 +60,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "49"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `SpeechSynthesisUtterance` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SpeechSynthesisUtterance
