### PR TITLE
Add Android WebView engine versions for 1-1.6

### DIFF
--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -22,7 +22,7 @@
           "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "523.12"
+          "engine_version": "525.20"
         },
         "1.6": {
           "release_date": "2009-09-15",

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -6,22 +6,30 @@
         "1": {
           "release_date": "2008-09-23",
           "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.0_(API_1)",
-          "status": "retired"
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "523.12"
         },
         "1.1": {
           "release_date": "2009-02-09",
           "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.1_(API_2)",
-          "status": "retired"
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "523.12"
         },
         "1.5": {
           "release_date": "2009-04-27",
           "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
-          "status": "retired"
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "523.12"
         },
         "1.6": {
           "release_date": "2009-09-15",
           "release_notes": "https://en.wikipedia.org/wiki/Android_Donut",
-          "status": "retired"
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "525.20"
         },
         "2": {
           "release_date": "2009-10-26",


### PR DESCRIPTION
This PR adds the WebKit versions for Android WebView for 1.0 through 1.6.  These were determined based upon the user agent strings from corresponding Android emulators (totally not foreshadowing here >:D).