### PR TITLE
Rename Hexadecimal escape sequences

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -279,7 +279,7 @@
       },
       "hexadecimal_escape_sequences": {
         "__compat": {
-          "description": "Hexadecimal escape sequences (<code>'\\0xA9'</code>)",
+          "description": "Hexadecimal escape sequences (<code>'\\xA9'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal_escape_sequences",
           "spec_url": "https://tc39.es/ecma262/#prod-HexEscapeSequence",
           "support": {


### PR DESCRIPTION
This PR fixes #6218.  During my testing, I found that `\0xA9` and `\xA9` return two different results (`xA9` and `©` respectively).
