### PR TITLE
Add IE versions for MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -235,7 +235,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -577,7 +577,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -626,7 +626,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -722,7 +722,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -771,7 +771,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1494,7 +1494,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1737,7 +1737,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent
