### PR TITLE
Mark all SVG features as supported no earlier than Safari 3

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGAnimateColorElement.json
+++ b/api/SVGAnimateColorElement.json
@@ -34,7 +34,7 @@
             "version_removed": "21"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGAnimateElement.json
+++ b/api/SVGAnimateElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGAnimateTransformElement.json
+++ b/api/SVGAnimateTransformElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -32,7 +32,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGCursorElement.json
+++ b/api/SVGCursorElement.json
@@ -34,7 +34,7 @@
             "version_removed": "43"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -274,7 +274,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -535,7 +535,7 @@
               "version_removed": "37"
             },
             "safari": {
-              "version_added": "1",
+              "version_added": "3",
               "version_removed": "11"
             },
             "safari_ios": {

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGGElement.json
+++ b/api/SVGGElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGMarkerElement.json
+++ b/api/SVGMarkerElement.json
@@ -28,7 +28,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -30,7 +30,7 @@
             "version_added": "15"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -34,7 +34,7 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -34,7 +34,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -34,7 +34,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGSetElement.json
+++ b/api/SVGSetElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -34,7 +34,7 @@
             "version_removed": "18"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "safari_ios": {
             "version_added": "1"

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -31,7 +31,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "1"
+                "version_added": "3"
               },
               "safari_ios": {
                 "version_added": "1"


### PR DESCRIPTION
Initial SVG support was in Safari 3 according to Wikipedia:
https://en.wikipedia.org/wiki/Safari_version_history#Safari_3

This is consistent with the "circa 2008" claim here:
https://www.w3.org/2010/09/svg_browser.php