### PR TITLE
Spec URLs for entries/keys/values/forEach: reference WebIDL

### DIFF
--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -100,7 +100,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/entries",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -149,7 +149,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/forEach",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -247,7 +247,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/keys",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -394,7 +394,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/values",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -149,7 +149,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/entries",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -198,7 +198,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/forEach",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -247,7 +247,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/keys",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -345,7 +345,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/values",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -197,7 +197,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/entries",
-          "spec_url": "https://dom.spec.whatwg.org/#domtokenlist",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -246,7 +246,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/forEach",
-          "spec_url": "https://dom.spec.whatwg.org/#domtokenlist",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -344,7 +344,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/keys",
-          "spec_url": "https://dom.spec.whatwg.org/#domtokenlist",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -934,7 +934,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMTokenList/values",
-          "spec_url": "https://dom.spec.whatwg.org/#domtokenlist",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -51,7 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/entries",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -198,7 +198,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/keys",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle-getfilehandle",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -345,7 +345,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/values",
-          "spec_url": "https://wicg.github.io/file-system-access/#dom-filesystemdirectoryhandle-resolve",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "86"

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -254,7 +254,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormData/entries",
-          "spec_url": "https://xhr.spec.whatwg.org/#dom-formdata",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "50"
@@ -497,7 +497,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormData/keys",
-          "spec_url": "https://xhr.spec.whatwg.org/#dom-formdata",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "50"
@@ -595,7 +595,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormData/values",
-          "spec_url": "https://xhr.spec.whatwg.org/#dom-formdata",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "50"

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -419,6 +419,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/entries",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -792,6 +793,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/keys",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -992,6 +994,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/values",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "45"

--- a/api/KeyboardLayoutMap.json
+++ b/api/KeyboardLayoutMap.json
@@ -51,7 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/entries",
-          "spec_url": "https://wicg.github.io/keyboard-map/#keyboardlayoutmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "69"
@@ -100,7 +100,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/forEach",
-          "spec_url": "https://wicg.github.io/keyboard-map/#keyboardlayoutmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "69"
@@ -247,7 +247,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/keys",
-          "spec_url": "https://wicg.github.io/keyboard-map/#keyboardlayoutmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "69"
@@ -345,7 +345,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/values",
-          "spec_url": "https://wicg.github.io/keyboard-map/#keyboardlayoutmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -51,7 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/entries",
-          "spec_url": "https://w3c.github.io/encrypted-media/#mediakeystatusmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -100,7 +100,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/forEach",
-          "spec_url": "https://w3c.github.io/encrypted-media/#mediakeystatusmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -247,7 +247,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/keys",
-          "spec_url": "https://w3c.github.io/encrypted-media/#mediakeystatusmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"
@@ -345,7 +345,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/values",
-          "spec_url": "https://w3c.github.io/encrypted-media/#mediakeystatusmap-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -51,6 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/entries",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"
@@ -99,7 +100,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/forEach",
-          "spec_url": "https://heycam.github.io/webidl/#es-forEach",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"
@@ -197,6 +198,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/keys",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"
@@ -294,6 +296,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/values",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -51,7 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/entries",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#the-stylepropertymap",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -100,7 +100,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/forEach",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#the-stylepropertymap",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -296,7 +296,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/keys",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#the-stylepropertymap",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -394,7 +394,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/values",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#the-stylepropertymap",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -383,7 +383,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries",
-          "spec_url": "https://url.spec.whatwg.org/#interface-urlsearchparams",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -435,7 +435,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLSearchParams/forEach",
-          "spec_url": "https://url.spec.whatwg.org/#interface-urlsearchparams",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -640,7 +640,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys",
-          "spec_url": "https://url.spec.whatwg.org/#interface-urlsearchparams",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -848,7 +848,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLSearchParams/values",
-          "spec_url": "https://url.spec.whatwg.org/#interface-urlsearchparams",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "49"

--- a/api/XRInputSourceArray.json
+++ b/api/XRInputSourceArray.json
@@ -51,7 +51,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSourceArray/entries",
-          "spec_url": "https://immersive-web.github.io/webxr/#xrinputsourcearray-interface",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "description": "<code>entries()</code>",
           "support": {
             "chrome": {
@@ -101,7 +101,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSourceArray/forEach",
-          "spec_url": "https://immersive-web.github.io/webxr/#xrinputsourcearray",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "description": "<code>forEach()</code>",
           "support": {
             "chrome": {
@@ -151,7 +151,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSourceArray/keys",
-          "spec_url": "https://immersive-web.github.io/webxr/#xrinputsourcearray",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -249,7 +249,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSourceArray/values",
-          "spec_url": "https://immersive-web.github.io/webxr/#xrinputsourcearray",
+          "spec_url": "https://heycam.github.io/webidl/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "79"


### PR DESCRIPTION
This change makes the data for entries/keys/values/forEach members `iterable`-annotated interfaces use the spec URL https://heycam.github.io/webidl/#idl-iterable

---

Without this change, entries/keys/values/forEach members of these interfaces either have no spec URLs at all, or were set to URL values for the anchors/fragment IDs of the interfaces themselves. But a developer following a link from MDN to the anchor for an interface is likely to be confused, because they won’t see anything there about entries/keys/values/forEach members.

But if instead direct developers to https://heycam.github.io/webidl/#idl-iterable, they will see something useful there.