### PR TITLE
Add Edge versions for WEBGL_depth_texture API

### DIFF
--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": [
             {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WEBGL_depth_texture` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.1).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_depth_texture
