### PR TITLE
feat(css): Add CSS Values Level 4 `abs()` compatibility data

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "selectors": {
+      "list": {
+        "__compat": {
+          "description": "<code>abs()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs()",
+          "spec_url": "https://drafts.csswg.org/css-values-4/#sign-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -1,48 +1,33 @@
 {
   "css": {
-    "selectors": {
-      "list": {
+    "types": {
+      "abs": {
         "__compat": {
           "description": "<code>abs()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs()",
-          "spec_url": "https://drafts.csswg.org/css-values-4/#sign-funcs",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#sign-funcs",
           "support": {
             "chrome": {
               "version_added": false
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -4,7 +4,7 @@
       "abs": {
         "__compat": {
           "description": "<code>abs()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#sign-funcs",
           "support": {
             "chrome": {


### PR DESCRIPTION
Add browser compatibility data for the CSS abs() function to contain the new additions from CSS Values and Units Level 4.

Related: https://github.com/mdn/content/pull/5168
