### PR TITLE
Switch menclose spec URL to MathML4 spec

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -4,7 +4,7 @@
       "menclose": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/menclose",
-          "spec_url": "https://www.w3.org/TR/MathML3/chapter3.html#presm.menclose",
+          "spec_url": "https://mathml-refresh.github.io/mathml/#presm_menclose",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This change replaces the MathML3 spec URL for the `menclose` element with a URL to the MathML4 spec (aka MathML Full) — which supersedes the MathML3 spec and is in active development (in roughly the same way the other specs we reference in BCD generally are).