### PR TITLE
Make JSON schema allow WebGL extension spec URLs

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -107,7 +107,7 @@ The `__compat` object consists of the following:
 - An optional `mdn_url` property which **points to an MDN reference page documenting the feature**.
   It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
 
-- An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`).
+- An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://www.khronos.org/registry/webgl/extensions/[^/]+/` (e.g. `https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/`).
 
 ### The `support` object
 

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -170,6 +170,12 @@
       }
     },
 
+    "spec_url_value": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "(^http(s)?:\/\/[^#]+#.+)|(^https://www.khronos.org/registry/webgl/extensions/[^/]+/)"
+    },
+
     "compat_statement": {
       "type": "object",
       "properties": {
@@ -186,17 +192,13 @@
         "spec_url": {
           "anyOf": [
             {
-              "type": "string",
-              "format": "uri",
-              "pattern": "^http(s)?:\/\/[^#]+#.+"
+              "$ref": "#/definitions/spec_url_value"
             },
             {
               "type": "array",
               "minItems": 2,
               "items": {
-                "type": "string",
-                "format": "uri",
-                "pattern": "^http(s)?:\/\/[^#]+#.+"
+                "$ref": "#/definitions/spec_url_value"
               }
             }
           ],


### PR DESCRIPTION
We’re at the point where we need to add spec URLs for 61 WebGL features from https://www.khronos.org/registry/webgl/extensions/ WebGL extension specs.

But all https://www.khronos.org/registry/webgl/extensions/ specs lack any ID/anchors at all, and therefore don’t conform to the JSON schema requirement in the compat-data.schema.json file for `spec_url` values to have a fragment identifier. So this change updates the schema to allow any URLs matching the following pattern:

```
^https://www.khronos.org/registry/webgl/extensions/[^/]+/
```

Otherwise, without this change, CI fails on all those URLs, because doesn’t find the required fragment IDs in them.

https://github.com/mdn/browser-compat-data/pull/10358 is the related data change.