### PR TITLE
Mark all features from DNT spec deprecated

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -786,9 +786,9 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -48,7 +48,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/tk.json
+++ b/http/headers/tk.json
@@ -46,7 +46,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The https://www.w3.org/TR/tracking-dnt/ spec never made it to W3C Recommendation; instead it was retired as a Working Group Note:

https://www.w3.org/TR/2019/NOTE-tracking-dnt-20190117/

In the W3C spec database its formal status is Retired:

https://www.w3.org/TR/?tag=privacy&status=ret

And the Status section of https://www.w3.org/TR/tracking-dnt/ itself says:

> Since its last publication as a Candidate Recommendation, there has not been sufficient deployment of these extensions (as defined) to justify further advancement, nor have there been indications of planned support among user agents, third parties, and the ecosystem at large.

All of that is sufficient to merit the features being marked as deprecated in BCD.

The affected features are:

* the DNT HTTP request header
* the Tk HTTP response header
* the navigator.doNotTrack property

Related MDN change: https://github.com/mdn/content/pull/4960