### PR TITLE
api.PresentationRequest.startWithDevice is not supported in Chrome

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -445,13 +445,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationRequest/startWithDevice",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "51",
@@ -479,10 +479,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -491,7 +491,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
While working on #10254, @foolip noticed that Chrome didn't support the `startWithDevice` feature either, leaving question as to whether the data was accurate.  Doing some more digging into the issue, I found that Chrome never actually supported this property to begin with.  Considering the original data came from the wiki migration, I question its accuracy.
