### PR TITLE
Fix order and versions of gutter properties for Safari

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -134,7 +134,7 @@
               ],
               "safari": [
                 {
-                  "version_added": "12.1"
+                  "version_added": "12"
                 },
                 {
                   "version_added": "10.1",

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -126,20 +126,20 @@
               ],
               "safari": [
                 {
-                  "version_added": "10.1",
-                  "alternative_name": "grid-gap"
+                  "version_added": "12"
                 },
                 {
-                  "version_added": "12"
+                  "version_added": "10.1",
+                  "alternative_name": "grid-gap"
                 }
               ],
               "safari_ios": [
                 {
-                  "version_added": "10.3",
-                  "alternative_name": "grid-gap"
+                  "version_added": "12"
                 },
                 {
-                  "version_added": "12"
+                  "version_added": "10.3",
+                  "alternative_name": "grid-gap"
                 }
               ],
               "samsunginternet_android": [

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -126,7 +126,7 @@
               ],
               "safari": [
                 {
-                  "version_added": "12.1"
+                  "version_added": "12"
                 },
                 {
                   "version_added": "10.1",


### PR DESCRIPTION
This change happened in WebKit trunk version 606.1.4:
https://trac.webkit.org/changeset/228095/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=228095

From the commit message:
> grid-column-gap => column-gap
> grid-row-gap => row-gap
> grid-gap => gap

See https://github.com/mdn/yari/issues/3839 about the order.