### PR TITLE
Include CanIUse Embed as a project using the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Here are some projects using the data, as an [npm module](https://www.npmjs.com/
 
 - [Add-ons Linter](https://github.com/mozilla/addons-linter) - the Add-ons Linter is used on [addons.mozilla.org](https://addons.mozilla.org/) and the [web-ext](https://github.com/mozilla/web-ext/) tool. It uses browser-compat-data to check that the Firefox version that the add-on lists support for does in fact support the APIs used by the add-on.
 - [caniuse](https://caniuse.com/) - In addition to the existing caniuse database, caniuse includes features from the MDN BCD project, formatted and interactive like any other caniuse support table.
+- [CanIUse Embed](https://caniuse.bitsofco.de/) - Thanks to the inclusion of MDN BCD data in caniuse, this embed tool allows for embedding BCD data into any project.
 - [Compat Report](https://addons.mozilla.org/en-US/firefox/addon/compat-report/) - Firefox Add-on that shows compatibility data for the current site in the developer tools.
 - [compat-tester](https://github.com/SphinxKnight/compat-tester) - Scan local documents for compatibility issues.
 - [Visual Studio Code](https://code.visualstudio.com) - Shows the compatibility information in [the code completion popup](https://code.visualstudio.com/updates/v1_25#_improved-accuracy-of-browser-compatibility-data).


### PR DESCRIPTION
Since the inclusion of MDN BCD content directly in CanIUse, projects that are using CanIUse data are also able to use BCD data, including the CanIUse embed by @ireade.  Ire has also made some tweaks so that any BCD data will display with a blue border (vs. an orange one) and state the data comes from BCD.  This PR adds a link back to their tool in the "projects using the data" section of the Readme, to help users interested in embedding BCD find a tool much quicker (and as a thanks to the tool's author).
