### PR TITLE
Drop the api.TransitionEvent.animationName feature

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -124,58 +124,10 @@
           }
         }
       },
-      "animationName": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/animationName",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "elapsedTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/elapsedTime",
+          "spec_url": "https://drafts.csswg.org/css-transitions/#Events-TransitionEvent-elapsedTime",
           "support": {
             "chrome": {
               "version_added": "2"


### PR DESCRIPTION
https://drafts.csswg.org/css-transitions/#interface-transitionevent has no member named `animationName`. Instead it has a `propertyName` member, which we already include in BCD.

Related MDN change: https://github.com/mdn/content/pull/4760