### PR TITLE
Window event deprecate

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -517,6 +517,7 @@
       },
       "appinstalled_event": {
         "__compat": {
+          "description": "<code>appinstalled</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/appinstalled_event",
           "support": {
             "chrome": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -10555,7 +10555,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10386,7 +10386,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10211,7 +10211,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10505,7 +10505,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -515,6 +515,69 @@
           }
         }
       },
+      "appinstalled_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/appinstalled_event",
+          "support": {
+            "chrome": {
+              "version_added": "64"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": "49",
+              "version_removed": "76",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.manifest.onappinstall",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "49",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.manifest.onappinstall",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "beforeprint_event": {
         "__compat": {
           "description": "<code>beforeprint</code> event",

--- a/api/Window.json
+++ b/api/Window.json
@@ -10605,7 +10605,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10455,7 +10455,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10330,7 +10330,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10261,7 +10261,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -10673,7 +10673,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This changes a number of windows events to match the deprecation status of their on_event handler, as discussed in #10224.

This includes Window event for vrdisplayblur vrdisplayconnect vrdisplayactivate vrdisplaydeactivate vrdisplaydisconnect vrdisplayfocus vrdisplaypointerrestricted vrdisplaypointerunrestricted vrdisplaypresentchange 

It also creates a deprecated appinstalled event based on onappinstalled (when this merges, need to change https://developer.mozilla.org/en-US/docs/Web/API/Window/appinstalled_event to point to this new event).

