### PR TITLE
Add Opera for Android 63

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -339,9 +339,15 @@
         "62": {
           "release_date": "2021-02-16",
           "release_notes": "https://blogs.opera.com/mobile/2021/02/the-opera-browser-for-android-hit-a-new-record-of-80-million-maus/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
+        },
+        "63": {
+          "release_date": "2021-04-16",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "89"
         }
       }
     }


### PR DESCRIPTION
There's no formal release notes but it appears that it was released in April, with Chromium 89, according to [this Opera forum post](https://forums.opera.com/topic/48543/opera-for-android-63):

> We are happy to announce the release of Opera for Android 63(63.1.3216.58539)! This version includes Chromecast support (media files only), city based news and improvements to Flow and site suggestions.
>
> More changes:
>
> - Chromium 89