### PR TITLE
Fix formatting of compare link in release stats

### DIFF
--- a/scripts/release-stats.js
+++ b/scripts/release-stats.js
@@ -121,7 +121,7 @@ function formatStats(details) {
 
   return `\
 ### Statistics
-- ${releaseContributors} contributors have changed ${changed} files with ${insertions} additions and ${deletions} deletions in ${commits} commits [\`${start}...${end}\`](https://github.com/mdn/browser-compat-data/compare/${start}...${end})
+- ${releaseContributors} contributors have changed ${changed} files with ${insertions} additions and ${deletions} deletions in ${commits} commits ([\`${start}...${end}\`](https://github.com/mdn/browser-compat-data/compare/${start}...${end}))
 - ${features} total features
 - ${totalContributors} total contributors
 - ${stars} total stargazers`;


### PR DESCRIPTION
This should ensure they're more consistent between releases.

(Since I'm the only one who runs this script with any regularity, I'll leave this open for a few days, but if there's no comment or self-assigned review requests outstanding, then I'll merge it.)