### PR TITLE
Remove WebView for Android 1.1, 1.6 and 4.2

### DIFF
--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -10,23 +10,9 @@
           "engine": "WebKit",
           "engine_version": "523.12"
         },
-        "1.1": {
-          "release_date": "2009-02-09",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.1_(API_2)",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "523.12"
-        },
         "1.5": {
           "release_date": "2009-04-27",
           "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "525.20"
-        },
-        "1.6": {
-          "release_date": "2009-09-15",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Donut",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "525.20"
@@ -68,13 +54,6 @@
         },
         "4.1": {
           "release_date": "2012-07-09",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Jelly_Bean",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "534.30"
-        },
-        "4.2": {
-          "release_date": "2013-07-24",
           "release_notes": "https://en.wikipedia.org/wiki/Android_Jelly_Bean",
           "status": "retired",
           "engine": "WebKit",


### PR DESCRIPTION
This PR is one part of work towards #10524.  I've recently found that Android WebView 1.1 and 1.6 have the same engine versions as 1.0 and 1.5 respectively.  Additionally, none of our data was set to either of these WebView versions, further leading towards a decision to remove it from the data.  I then found the same scenario with Android WebView 4.1 and 4.2, where 4.2 is unused and has the same engine version as 4.1.

This PR removes the data for WebView Android 1.1, 1.6, and 4.2 as they are unused in any of our data and have the exact same engine versions as their preceeding versions.
