### PR TITLE
Deprecate Accept-CH-Lifetime HTTP header

### DIFF
--- a/http/headers/accept-ch-lifetime.json
+++ b/http/headers/accept-ch-lifetime.json
@@ -44,8 +44,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://github.com/httpwg/http-extensions/pull/878 removed the `Accept-CH-Lifetime` HTTP header from the Client Hints spec, and it’s not part of any other spec — so this change marks it deprecated and standard_track:false.

Related MDN change: https://github.com/mdn/content/pull/4854