### PR TITLE
Add IE versions for PerformanceEntry API

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -33,7 +33,7 @@
             "version_added": "25"
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "nodejs": {
             "version_added": "8.5.0",
@@ -109,7 +109,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": null
@@ -161,7 +161,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": "8.5.0"
@@ -213,7 +213,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": "8.5.0"
@@ -265,7 +265,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "nodejs": {
               "version_added": "8.5.0"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `PerformanceEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEntry
