### PR TITLE
Add Edge versions for VTTCue API

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "26"
@@ -107,7 +107,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -155,7 +155,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -203,7 +203,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -299,7 +299,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -443,7 +443,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -491,7 +491,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true
@@ -539,7 +539,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -587,7 +587,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `VTTCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VTTCue
