### PR TITLE
-webkit-overflow-scrolling no longer supported in iOS 13+

### DIFF
--- a/css/properties/-webkit-overflow-scrolling.json
+++ b/css/properties/-webkit-overflow-scrolling.json
@@ -33,7 +33,8 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -77,11 +77,21 @@
               "opera_android": {
                 "version_added": "14"
               },
-              "safari": {
-                "version_added": false
-              },
+              "safari": [
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                },
+                {
+                  "version_added": "3.1",
+                  "version_removed": "14"
+                }
+              ],
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": "5",
+                "partial_implementation": true,
+                "notes": "<code>local</code> is recognized but has no effect."
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -125,12 +135,29 @@
               "opera_android": {
                 "version_added": "14"
               },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": "4.2"
-              },
+              "safari": [
+                {
+                  "version_added": "13",
+                  "partial_implementation": true,
+                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                },
+                {
+                  "version_added": "5",
+                  "version_removed": "13"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "13",
+                  "partial_implementation": true,
+                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                },
+                {
+                  "version_added": "4.2",
+                  "version_removed": "13",
+                  "notes": "<code>local</code> is only supported when <code>-webkit-overflow-scrolling: touch</code> is NOT used."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "1.0"
               },

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -81,7 +81,7 @@
                 {
                   "version_added": "14",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
                 },
                 {
                   "version_added": "3.1",
@@ -139,7 +139,7 @@
                 {
                   "version_added": "13",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
                 },
                 {
                   "version_added": "5",
@@ -150,12 +150,12 @@
                 {
                   "version_added": "13",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to [a bug](https://bugs.webkit.org/show_bug.cgi?id=219324)."
+                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
                 },
                 {
                   "version_added": "4.2",
                   "version_removed": "13",
-                  "notes": "<code>local</code> is only supported when <code>-webkit-overflow-scrolling: touch</code> is NOT used."
+                  "notes": "If <code>-webkit-overflow-scrolling: touch</code> is set, then <code>local</code> has no effect."
                 }
               ],
               "samsunginternet_android": {


### PR DESCRIPTION
#### Summary
-webkit-overflow-scrolling is no longer supported on iOS 13+

#### Test results and supporting details
Tested on iPhone with iOS 14 + Safari 14.

https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes
"Added support for one-finger accelerated scrolling to all frames and overflow:scroll elements eliminating the need to set-webkit-overflow-scrolling: touch."