### PR TITLE
Add Edge versions for WindowClient API

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -59,7 +59,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -107,7 +107,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -156,7 +156,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -205,7 +205,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -254,7 +254,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WindowClient` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WindowClient
