### PR TITLE
accept-ch HTTP header - update spec URL

### DIFF
--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -4,7 +4,7 @@
       "Accept-CH": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942#section-3.1",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -4,6 +4,7 @@
       "Accept-CH": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942",
           "support": {
             "chrome": {
               "version_added": "46"


### PR DESCRIPTION
This adds https://datatracker.ietf.org/doc/html/rfc8942 as the spec URL for Accept-CH HTTP header. This is latest version as per Feb 2021