### PR TITLE
Deprecate glyph-orientation-horizontal|vertical

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1436,7 +1436,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -1485,7 +1485,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
Examination of the WebKit code seems to indicate these are actually in the current WebKit code, so we can’t just remove them. But the current SVG spec says:

https://svgwg.org/svg2-draft/single-page.html#text-GlyphOrientationHorizontalProperty

> 11.10.1.2. The ‘glyph-orientation-horizontal’ property
>
> This property has been removed in SVG 2.
>
> 11.10.1.3. The ‘glyph-orientation-vertical’ property
>
> This property applies only to vertical text. It has been obsoleted in SVG 2 and partially replaced by the text-orientation property of CSS Writing Modes Level 3.

They’re already marked deprecated in MDN.