### PR TITLE
Add Edge versions for XMLDocument API

### DIFF
--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -27,7 +27,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `XMLDocument` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLDocument
