### PR TITLE
Update `api.Node.isConnected` for Firefox

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -790,10 +790,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "49"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Based on [testing](https://mdn-bcd-collector.appspot.com/tests/api/Node/isConnected), this was supported some versions earlier than previously reported. Fixes #9639.
