### PR TITLE
Allow preview browsers in the data structure

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -2,6 +2,7 @@
   "browsers": {
     "chrome": {
       "name": "Chrome",
+      "preview_name": "Canary",
       "pref_url": "chrome://flags",
       "releases": {
         "1": {

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -2,6 +2,7 @@
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "preview_name": "Nightly",
       "pref_url": "about:config",
       "releases": {
         "1": {

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -2,6 +2,7 @@
   "browsers": {
     "safari": {
       "name": "Safari",
+      "preview_name": "TP",
       "releases": {
         "1": {
           "release_date": "2003-06-23",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -17,6 +17,7 @@ The file `firefox.json` is structured like this:
   "browsers": {
     "firefox": {
       "name": "Firefox",
+      "preview_name": "Nightly",
       "pref_url": "about:config",
       "releases": {
         "1.5": {
@@ -47,6 +48,10 @@ An optional boolean indicating whether the browser supports flags. This is a hin
 ### `pref_url`
 
 An optional string containing the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
+
+### `preview_name`
+
+An optional string containing the name of the preview browser. For example, "Nightly" for Firefox, "Canary" for Chrome, and "TP" for Safari.
 
 ### Release objects
 

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -38,6 +38,10 @@
           "type": "string",
           "description": "URL of the page where feature flags can be changed (e.g. 'about:config' or 'chrome://flags')."
         },
+        "preview_name": {
+          "type": "string",
+          "description": "Preview name, avoid long-form names (use 'Nightly' instead of 'Firefox Nightly')."
+        },
         "releases": {
           "type": "object",
           "additionalProperties": { "$ref": "#/definitions/release_statement" }

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -322,6 +322,15 @@ class ConsistencyChecker {
       if (b_version_added.startsWith('≤')) {
         return false;
       }
+      if (a_version_added === 'preview' && b_version_added === 'preview') {
+        return false;
+      }
+      if (b_version_added === 'preview') {
+        return true;
+      }
+      if (a_version_added === 'preview') {
+        return false;
+      }
       return compareVersions.compare(
         a_version_added.replace('≤', ''),
         b_version_added,

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -33,6 +33,9 @@ for (const browser of Object.keys(browsers)) {
   if (VERSION_RANGE_BROWSERS[browser]) {
     validBrowserVersions[browser].push(...VERSION_RANGE_BROWSERS[browser]);
   }
+  if (browsers[browser].preview_name) {
+    validBrowserVersions[browser].push('preview');
+  }
 }
 
 /**
@@ -61,6 +64,16 @@ function addedBeforeRemoved(statement) {
 
   if (!compareVersions.validate(added) || !compareVersions.validate(removed)) {
     return null;
+  }
+
+  if (added === 'preview' && removed === 'preview') {
+    return false;
+  }
+  if (added === 'preview' && removed !== 'preview') {
+    return false;
+  }
+  if (added !== 'preview' && removed === 'preview') {
+    return true;
   }
 
   return compareVersions.compare(added, removed, '<');

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,12 @@ export interface BrowserStatement {
   name: string;
 
   /**
+   * The preview browser's name, for example:
+   * `"Nightly"`, `"Canary"`, `"TP"`, etc.
+   */
+  preview_name: string;
+
+  /**
    * The known versions of this browser.
    */
   releases: {


### PR DESCRIPTION
This PR is based on a discussion that is going on for quite some time now. BCD has no way to represent "Preview browsers". Instead two main workaround have been used:

1) Oftentimes, there are support statements that say "false" but then a note is added to say "Implemented in Nightly/Canaray/TP". 
2) Sometimes, a release number far into the future is added (for example "Safari 15") because it is assumed from the support in the Safari Technical Preview browser that the feature will be in that version (although the version number is still somewhat unknown).

Both approaches aren't ideal.

<hr>

This PR experiments with allowing "preview" as an allowed version string for `version_added` and `version_removed`.
Further, the browser objects are extended with an optional property `preview_name` that contains the brand name for these preview browsers ("Canary", "Nightly", "TP") - these names are meant to be short, so that e.g. the MDN compat table renderer can pick them up and displays them in the table cells.

If a browser has a `preview_name` declared in its `browsers/*` file, the following statements are allowed:

```
"safari": {
  "version_added": "preview"
}

"safari": {
  "version_added: "11.1"
  "version_removed": "preview"
}
```

Disallowed is this:

```
"safari": {
  "version_added: "preview"
  "version_removed": "11.1"
}
```

In trees, a parent feature is not allowed to be "preview" when sub features are a version number.

Parent:
```
"safari": {
  "version_added": "preview"
}
```
Child:
```
"safari": {
  "version_added: "11.1"
}
```

<hr>

Opening this as a draft for now to collect feedback. If this seems plausible, it probably means a major version release for BCD.