### PR TITLE
Add/fix some CSS/HTTP/JavaScript/SVG spec URLs

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -204,7 +204,7 @@
         "ascent-override": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/ascent-override",
-            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-ascent-override",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#descdef-font-face-ascent-override",
             "support": {
               "chrome": {
                 "version_added": "87"
@@ -253,7 +253,7 @@
         "descent-override": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/descent-override",
-            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-descent-override",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#descdef-font-face-descent-override",
             "support": {
               "chrome": {
                 "version_added": "87"
@@ -708,7 +708,7 @@
         "line-gap-override": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/line-gap-override",
-            "spec_url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-line-gap-override",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#descdef-font-face-line-gap-override",
             "support": {
               "chrome": {
                 "version_added": "87"

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -299,6 +299,7 @@
         "subgrid": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid",
+            "spec_url": "https://drafts.csswg.org/css-grid/#subgrids",
             "description": "<code>subgrid</code>",
             "support": {
               "chrome": {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -355,6 +355,7 @@
         "subgrid": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid",
+            "spec_url": "https://drafts.csswg.org/css-grid/#subgrids",
             "description": "<code>subgrid</code>",
             "support": {
               "chrome": {

--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -5,6 +5,7 @@
         "__compat": {
           "description": "<code>::file-selector-button</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::file-selector-button",
+          "spec_url": "https://drafts.csswg.org/css-pseudo/#file-selector-button-pseudo",
           "support": {
             "chrome": [
               {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -53,6 +53,7 @@
         "alpha": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/rgba()",
+            "spec_url": "https://drafts.csswg.org/css-color/#rgb-functions",
             "description": "Alpha color values (<code>rgba()</code>, <code>hsla()</code>)",
             "support": {
               "chrome": {
@@ -153,6 +154,7 @@
         "color-mix": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix()",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#color-mix",
             "description": "<code>color-mix()</code>",
             "support": {
               "chrome": {
@@ -313,6 +315,7 @@
         "hsl": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/hsl()",
+            "spec_url": "https://drafts.csswg.org/css-color/#the-hsl-notation",
             "description": "HSL color values (<code>hsl()</code>)",
             "support": {
               "chrome": {
@@ -556,6 +559,7 @@
         "rgb_functional_notation": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/rgb()",
+            "spec_url": "https://drafts.csswg.org/css-color/#rgb-functions",
             "description": "RGB functional notation (<code>rgb()</code>)",
             "support": {
               "chrome": {

--- a/http/data-url.json
+++ b/http/data-url.json
@@ -3,6 +3,7 @@
     "data-url": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs",
+        "spec_url": "https://datatracker.ietf.org/doc/html/rfc2397#section-2",
         "description": "data URL scheme",
         "support": {
           "chrome": {

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -4,6 +4,7 @@
       "Accept-CH": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942#section-3.1",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/http/headers/alt-svc.json
+++ b/http/headers/alt-svc.json
@@ -4,6 +4,7 @@
       "Alt-Svc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7838#section-3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -4,6 +4,10 @@
       "Cache-Control": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control",
+          "spec_url": [
+            "https://datatracker.ietf.org/doc/html/rfc7234#section-5.2",
+            "https://datatracker.ietf.org/doc/html/rfc8246#section-2"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -4,6 +4,7 @@
       "Clear-Site-Data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+          "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#header",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -4,6 +4,7 @@
       "Connection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7230#section-6.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -4,6 +4,10 @@
       "Content-Disposition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Disposition",
+          "spec_url": [
+            "https://datatracker.ietf.org/doc/html/rfc6266#section-4",
+            "https://datatracker.ietf.org/doc/html/rfc7578#section-4.2"
+          ],
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -4,6 +4,7 @@
       "Content-Security-Policy-Report-Only": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#cspro-header",
           "support": {
             "chrome": {
               "version_added": "25"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -5,6 +5,7 @@
         "Content-Security-Policy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#csp-header",
             "support": {
               "chrome": [
                 {
@@ -814,7 +815,6 @@
           "plugin-types": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types",
-              "spec_url": "https://www.w3.org/TR/CSP2/#directive-plugin-types",
               "support": {
                 "chrome": {
                   "version_added": "40"
@@ -1023,6 +1023,7 @@
           "report-to": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to",
+              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-report-to",
               "support": {
                 "chrome": {
                   "version_added": "70"
@@ -1631,6 +1632,7 @@
           "trusted-types": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types",
+              "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-types-csp-directive",
               "support": {
                 "chrome": [
                   {

--- a/http/headers/digest.json
+++ b/http/headers/digest.json
@@ -4,6 +4,7 @@
       "Digest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Digest",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -4,6 +4,7 @@
       "Expect-CT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect-CT",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08#section-2.1",
           "support": {
             "chrome": {
               "version_added": "61",

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1243,6 +1243,7 @@
         "payment": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/payment",
+            "spec_url": "https://w3c.github.io/payment-request/#permissions-policy",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1305,6 +1306,7 @@
         "picture-in-picture": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/picture-in-picture",
+            "spec_url": "https://w3c.github.io/picture-in-picture/#feature-policy",
             "support": {
               "chrome": {
                 "version_added": "71"

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -4,6 +4,7 @@
       "Strict-Transport-Security": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Strict-Transport-Security",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6797#section-6.1",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/http/headers/want-digest.json
+++ b/http/headers/want-digest.json
@@ -4,6 +4,7 @@
       "Want-Digest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Want-Digest",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -4,6 +4,7 @@
       "X-Frame-Options": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Frame-Options",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7034#section-2",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/http/status.json
+++ b/http/status.json
@@ -1083,6 +1083,7 @@
       "451": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/451",
+          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7725#section-3",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1000,7 +1000,7 @@
           "__compat": {
             "description": "<code>RegExp.$1-$9</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n",
-            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features#additional-properties-of-the-regexp-constructor",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -207,6 +207,7 @@
         "clip-rule": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/clip-rule",
+            "spec_url": "https://drafts.fxtf.org/css-masking/#the-clip-rule",
             "support": {
               "chrome": {
                 "version_added": null
@@ -499,6 +500,7 @@
         "cursor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/cursor",
+            "spec_url": "https://drafts.csswg.org/css-ui/#cursor",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/attributes/style.json
+++ b/svg/attributes/style.json
@@ -5,6 +5,7 @@
         "class": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/class",
+            "spec_url": "https://svgwg.org/svg2-draft/styling.html#ElementSpecificStyling",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
This change adds some CSS/HTTP/JavaScript/SVG spec URLs that got missed in the first pass of adding spec URLs, as well as fixing a few — including:

* Replace some https://www.w3.org/TR/css-fonts-4/ URLs with https://drafts.csswg.org/css-fonts/ URLs

* Drop the https://www.w3.org/TR/CSP2/#directive-plugin-types (the plugin-types directive deprecated/obsolete — is is not part of CSP3, and this URL was the only remaining CSP2 URL in BCD).

* For https://github.com/tc39/proposal-regexp-legacy-features/, add the trailing slash (for consistency with how we format other such URLs).