### PR TITLE
Add IE/Edge versions for SVGURIReference API

### DIFF
--- a/api/SVGURIReference.json
+++ b/api/SVGURIReference.json
@@ -21,7 +21,7 @@
             "version_added": null
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGURIReference` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGURIReference
