### PR TITLE
Add Safari 14.1 support for ::file-selector-button

### DIFF
--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -62,7 +62,7 @@
             ],
             "safari": [
               {
-                "version_added": false
+                "version_added": "14.1"
               },
               {
                 "version_added": "3",
@@ -71,7 +71,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": false
+                "version_added": "14.5"
               },
               {
                 "version_added": "1",


### PR DESCRIPTION
Add Safari 14.1 and Safari on iOS 14.5 support for the `::file-selector-button` pseudo element.

Tested on Safari 14.1 (16611.1.21.161.6) on macOS Big Sur 11.3.1