### PR TITLE
Mark several Permission Policy features non-standard

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -859,7 +859,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -942,7 +942,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -1235,7 +1235,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -1525,7 +1525,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -1608,7 +1608,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }


### PR DESCRIPTION
There is no spec for the following policy-controlled features:

* layout-animations
* legacy-image-formats
* oversized-images
* unoptimized-images
* unsized-media

So this change marks them all standard_track:false.

Related MDN change: https://github.com/mdn/content/pull/4872
Related MDN change: https://github.com/mdn/content/pull/4899