### PR TITLE
Add IE versions for SVGHKernElement API

### DIFF
--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -21,7 +21,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `SVGHKernElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGHKernElement
