### PR TITLE
Add note that Safari doesn't support wss scheme.

### DIFF
--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -23,7 +23,8 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Safari does not support the 'wss:' scheme in content security policy sources.
             }
           }
         },


### PR DESCRIPTION
I've opened https://github.com/mdn/content/pull/4787 to add the `wss:` scheme (WebSocket Secure) to the list of allowed sources in the Web Extension CSP. This scheme works in chromium-based browsers and Firefox, but is not currently supported in Safari. I've opened a Feedback with Apple to add support for `wss:` schemes (FB9098957).

I don't believe Apple publishes any documentation as a valid data point, but I did run into this issue while working on a Safari Web Extension. Here's a screenshot of logs (hosts redacted) showing that Safari Web Extensions filter out WSS URLs:

![csp_filtered](https://user-images.githubusercontent.com/16485763/117432138-426c3c00-aee7-11eb-983f-1c55eac88287.png)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any


