### PR TITLE
Drop Node.js Maintenance LTS from CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: 14.x
     - run: npm install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,20 +11,13 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        include:
-          - name: Maintenance LTS
-            node-version: 10.x # use oldest
-          - name: Active LTS
-            node-version: 14.x
-    name: ${{ matrix.name }}
+    name: Active LTS
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2-beta
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 14.x
     - run: npm install
     - run: npm test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: 14.x
         registry-url: "https://registry.npmjs.org/"


### PR DESCRIPTION
Since the merge of https://github.com/mdn/browser-compat-data/pull/7398, the published package has become a thin wrapper around a JSON file, supported by very old versions of Node.js. For development, I don't think we need to continue to test multiple versions of Node.js. Instead, we can commit to supporting a single baseline version of Node and test against _that_. This PR changes the CI workflow to require only the Active LTS version (presently, Node.js 14).

This has a few of benefits:

- There's a single, obvious workflow to check for failures during review.
- It's often the case that there are two Node.js releases in Maintenance LTS status, but there's only one Active LTS. By using only the Active LTS, we'll avoid ambiguity about which version we're testing against.
- We can adopt more modern JS and Node features internally to BCD (as long as we continue to publish our simple JSON package).
- CI checks against PRs will be marginally faster. Node 14 CI seems often appears to finish 2-5 seconds faster.

Incidentally, this PR also sets `actions/setup-node` to stable instead of beta.

This PR is blocked by dropping Maintenance LTS from our branch protection rules. The PR is ready for review, but I don't want to relax the rules until this is approved to merge.