### PR TITLE
Mark the SVG ‘kerning’ property deprecated

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1583,7 +1583,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
https://svgwg.org/svg2-draft/text.html#KerningProperty says:

> The ‘kerning’ property has been removed in SVG 2. This property is replaced in SVG 2 by the CSS font-kerning property

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/kerning also already has a Deprecated banner.