### PR TITLE
Safari 14.1 and iOS 14.5 Intl supplemental updates

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -196,10 +196,10 @@
                     "version_added": false
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.5"
                   },
                   "samsunginternet_android": {
                     "version_added": false

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -194,10 +194,10 @@
                     "version_added": "60"
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "14.1"
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "14.5"
                   },
                   "samsunginternet_android": {
                     "version_added": false
@@ -505,10 +505,10 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
An engineer on our team noted the following:

- Intl.Collator collation option is supported in 14.1 https://trac.webkit.org/changeset/267102/webkit
- Intl.DateTimeFormat fractionalSecondDigits option is supported in 14.1 - https://trac.webkit.org/changeset/266170/webkit
- Intl.DateTimeFormat#formatRangeToParts is supported in 14.1 https://trac.webkit.org/changeset/269706/webkit
- Intl.NumberFormat supports currencyDisplay: 'narrowSymbol' in 14.1 https://trac.webkit.org/changeset/266031/webkit