### PR TITLE
Add Edge versions for WEBGL_debug_renderer_info API

### DIFF
--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WEBGL_debug_renderer_info` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_debug_renderer_info
