### PR TITLE
submit.json: Escape <button> HTML in Firefox notes

### DIFF
--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -19,11 +19,11 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code><button></code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
               },
               "firefox_android": {
                 "version_added": "4",
-                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code><button></code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
The footnotes for Firefox version 1 and 4 contain unescaped "<" and ">" marks, leading to the notes containing an actual button element.