### PR TITLE
Spec URLs last pass: Add/change CSS* API spec URLs

### DIFF
--- a/api/CSSMathInvert.json
+++ b/api/CSSMathInvert.json
@@ -3,6 +3,7 @@
     "CSSMathInvert": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathInvert",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathinvert",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMathInvert": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathInvert/CSSMathInvert",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathinvert-cssmathinvert",
           "description": "<code>CSSMathInvert()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathInvert/value",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathinvert-value",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMathMax.json
+++ b/api/CSSMathMax.json
@@ -3,6 +3,7 @@
     "CSSMathMax": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMax",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathmax",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMathMax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMax/CSSMathMax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathmax-cssmathmax",
           "description": "<code>CSSMathMax()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMax/values",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathmax-values",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMathMin.json
+++ b/api/CSSMathMin.json
@@ -51,7 +51,7 @@
       "CSSMathMin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMin/CSSMathMin",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathmin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathmin-cssmathmin",
           "description": "<code>CSSMathMin()</code> constructor",
           "support": {
             "chrome": {

--- a/api/CSSMathMin.json
+++ b/api/CSSMathMin.json
@@ -3,6 +3,7 @@
     "CSSMathMin": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMin",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathmin",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMathMin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMin/CSSMathMin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathmin",
           "description": "<code>CSSMathMin()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathMin/values",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathmin-values",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -3,6 +3,7 @@
     "CSSMathNegate": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathnegate",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,6 +51,7 @@
       "CSSMathNegate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate/CSSMathNegate",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathnegate-cssmathnegate",
           "description": "<code>CSSMathNegate()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +101,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate/value",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathnegate-value",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -3,6 +3,7 @@
     "CSSNumericArray": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssnumericarray",
         "support": {
           "chrome": {
             "version_added": "66"

--- a/api/CSSRotate.json
+++ b/api/CSSRotate.json
@@ -3,6 +3,7 @@
     "CSSRotate": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssrotate",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -50,7 +51,10 @@
       "CSSRotate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSRotate/CSSRotate",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssrotate",
+          "spec_url": [
+            "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-cssrotate",
+            "https://drafts.css-houdini.org/css-typed-om/#dom-cssrotate-cssrotate-x-y-z-angle"
+          ],
           "description": "<code>CSSRotate()</code> constructor",
           "support": {
             "chrome": {

--- a/api/CSSScale.json
+++ b/api/CSSScale.json
@@ -3,6 +3,7 @@
     "CSSScale": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSScale",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssscale",
         "support": {
           "chrome": {
             "version_added": "66"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -3,7 +3,7 @@
     "CSSTransformValue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue",
-        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#csstransformvalue",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -51,6 +51,7 @@
       "CSSTransformValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/CSSTransformValue",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-csstransformvalue",
           "description": "<code>CSSTransformValue()</code> constructor",
           "support": {
             "chrome": {

--- a/api/CSSTranslate.json
+++ b/api/CSSTranslate.json
@@ -3,6 +3,7 @@
     "CSSTranslate": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTranslate",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#csstranslate",
         "support": {
           "chrome": {
             "version_added": "66"


### PR DESCRIPTION
Notes: `CSSRotate()` constructor has two signatures, and so two spec URLs