### PR TITLE
Add spec URLs for features from WebGL extensions specs

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -3,6 +3,7 @@
     "ANGLE_instanced_arrays": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
         "support": {
           "chrome": {
             "version_added": "32"
@@ -50,6 +51,7 @@
       "drawArraysInstancedANGLE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -98,6 +100,7 @@
       "drawElementsInstancedANGLE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/drawElementsInstancedANGLE",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -146,6 +149,7 @@
       "vertexAttribDivisorANGLE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays/vertexAttribDivisorANGLE",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
               "version_added": "32"

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -3,6 +3,7 @@
     "EXT_blend_minmax": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_blend_minmax",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/",
         "support": {
           "chrome": {
             "version_added": "38"

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -3,6 +3,7 @@
     "EXT_color_buffer_float": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_float",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/",
         "support": {
           "chrome": {
             "version_added": "63"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -3,6 +3,7 @@
     "EXT_color_buffer_half_float": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_half_float",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/",
         "support": {
           "chrome": {
             "version_added": "63"

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -3,6 +3,7 @@
     "EXT_disjoint_timer_query": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
         "support": {
           "chrome": {
             "version_added": "47",
@@ -64,6 +65,7 @@
       "beginQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/beginQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -126,6 +128,7 @@
       "createQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/createQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -188,6 +191,7 @@
       "deleteQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/deleteQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -250,6 +254,7 @@
       "endQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/endQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -312,6 +317,7 @@
       "getQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/getQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -374,6 +380,7 @@
       "getQueryObjectEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/getQueryObjectEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -436,6 +443,7 @@
       "isQueryEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/isQueryEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",
@@ -498,6 +506,7 @@
       "queryCounterEXT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/queryCounterEXT",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
             "chrome": {
               "version_added": "47",

--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -3,6 +3,7 @@
     "EXT_float_blend": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_float_blend",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/",
         "support": {
           "chrome": {
             "version_added": "75"

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -3,6 +3,7 @@
     "EXT_frag_depth": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_frag_depth",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/",
         "support": {
           "chrome": {
             "version_added": "38"

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -3,6 +3,7 @@
     "EXT_sRGB": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_sRGB",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/",
         "support": {
           "chrome": {
             "version_added": "40"

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -3,6 +3,7 @@
     "EXT_shader_texture_lod": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_shader_texture_lod",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/",
         "support": {
           "chrome": {
             "version_added": "38"

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -3,6 +3,7 @@
     "EXT_texture_compression_bptc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_compression_bptc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
         "support": {
           "chrome": {
             "version_added": false

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -3,6 +3,7 @@
     "EXT_texture_compression_rgtc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_compression_rgtc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
         "support": {
           "chrome": {
             "version_added": false

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -3,6 +3,7 @@
     "EXT_texture_filter_anisotropic": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_filter_anisotropic",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/",
         "support": {
           "chrome": [
             {

--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -3,6 +3,7 @@
     "EXT_texture_norm16": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_norm16",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/",
         "support": {
           "chrome": {
             "version_added": "87"

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -3,6 +3,7 @@
     "KHR_parallel_shader_compile": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/KHR_parallel_shader_compile",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/",
         "support": {
           "chrome": {
             "version_added": "76"

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -3,6 +3,7 @@
     "OES_element_index_uint": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_element_index_uint",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/",
         "support": {
           "chrome": {
             "version_added": "24"

--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -3,6 +3,7 @@
     "OES_fbo_render_mipmap": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_fbo_render_mipmap",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/",
         "support": {
           "chrome": {
             "version_added": false

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -3,6 +3,7 @@
     "OES_standard_derivatives": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_standard_derivatives",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/",
         "support": {
           "chrome": {
             "version_added": "10"

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -3,6 +3,7 @@
     "OES_texture_float": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float/",
         "support": {
           "chrome": {
             "version_added": "10"

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -3,6 +3,7 @@
     "OES_texture_float_linear": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_float_linear",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/",
         "support": {
           "chrome": {
             "version_added": "29"

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -3,6 +3,7 @@
     "OES_texture_half_float": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/",
         "support": {
           "chrome": {
             "version_added": "27"

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -3,6 +3,7 @@
     "OES_texture_half_float_linear": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_texture_half_float_linear",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/",
         "support": {
           "chrome": {
             "version_added": "29"

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -3,6 +3,7 @@
     "OES_vertex_array_object": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
         "support": {
           "chrome": {
             "version_added": "24"
@@ -50,6 +51,7 @@
       "bindVertexArrayOES": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -98,6 +100,7 @@
       "createVertexArrayOES": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/createVertexArrayOES",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -146,6 +149,7 @@
       "deleteVertexArrayOES": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/deleteVertexArrayOES",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -194,6 +198,7 @@
       "isVertexArrayOES": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object/isVertexArrayOES",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/",
           "support": {
             "chrome": {
               "version_added": "24"

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -3,6 +3,7 @@
     "OVR_multiview2": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OVR_multiview2",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
         "support": {
           "chrome": [
             {
@@ -83,6 +84,7 @@
       "framebufferTextureMultiviewOVR": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OVR_multiview2/framebufferTextureMultiviewOVR",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
           "support": {
             "chrome": [
               {

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -3,6 +3,7 @@
     "WEBGL_color_buffer_float": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_color_buffer_float",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/",
         "support": {
           "chrome": {
             "version_added": "63"

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_astc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/",
         "support": {
           "chrome": {
             "version_added": "47"
@@ -50,6 +51,7 @@
       "getSupportedProfiles": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc/getSupportedProfiles",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/",
           "support": {
             "chrome": {
               "version_added": "47"

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_etc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_etc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/",
         "support": {
           "chrome": {
             "version_added": "63"

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_etc1": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_etc1",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/",
         "support": {
           "chrome": {
             "version_added": "49"

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_pvrtc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_pvrtc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
         "support": {
           "chrome": {
             "version_added": true

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_s3tc": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/",
         "support": {
           "chrome": [
             {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -3,6 +3,7 @@
     "WEBGL_compressed_texture_s3tc_srgb": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
         "support": {
           "chrome": {
             "version_added": "60"

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -3,6 +3,7 @@
     "WEBGL_debug_renderer_info": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_debug_renderer_info",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/",
         "support": {
           "chrome": {
             "version_added": "33"

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -3,6 +3,7 @@
     "WEBGL_debug_shaders": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/",
         "support": {
           "chrome": {
             "version_added": "47"
@@ -58,6 +59,7 @@
       "getTranslatedShaderSource": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders/getTranslatedShaderSource",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/",
           "support": {
             "chrome": {
               "version_added": "47"

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -3,6 +3,7 @@
     "WEBGL_depth_texture": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_depth_texture",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/",
         "support": {
           "chrome": [
             {

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -3,6 +3,7 @@
     "WEBGL_draw_buffers": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/",
         "support": {
           "chrome": {
             "version_added": "36"
@@ -50,6 +51,7 @@
       "drawBuffersWEBGL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers/drawBuffersWEBGL",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/",
           "support": {
             "chrome": {
               "version_added": "36"

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -3,6 +3,7 @@
     "WEBGL_lose_context": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
         "support": {
           "chrome": [
             {
@@ -93,6 +94,7 @@
       "loseContext": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context/loseContext",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
           "support": {
             "chrome": {
               "version_added": "26"
@@ -148,6 +150,7 @@
       "restoreContext": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context/restoreContext",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/",
           "support": {
             "chrome": {
               "version_added": "26"

--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -3,6 +3,7 @@
     "WEBGL_multi_draw": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw",
+        "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -50,6 +51,7 @@
       "multiDrawArraysInstancedWEBGL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -98,6 +100,7 @@
       "multiDrawArraysWEBGL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -146,6 +149,7 @@
       "multiDrawElementsInstancedWEBGL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -194,6 +198,7 @@
       "multiDrawElementsWEBGL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL",
+          "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/",
           "support": {
             "chrome": {
               "version_added": "86"


### PR DESCRIPTION
Depends on https://github.com/mdn/browser-compat-data/pull/10353. CI breakage on this PR branch is expected until that schema change is merged.  Once that gets merged, this can be rebased to turn CI green.