### PR TITLE
Add IE versions for PageTransitionEvent API

### DIFF
--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -21,7 +21,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "11"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `PageTransitionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PageTransitionEvent
