### PR TITLE
Add spec_urls for obsolete but implemented HTML elements

### DIFF
--- a/html/elements/dir.json
+++ b/html/elements/dir.json
@@ -4,6 +4,7 @@
       "dir": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/dir",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dir",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/html/elements/font.json
+++ b/html/elements/font.json
@@ -4,6 +4,7 @@
       "font": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/font",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#font",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/frame.json
+++ b/html/elements/frame.json
@@ -4,6 +4,7 @@
       "frame": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/frame",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#frame",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/frameset.json
+++ b/html/elements/frameset.json
@@ -4,6 +4,7 @@
       "frameset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/frameset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#frameset",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/nextid.json
+++ b/html/elements/nextid.json
@@ -4,6 +4,7 @@
       "nextid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/nextid",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#nextid",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/nobr.json
+++ b/html/elements/nobr.json
@@ -4,6 +4,7 @@
       "nobr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/nobr",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#nobr",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/noembed.json
+++ b/html/elements/noembed.json
@@ -4,6 +4,7 @@
       "noembed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/noembed",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#noembed",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/noframes.json
+++ b/html/elements/noframes.json
@@ -4,6 +4,7 @@
       "noframes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/noframes",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#noframes",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/plaintext.json
+++ b/html/elements/plaintext.json
@@ -4,6 +4,7 @@
       "plaintext": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/plaintext",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#plaintext",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -4,6 +4,7 @@
       "rb": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/rb",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#rb",
           "support": {
             "chrome": {
               "version_added": "5",

--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -4,6 +4,7 @@
       "rtc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/rtc",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#rtc",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/spacer.json
+++ b/html/elements/spacer.json
@@ -4,6 +4,7 @@
       "spacer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/spacer",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#spacer",
           "support": {
             "chrome": {
               "version_added": false

--- a/html/elements/strike.json
+++ b/html/elements/strike.json
@@ -4,6 +4,7 @@
       "strike": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/strike",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#strike",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/tt.json
+++ b/html/elements/tt.json
@@ -4,6 +4,7 @@
       "tt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/tt",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#tt",
           "support": {
             "chrome": {
               "version_added": true

--- a/html/elements/xmp.json
+++ b/html/elements/xmp.json
@@ -4,6 +4,7 @@
       "xmp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/xmp",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#xmp",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
Add spec_urls for HTML elements that are still relevant (implemented in browsers). 