### PR TITLE
Add Edge versions for WheelEvent API

### DIFF
--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -64,7 +64,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -64,7 +64,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": false
+              "version_added": null
             },
             "firefox": {
               "version_added": null
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "17"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WheelEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WheelEvent
