### PR TITLE
Add note for return value for webRequest.getAllFrames on Firefox.

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -357,6 +357,7 @@
                 "version_added": "14"
               },
               "firefox": {
+                "notes": "The return value does not included 'errorOccurred'.",
                 "version_added": "47"
               },
               "firefox_android": {

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -357,11 +357,12 @@
                 "version_added": "14"
               },
               "firefox": {
-                "notes": "The return value does not included 'errorOccurred'.",
-                "version_added": "47"
+                "version_added": "47",
+                "notes": "The returned objects do not include the <code>errorOccurred</code> property. See <a href='https://bugzil.la/1248418'>bug 1248418</a>."
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "The returned objects do not include the <code>errorOccurred</code> property. See <a href='https://bugzil.la/1248418'>bug 1248418</a>."
               },
               "opera": {
                 "version_added": "17"


### PR DESCRIPTION
- Added note that the return value for browser.webNavigation.getAllFrames on Firefox doesn't include errorOccurred.

- You can see my tests here as well as a working example: https://github.com/beyera/swe-webnav-allframes

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
 
