### PR TITLE
Deprecate SVGPoint

### DIFF
--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -45,7 +45,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "matrixTransform": {
@@ -93,7 +93,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -142,7 +142,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -191,7 +191,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`SVGPoint` is not part of the current SVG spec (SVG2); instead at https://svgwg.org/svg2-draft/single-page.html#changes-types the SVG2 spec specifically says:

> All appearance of SVGPoint were replaced by DOMPoint or DOMPointReadOnly.

Related MDN change: https://github.com/mdn/content/pull/5142