### PR TITLE
Add Edge versions for TaskAttributionTiming API

### DIFF
--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -12,7 +12,7 @@
             "version_added": "58"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false,
@@ -61,7 +61,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -109,7 +109,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -157,7 +157,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -205,7 +205,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `TaskAttributionTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TaskAttributionTiming
