### PR TITLE
Add Edge versions for WorkerNavigator API

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "3.5"
@@ -58,7 +58,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -203,7 +203,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WorkerNavigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerNavigator
