### PR TITLE
Add IE versions for SVGStylable API

### DIFF
--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -23,7 +23,7 @@
             "version_removed": "20"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGStylable` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStylable
