### PR TITLE
Add IE/Edge versions for SVGZoomAndPan API

### DIFF
--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -22,7 +22,7 @@
             "version_removed": "79"
           },
           "ie": {
-            "version_added": null
+            "version_added": "9"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `SVGZoomAndPan` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGZoomAndPan
