### PR TITLE
Add Edge versions for TouchEvent API

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -81,7 +81,7 @@
               "notes": "Chrome only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Edge only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "firefox": {
@@ -132,7 +132,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -186,7 +186,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -240,7 +240,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -294,7 +294,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -348,7 +348,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -402,7 +402,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -456,7 +456,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `TouchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TouchEvent
