### PR TITLE
Add mdn and spec url for html.elements.link.rel

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -672,6 +672,8 @@
         },
         "rel": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#linkTypes",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -672,7 +672,7 @@
         },
         "rel": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types",
             "spec_url": "https://html.spec.whatwg.org/multipage/links.html#linkTypes",
             "support": {
               "chrome": {


### PR DESCRIPTION
Discovered as I needed a spec_url for this page: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types