### PR TITLE
Mark "URL scheme-aware (schemeful) SameSite cookies" supported in Chrome 89

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -418,26 +418,36 @@
             "__compat": {
               "description": "URL scheme-aware (\"schemeful\")",
               "support": {
-                "chrome": {
-                  "version_added": "86",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#schemeful-same-site",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "86",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#schemeful-same-site",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "89"
+                  },
+                  {
+                    "version_added": "86",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#schemeful-same-site",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "89"
+                  },
+                  {
+                    "version_added": "86",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#schemeful-same-site",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "edge": {
                   "version_added": "86",
                   "flags": [


### PR DESCRIPTION
Fixes #10271. 

URL scheme-aware (schemeful) SameSite support was enabled by default in Chrome 89 and Chrome for Android 89, per Chrome Platform Status: https://www.chromestatus.com/feature/5096179480133632

I wasn't sure if I should keep the support statements for Chrome 86 when it was available via a flag, but it seems like that's unnecessary. Please let me know if I'm wrong and I'll fix it.