### PR TITLE
Set api.Element.scroll_event value for Safari

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6939,10 +6939,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR addresses issue #9474 (scroll_event)

Fixes #9474