### PR TITLE
Document scroll-margin bug of firefox and firefox android

### DIFF
--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -21,6 +21,7 @@
               },
               {
                 "version_added": "68",
+                "version_removed": "90",
                 "partial_implementation": true,
                 "notes": "The <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -31,6 +31,7 @@
               },
               {
                 "version_added": "68",
+                "version_removed": "90",
                 "partial_implementation": true,
                 "notes": "The <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -22,7 +22,7 @@
               {
                 "version_added": "68",
                   "partial_implementation": true,
-                  "notes": "Before version 90, scroll margin is not calculated correctly on <code>element.focus()</code>, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1708303'>bug 1708303</a>."
+                  "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "firefox_android": [

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -32,7 +32,7 @@
               {
                 "version_added": "68",
                   "partial_implementation": true,
-                  "notes": "Before version 90, scroll margin is not calculated correctly on <code>element.focus()</code>, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1708303'>bug 1708303</a>."
+                  "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "ie": {

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -15,12 +15,26 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "68"
-            },
-            "firefox_android": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "68",
+                  "partial_implementation": true,
+                  "notes": "Before version 90, scroll margin is not calculated correctly on <code>element.focus()</code>, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1708303'>bug 1708303</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "90"
+              },
+              {
+                "version_added": "68",
+                  "partial_implementation": true,
+                  "notes": "Before version 90, scroll margin is not calculated correctly on <code>element.focus()</code>, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1708303'>bug 1708303</a>."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -21,8 +21,8 @@
               },
               {
                 "version_added": "68",
-                  "partial_implementation": true,
-                  "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
+                "partial_implementation": true,
+                "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "firefox_android": [
@@ -31,8 +31,8 @@
               },
               {
                 "version_added": "68",
-                  "partial_implementation": true,
-                  "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
+                "partial_implementation": true,
+                "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "ie": {

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -22,7 +22,7 @@
               {
                 "version_added": "68",
                 "partial_implementation": true,
-                "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
+                "notes": "The <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "firefox_android": [
@@ -32,7 +32,7 @@
               {
                 "version_added": "68",
                 "partial_implementation": true,
-                "notes": "Before version 90, the <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
+                "notes": "The <code>scroll-margin</code> property can cause an element's visibility to be incorrectly calculated for <code>element.focus()</code>. See <a href='https://bugzil.la/1708303'>bug 1708303</a>."
               }
             ],
             "ie": {


### PR DESCRIPTION
Hi all

This is my first PR to the data repo. Hope this PR is okay like this.
I tried to solve my issue https://github.com/mdn/content/issues/4770

I did build a minimal example that demonstrates the bug with both stable firefoxes:
https://data.estada.ch/firefox_scroll-margin_bug/

The corresponding bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1708303

Cheers,
Stefan
