### PR TITLE
Add IE versions for BeforeUnloadEvent API

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "4"
           },
           "opera": {
             "version_added": "17"

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": "17"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `BeforeUnloadEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BeforeUnloadEvent
