### PR TITLE
Update to node 16 and fs.rmdir to fs.rm because with the flag recursi…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: 16.x
     - run: npm install
     - run: npm test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: 16.x
         registry-url: "https://registry.npmjs.org/"
     - run: npm install
     - run: npm test

--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -72,7 +72,7 @@ async function writeManifest() {
 async function main() {
   // Remove existing files, if there are any
   await fs
-    .rmdir(directory, {
+    .rm(directory, {
       force: true,
       recursive: true,
     })


### PR DESCRIPTION



#### Summary
Update to node 16 and `fs.rmdir` to `fs.rm` because with the flag recursive the call has been deprecated.

Node 16 will become the LTS on 2021-10-26 so the release will be around and maintained until 2024 atleast.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I ran the following commands and everything worked:
```bash
npm install
npm test
npm run release-build
```

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Builds on #9877

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
