### PR TITLE
Add IE versions for PopStateEvent API

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
             "version_added": true
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `PopStateEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PopStateEvent
