### PR TITLE
Remove Android WebView 2.3

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4843,7 +4843,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -45,13 +45,6 @@
           "engine": "WebKit",
           "engine_version": "533.1"
         },
-        "2.3": {
-          "release_date": "2010-12-06",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Gingerbread",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "533.1"
-        },
         "3": {
           "release_date": "2011-02-22",
           "release_notes": "https://en.wikipedia.org/wiki/Android_Honeycomb",

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -119,7 +119,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "2.3"
+                "version_added": "2.2"
               },
               {
                 "version_added": "≤37",

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -42,7 +42,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -52,7 +52,7 @@
               "notes": "Before version 6.0, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 6.0, it was changed to only match enabled read-write inputs."
             },
             "webview_android": {
-              "version_added": "2.3",
+              "version_added": "2.2",
               "notes": "Before version 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 52, it was changed to only match enabled read-write inputs."
             }
           },

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -44,7 +44,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "2.2"
             }
           },
           "status": {


### PR DESCRIPTION
This PR removes Android WebView 2.3 from our data (as a part of #10524).  Since the WebKit versions match for both WebView 2.2 and 2.3, it's highly doubtful that there would be anything added in 2.3 that isn't present in 2.2.  Additionally, this PR changes everywhere where WebView is set to 2.3 and replaces the value with 2.2 in its place.