### PR TITLE
Add queueMicrotask support for Firefox for Android

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1020,7 +1020,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #9768 (and a duplicate issue).

Mirrored to Firefox for Android 79, after the relevant desktop release. This is a bit of a guess, but I don't see any reason to think it would be otherwise, from the original bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1480236.