### PR TITLE
Update Chromium versions for api.Request.clone

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -453,7 +453,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "edge": {
               "version_added": "14"


### PR DESCRIPTION
This PR fixes the Chrome Android data for `api.Request.clone`.  Running a quick test in the latest Chrome Android reveals there is indeed support, and I highly doubt that it would be implemented later than Chrome Desktop, so this PR sets it to match the version.