### PR TITLE
Added missing Safari calc/percentage value support in gap

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -196,10 +196,10 @@
                   "version_added": "47"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": "9.0"
@@ -244,10 +244,10 @@
                   "version_added": "47"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": "9.0"

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -196,7 +196,7 @@
                   "version_added": "47"
                 },
                 "safari": {
-                  "version_added": "11"
+                  "version_added": "12.1"
                 },
                 "safari_ios": {
                   "version_added": "11"

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -199,7 +199,7 @@
                   "version_added": "12.1"
                 },
                 "safari_ios": {
-                  "version_added": "11"
+                  "version_added": "12.2"
                 },
                 "samsunginternet_android": {
                   "version_added": "9.0"


### PR DESCRIPTION
#### Summary
Added Safari version support for gap `calc_values` and `percentage_values`.

#### Test results and supporting details
Added support for percentage gaps: https://bugs.webkit.org/show_bug.cgi?id=170764
Shipped in STP29: https://developer.apple.com/safari/technology-preview/release-notes/#r29
