### PR TITLE
Add IE versions for SVGRenderingIntent API

### DIFF
--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "15",


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGRenderingIntent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGRenderingIntent
