### PR TITLE
Remove window.returnValue

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7471,54 +7471,6 @@
           }
         }
       },
-      "returnValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/returnValue",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "routeEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/routeEvent",


### PR DESCRIPTION
All support values for the feature are either “false” or “null”, it’s not defined in any current spec, and it has no MDN article (the mdn_url https://developer.mozilla.org/docs/Web/API/Window/returnValue is 404).  So this change removes it from BCD.