### PR TITLE
Mark SVGGraphicsElement members as supported since ancient times

### DIFF
--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -5,23 +5,57 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement",
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement",
         "support": {
-          "chrome": {
-            "version_added": "30"
-          },
-          "chrome_android": {
-            "version_added": "30"
-          },
+          "chrome": [
+            {
+              "version_added": "30"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "30",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "30"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "30",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
-          "firefox": {
-            "version_added": "20"
-          },
-          "firefox_android": {
-            "version_added": "20"
-          },
+          "firefox": [
+            {
+              "version_added": "20"
+            },
+            {
+              "version_added": "1.5",
+              "version_removed": "20",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "20"
+            },
+            {
+              "version_added": "4",
+              "version_removed": "20",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
           "ie": {
-            "version_added": false
+            "version_added": "9",
+            "partial_implementation": true,
+            "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
           },
           "opera": [
             {
@@ -29,7 +63,9 @@
             },
             {
               "version_added": "≤12.1",
-              "version_removed": "15"
+              "version_removed": "17",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
             }
           ],
           "opera_android": [
@@ -38,21 +74,55 @@
             },
             {
               "version_added": "≤12.1",
-              "version_removed": "14"
+              "version_removed": "18",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
             }
           ],
-          "safari": {
-            "version_added": "6.1"
-          },
-          "safari_ios": {
-            "version_added": "7"
-          },
-          "samsunginternet_android": {
-            "version_added": "2.0"
-          },
-          "webview_android": {
-            "version_added": "4.4"
-          }
+          "safari": [
+            {
+              "version_added": "6.1"
+            },
+            {
+              "version_added": "3",
+              "version_removed": "6.1",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "7"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "7",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "version_added": "1.0",
+              "version_removed": "2.0",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "4.4"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "4.4",
+              "partial_implementation": true,
+              "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -62,62 +132,51 @@
       },
       "getBBox": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "20",
+              "version_added": "1.5",
               "notes": [
                 "The <code>getBBox()</code> method returns an empty <code>DOMRect</code> when there is no fill (<a href='https://bugzil.la/1019326'>bug 1019326</a>).",
                 "This method doesn't work for <code>&lt;textPath&gt;</code> and <code>&lt;tspan&gt;</code> elements (<a href='https://bugzil.la/937268'>bug 937268</a>)."
               ]
             },
             "firefox_android": {
-              "version_added": "20",
+              "version_added": "4",
               "notes": [
                 "The <code>getBBox()</code> method returns an empty <code>DOMRect</code> when there is no fill (<a href='https://bugzil.la/1019326'>bug 1019326</a>).",
                 "This method doesn't work for <code>&lt;textPath&gt;</code> and <code>&lt;tspan&gt;</code> elements (<a href='https://bugzil.la/937268'>bug 937268</a>)."
               ]
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "1"
             }
           },
           "status": {
@@ -129,54 +188,43 @@
       },
       "getCTM": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getCTM",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "20"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "1"
             }
           },
           "status": {
@@ -188,54 +236,43 @@
       },
       "getScreenCTM": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getScreenCTM",
           "support": {
             "chrome": {
-              "version_added": "30"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "30"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "20"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "1"
             }
           },
           "status": {
@@ -247,54 +284,43 @@
       },
       "transform": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__transform",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "20"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "17"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9339 was
used to test for support of the interface itself. Results:
 - Chrome 30 (not in 29)
 - Not in IE11
 - Edge 13 => Edge 12 assumed
 - Firefox 20 (not in 19)
 - Not in Opera 12.16
 - Safari 6.2 (not in 6.0) => Safari 6.1 assumed

http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9295 was
used to test for support for the members on concrete interfaces:
```html
<!DOCTYPE html>
<script>
var members = ['transform', 'getBBox', 'getCTM', 'getScreenCTM'];
var instances = {
  SVGAElement: document.createElementNS('http://www.w3.org/2000/svg', 'a'),
  SVGCircleElement: document.createElementNS('http://www.w3.org/2000/svg', 'circle'),
  SVGDefsElement: document.createElementNS('http://www.w3.org/2000/svg', 'defs'),
  SVGEllipseElement: document.createElementNS('http://www.w3.org/2000/svg', 'ellipse'),
  SVGForeignObjectElement: document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject'),
  SVGGElement: document.createElementNS('http://www.w3.org/2000/svg', 'g'),
  SVGImageElement: document.createElementNS('http://www.w3.org/2000/svg', 'image'),
  SVGLineElement: document.createElementNS('http://www.w3.org/2000/svg', 'line'),
  SVGPathElement: document.createElementNS('http://www.w3.org/2000/svg', 'path'),
  SVGPolygonElement: document.createElementNS('http://www.w3.org/2000/svg', 'polygon'),
  SVGPolylineElement: document.createElementNS('http://www.w3.org/2000/svg', 'polyline'),
  SVGRectElement: document.createElementNS('http://www.w3.org/2000/svg', 'rect'),
  SVGSVGElement: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
  SVGSwitchElement: document.createElementNS('http://www.w3.org/2000/svg', 'switch'),
  SVGSymbolElement: document.createElementNS('http://www.w3.org/2000/svg', 'symbol'),
  SVGUseElement: document.createElementNS('http://www.w3.org/2000/svg', 'use'),
};
for (var iface in instances) {
  var instance = instances[iface];
  for (var i = 0; i < members.length; i++) {
    var member = members[i];
    w(iface + '.' + member + ': ' + (member in instance));
  }
}
</script>
```

Results:
 - IE9 supports everything except SVGForeignObjectElement,
   SVGSymbolElement and SVGSVGElement.transform
 - Edge 15 supports everything except SVGSymbolElement
 - Chrome 15, Firefox 3, Opera 12.16 and Safari 4 support everything
   except SVGSymbolElement and SVGSVGElement.transform

SVGGraphicsElement was introduced in WebKit here:
https://trac.webkit.org/changeset/152167/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=152167

It combined SVGLocatable and SVGTransformable going back to the initial
SVG support in Safari 3, which also shipped in Chrome 1:
https://trac.webkit.org/browser/webkit/branches/old/Safari-3-branch/WebCore/ksvg2/svg/SVGLocatable.idl
https://trac.webkit.org/browser/webkit/branches/old/Safari-3-branch/WebCore/ksvg2/svg/SVGTransformable.idl

All together, the members are assumed to be supported from when SVG
support was introduced in each browser.