### PR TITLE
Deprecate all vrdisplay* events

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -10211,7 +10211,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10261,7 +10261,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10330,7 +10330,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10386,7 +10386,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10455,7 +10455,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10505,7 +10505,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10555,7 +10555,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10605,7 +10605,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -10673,13 +10673,14 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
       "window": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/window",
+          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-dev",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The WebVR spec at https://immersive-web.github.io/webvr/spec/1.1/ is deprecated (in favor of WebXR), and all features from it are marked deprecated — except for the `vrdisplay*` events defined in the spec. So this change marks all those `vrdisplay*` events deprecated:true.