### PR TITLE
Rename http.headers.feature-policy.wake-lock to screen-wake-lock

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1399,6 +1399,55 @@
             }
           }
         },
+        "screen-wake-lock": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/wake-lock",
+            "spec_url": "https://w3c.github.io/screen-wake-lock/#policy-control",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sync-xhr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/sync-xhr",
@@ -1767,54 +1816,6 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": true
-            }
-          }
-        },
-        "wake-lock": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/wake-lock",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1401,7 +1401,7 @@
         },
         "screen-wake-lock": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/wake-lock",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/screen-wake-lock",
             "spec_url": "https://w3c.github.io/screen-wake-lock/#policy-control",
             "support": {
               "chrome": {


### PR DESCRIPTION
There is no “wake-lock” feature-controlled-policy defined in any current spec, and no “wake-lock” feature-controlled-policy was ever implemented in any browser. It’s instead called `screen-wake-lock`.

So this change renames http.headers.feature-policy.wake-lock to http.headers.feature-policy.screen-wake-lock.

The change also adds a spec URL for the feature.

Related MDN change: https://github.com/mdn/content/pull/4873