### PR TITLE
Fix Safari data for text-decoration-skip CSS property

### DIFF
--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -41,23 +41,23 @@
             "safari": [
               {
                 "version_added": "12.1",
-                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
               },
               {
                 "version_added": "8",
                 "prefix": "-webkit-",
-                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
               }
             ],
             "safari_ios": [
               {
                 "version_added": "12.2",
-                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
               },
               {
                 "version_added": "8",
                 "prefix": "-webkit-",
-                "notes": "Only supports the <code>none</code> and <code>skip</code> values; all other values behave like those two values."
+                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
               }
             ],
             "samsunginternet_android": {

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -41,23 +41,23 @@
             "safari": [
               {
                 "version_added": "12.1",
-                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
+                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               },
               {
-                "version_added": "8",
+                "version_added": "7",
                 "prefix": "-webkit-",
-                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
+                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               }
             ],
             "safari_ios": [
               {
                 "version_added": "12.2",
-                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
+                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               },
               {
-                "version_added": "8",
+                "version_added": "7",
                 "prefix": "-webkit-",
-                "notes": "Only supports the <code>none</code> and <code>auto</code> values; all other values behave like those two values."
+                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               }
             ],
             "samsunginternet_android": {


### PR DESCRIPTION
This PR resolves a small issue with the notes for Safari.  It mentions that the property only supports the `none` and `skip` values, yet `skip` is not a value, either in Safari or the spec.  I believe the note author meant `auto`, which is included in the spec.

Fixes #6211.
