### PR TITLE
Add WebGLRenderingContext spec URLs

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -3,6 +3,7 @@
     "WebGLRenderingContext": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext",
+        "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14",
         "support": {
           "chrome": {
             "version_added": "9"
@@ -52,6 +53,7 @@
       "activeTexture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/activeTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -100,6 +102,7 @@
       "attachShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/attachShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -148,6 +151,7 @@
       "bindAttribLocation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindAttribLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -196,6 +200,10 @@
       "bindBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindBuffer",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -291,6 +299,10 @@
       "bindFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindFramebuffer",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -386,6 +398,7 @@
       "bindRenderbuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -434,6 +447,10 @@
       "bindTexture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindTexture",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -529,6 +546,7 @@
       "blendColor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendColor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -577,6 +595,7 @@
       "blendEquation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendEquation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -672,6 +691,7 @@
       "blendEquationSeparate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendEquationSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -767,6 +787,7 @@
       "blendFunc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -815,6 +836,7 @@
       "blendFuncSeparate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendFuncSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -911,6 +933,7 @@
       "bufferData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bufferData",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1006,6 +1029,7 @@
       "bufferSubData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bufferSubData",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1101,6 +1125,7 @@
       "canvas": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/canvas",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-canvas",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1203,6 +1228,10 @@
       "checkFramebufferStatus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1298,6 +1327,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clear",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1346,6 +1376,7 @@
       "clearColor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearColor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1394,6 +1425,7 @@
       "clearDepth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearDepth",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1442,6 +1474,7 @@
       "clearStencil": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearStencil",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1490,6 +1523,7 @@
       "colorMask": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/colorMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1538,6 +1572,7 @@
       "commit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/commit",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext-commit",
           "support": {
             "chrome": {
               "version_added": false
@@ -1593,6 +1628,7 @@
       "compileShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compileShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1641,6 +1677,7 @@
       "compressedTexImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compressedTexImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSEDTEXIMAGE2D",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1784,6 +1821,7 @@
       "compressedTexSubImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compressedTexSubImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSEDTEXSUBIMAGE2D",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1927,6 +1965,7 @@
       "copyTexImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/copyTexImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -1975,6 +2014,7 @@
       "copyTexSubImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/copyTexSubImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2023,6 +2063,7 @@
       "createBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2071,6 +2112,7 @@
       "createFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2119,6 +2161,7 @@
       "createProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2167,6 +2210,7 @@
       "createRenderbuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2215,6 +2259,7 @@
       "createShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2263,6 +2308,7 @@
       "createTexture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2311,6 +2357,7 @@
       "cullFace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/cullFace",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2359,6 +2406,7 @@
       "deleteBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2407,6 +2455,7 @@
       "deleteFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2455,6 +2504,7 @@
       "deleteProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2503,6 +2553,7 @@
       "deleteRenderbuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2551,6 +2602,7 @@
       "deleteShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2599,6 +2651,7 @@
       "deleteTexture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2647,6 +2700,7 @@
       "depthFunc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2695,6 +2749,7 @@
       "depthMask": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2743,6 +2798,7 @@
       "depthRange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthRange",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2791,6 +2847,7 @@
       "detachShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/detachShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2839,6 +2896,7 @@
       "disable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/disable",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2887,6 +2945,7 @@
       "disableVertexAttribArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/disableVertexAttribArray",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2935,6 +2994,7 @@
       "drawArrays": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawArrays",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -2983,6 +3043,7 @@
       "drawElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawElements",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3031,6 +3092,7 @@
       "drawingBufferHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferHeight",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-drawingBufferHeight",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3079,6 +3141,7 @@
       "drawingBufferWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferWidth",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-drawingBufferWidth",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3127,6 +3190,7 @@
       "enable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/enable",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3175,6 +3239,7 @@
       "enableVertexAttribArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/enableVertexAttribArray",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3223,6 +3288,7 @@
       "finish": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/finish",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3271,6 +3337,7 @@
       "flush": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/flush",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3319,6 +3386,7 @@
       "framebufferRenderbuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/framebufferRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3414,6 +3482,7 @@
       "framebufferTexture2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/framebufferTexture2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3509,6 +3578,7 @@
       "frontFace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/frontFace",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3557,6 +3627,7 @@
       "generateMipmap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/generateMipmap",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3652,6 +3723,7 @@
       "getActiveAttrib": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getActiveAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3700,6 +3772,7 @@
       "getActiveUniform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getActiveUniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3748,6 +3821,7 @@
       "getAttachedShaders": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getAttachedShaders",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3796,6 +3870,7 @@
       "getAttribLocation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getAttribLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3844,6 +3919,10 @@
       "getBufferParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getBufferParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3939,6 +4018,7 @@
       "getContextAttributes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getContextAttributes",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.2",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -3987,6 +4067,7 @@
       "getError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getError",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4035,6 +4116,7 @@
       "getExtension": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getExtension",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4083,6 +4165,10 @@
       "getFramebufferAttachmentParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4178,6 +4264,10 @@
       "getParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4226,6 +4316,7 @@
       "getProgramInfoLog": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramInfoLog",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4274,6 +4365,10 @@
       "getProgramParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4369,6 +4464,10 @@
       "getRenderbufferParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getRenderbufferParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4464,6 +4563,7 @@
       "getShaderInfoLog": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderInfoLog",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4512,6 +4612,7 @@
       "getShaderParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderParameter",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4560,6 +4661,7 @@
       "getShaderPrecisionFormat": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderPrecisionFormat",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4608,6 +4710,7 @@
       "getShaderSource": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderSource",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4656,6 +4759,7 @@
       "getSupportedExtensions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getSupportedExtensions",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4704,6 +4808,10 @@
       "getTexParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getTexParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4799,6 +4907,10 @@
       "getUniform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniform",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4894,6 +5006,7 @@
       "getUniformLocation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniformLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -4942,6 +5055,10 @@
       "getVertexAttrib": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttrib",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5037,6 +5154,7 @@
       "getVertexAttribOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttribOffset",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5085,6 +5203,7 @@
       "hint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/hint",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5133,6 +5252,7 @@
       "isBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5181,6 +5301,7 @@
       "isContextLost": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isContextLost",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.13",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5229,6 +5350,10 @@
       "isEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isEnabled",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5324,6 +5449,7 @@
       "isFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5372,6 +5498,7 @@
       "isProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5420,6 +5547,7 @@
       "isRenderbuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5468,6 +5596,7 @@
       "isShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5516,6 +5645,7 @@
       "isTexture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5564,6 +5694,7 @@
       "lineWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/lineWidth",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": false
@@ -5613,6 +5744,7 @@
       "linkProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/linkProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5661,6 +5793,7 @@
       "makeXRCompatible": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/makeXRCompatible",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -5709,6 +5842,11 @@
       "pixelStorei": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/pixelStorei",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#PIXEL_STORAGE_PARAMETERS",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5804,6 +5942,7 @@
       "polygonOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/polygonOffset",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5852,6 +5991,7 @@
       "readPixels": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/readPixels",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -5995,6 +6135,10 @@
       "renderbufferStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/renderbufferStorage",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6090,6 +6234,7 @@
       "sampleCoverage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/sampleCoverage",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6138,6 +6283,7 @@
       "scissor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/scissor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6186,6 +6332,7 @@
       "shaderSource": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/shaderSource",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6234,6 +6381,7 @@
       "stencilFunc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6282,6 +6430,7 @@
       "stencilFuncSeparate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilFuncSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6330,6 +6479,7 @@
       "stencilMask": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6378,6 +6528,7 @@
       "stencilMaskSeparate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilMaskSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6426,6 +6577,7 @@
       "stencilOp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilOp",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6474,6 +6626,7 @@
       "stencilOpSeparate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilOpSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6522,6 +6675,10 @@
       "texImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texImage2D",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6665,6 +6822,10 @@
       "texParameterf": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6760,6 +6921,10 @@
       "texParameteri": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6855,6 +7020,10 @@
       "texSubImage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texSubImage2D",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#TEXSUBIMAGE2D",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -6998,6 +7167,7 @@
       "uniform1f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7046,6 +7216,7 @@
       "uniform1fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7094,6 +7265,7 @@
       "uniform1i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7142,6 +7314,7 @@
       "uniform1iv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7190,6 +7363,7 @@
       "uniform2f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7238,6 +7412,7 @@
       "uniform2fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7286,6 +7461,7 @@
       "uniform2i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7334,6 +7510,7 @@
       "uniform2iv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7382,6 +7559,7 @@
       "uniform3f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7430,6 +7608,7 @@
       "uniform3fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7478,6 +7657,7 @@
       "uniform3i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7526,6 +7706,7 @@
       "uniform3iv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7574,6 +7755,7 @@
       "uniform4f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7622,6 +7804,7 @@
       "uniform4fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7670,6 +7853,7 @@
       "uniform4i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7718,6 +7902,7 @@
       "uniform4iv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7766,6 +7951,7 @@
       "uniformMatrix2fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -7909,6 +8095,7 @@
       "uniformMatrix3fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8052,6 +8239,7 @@
       "uniformMatrix4fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8195,6 +8383,7 @@
       "useProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/useProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8243,6 +8432,7 @@
       "validateProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/validateProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8291,6 +8481,7 @@
       "vertexAttrib1f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8339,6 +8530,7 @@
       "vertexAttrib1fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8435,6 +8627,7 @@
       "vertexAttrib2f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8483,6 +8676,7 @@
       "vertexAttrib2fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8579,6 +8773,7 @@
       "vertexAttrib3f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8627,6 +8822,7 @@
       "vertexAttrib3fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8723,6 +8919,7 @@
       "vertexAttrib4f": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8771,6 +8968,7 @@
       "vertexAttrib4fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8867,6 +9065,7 @@
       "vertexAttribPointer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttribPointer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -8915,6 +9114,7 @@
       "viewport": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/viewport",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4",
           "support": {
             "chrome": {
               "version_added": "9"


### PR DESCRIPTION
Heads-up: This one adds 160 spec URLs. And in general the WebGL spec lacks anchors for individual members, so (with some exceptions) the URLs point to spec subsection headings. Also, there are a number of features with multiple spec URLs — due to the fact that the WebGL2 spec and some extension specs add members to objects or extend behavior of some.