### PR TITLE
Add Edge versions for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "31"
@@ -58,7 +58,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -204,7 +204,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -346,7 +346,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -394,7 +394,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -442,7 +442,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `TextTrackCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue
