### PR TITLE
Update Safari data for Blob.slice

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -251,13 +251,26 @@
             "opera_android": {
               "version_added": true
             },
-            "safari": {
-              "version_added": "5.1",
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "6.1"
+              },
+              {
+                "version_added": "5.1",
+                "version_removed": "6.1",
+                "prefix": "webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "7",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "1.5"


### PR DESCRIPTION
#### Summary
Provides Safari prefixed/unprefixed versions for `blob.slice`

#### Test results and supporting details
Reviewed WebKit code available from https://opensource.apple.com
