### PR TITLE
Add Edge versions for WEBGL_compressed_texture_s3tc API

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -17,7 +17,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WEBGL_compressed_texture_s3tc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_compressed_texture_s3tc
