### PR TITLE
Add IE versions for SVGUnitTypes API

### DIFF
--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGUnitTypes` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGUnitTypes
