### PR TITLE
Remove notes about support for SVG 1.1

### DIFF
--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -12,20 +12,16 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "12",
-            "notes": "Before Edge 79, this interface only implements the SVG 1.1 specification."
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "1.5",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": "4",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "4"
           },
           "ie": {
-            "version_added": "9",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -12,20 +12,16 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "12",
-            "notes": "Before Edge 79, this only implements the SVG 1.1 specification of the interface."
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "1.5",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": "4",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "4"
           },
           "ie": {
-            "version_added": "9",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -12,20 +12,16 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "12",
-            "notes": "Before Edge 79, this interface implements only the SVG 1.1 specification."
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "1.5",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": "4",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "4"
           },
           "ie": {
-            "version_added": "9",
-            "notes": "Only implements the SVG 1.1 specification of the interface."
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"


### PR DESCRIPTION
These notes came with the wiki migration:
https://github.com/mdn/browser-compat-data/pull/1585
https://github.com/mdn/browser-compat-data/pull/1587
https://github.com/mdn/browser-compat-data/pull/1588

Without knowing the difference between these interfaces in SVG 1.1 and
2, there's no way to interpret these notes. Any differences, if
uncovered, should be captured as much more concrete notes.