### PR TITLE
Add Edge versions for StorageManager API

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -11,7 +11,7 @@
             "version_added": "48"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -80,7 +80,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51"
@@ -189,7 +189,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -265,7 +265,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `StorageManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StorageManager
