### PR TITLE
Remove irrelevant "api.WindowClient.ancestorOrigins"

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -48,54 +48,6 @@
           "deprecated": false
         }
       },
-      "ancestorOrigins": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowClient/ancestorOrigins",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "focus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowClient/focus",


### PR DESCRIPTION
This PR removes the unsupported `ancestorOrigins` member of the `WindowClient` API per the [removal of irrelevant features](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features) guideline.  This feature is not supported in any browser.
