### PR TITLE
WorkerGlobalScope - add close() and close_event to match onclose()

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -47,6 +47,106 @@
           "deprecated": false
         }
       },
+      "close": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/close",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5",
+              "version_removed": "50"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "50"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "11.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "description": "<code>close</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5",
+              "version_removed": "50"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "50"
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "11.5"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "dump": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/dump",


### PR DESCRIPTION
This is part of fixing #10224

`WorkerGlobalScope` has the (deprecated) `onclose()` event handler property, but not the associated method `close()` and event `close_event`. This copies the event hanlder for the other two items. This then ensures that BCD matches MDN for this property.