### PR TITLE
Replace alternative_name with prefix where it is equivalent

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1378,12 +1378,12 @@
             "chrome": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "edge": {
               "version_added": false
@@ -1400,30 +1400,30 @@
             "opera": {
               "version_added": true,
               "version_removed": "26",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "opera_android": {
               "version_added": true,
               "version_removed": "26",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "safari": {
               "version_added": true,
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "safari_ios": {
               "version_added": true,
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": true,
               "version_removed": "4.0",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             },
             "webview_android": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromNodeToPage"
+              "prefix": "webkit"
             }
           },
           "status": {
@@ -1440,12 +1440,12 @@
             "chrome": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "chrome_android": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "edge": {
               "version_added": false
@@ -1462,30 +1462,30 @@
             "opera": {
               "version_added": true,
               "version_removed": "26",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "opera_android": {
               "version_added": true,
               "version_removed": "26",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "safari": {
               "version_added": true,
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "safari_ios": {
               "version_added": true,
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "samsunginternet_android": {
               "version_added": true,
               "version_removed": "4.0",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             },
             "webview_android": {
               "version_added": true,
               "version_removed": "39",
-              "alternative_name": "webkitConvertPointFromPageToNode"
+              "prefix": "webkit"
             }
           },
           "status": {

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -174,7 +174,7 @@
               {
                 "version_added": "12",
                 "version_removed": "79",
-                "alternative_name": "msElementsFromPoint",
+                "prefix": "ms",
                 "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
               }
             ],
@@ -186,7 +186,7 @@
             },
             "ie": {
               "version_added": "10",
-              "alternative_name": "msElementsFromPoint",
+              "prefix": "ms",
               "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
             },
             "opera": {
@@ -299,7 +299,7 @@
             },
             "safari_ios": {
               "version_added": "12",
-              "alternative_name": "webkitFullscreenElement",
+              "prefix": "webkit",
               "partial_implementation": true,
               "notes": "Full-screen mode is only supported on the iPad."
             },


### PR DESCRIPTION
These alternative names can be constructed with simple prefixing:
 - msElementsFromPoint
 - webkitConvertPointFromNodeToPage
 - webkitConvertPointFromPageToNode
 - webkitFullscreenElement