### PR TITLE
Add IE versions for MimeTypeArray API

### DIFF
--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "4"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -70,7 +70,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -120,7 +120,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -170,7 +170,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MimeTypeArray` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MimeTypeArray
