### PR TITLE
Document.domain SETTER is deprecated

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3605,7 +3605,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
The `Document.domain` setter is deprecated, as indicated in [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Document/domain#setter) and the specs:
![image](https://user-images.githubusercontent.com/5368500/117403707-f6071780-af4b-11eb-9584-cede933b5400.png)

There is no way to mark just the setter deprecated, and I don't know how I might add a note to clarify this. So I have marked the whole item as deprecated. This PR is therefore obviously "for discussion."

This came out of #10224 
