### PR TITLE
Add Edge versions for WorkerLocation API

### DIFF
--- a/api/WorkerLocation.json
+++ b/api/WorkerLocation.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3.5"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WorkerLocation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerLocation
