### PR TITLE
Change Android WebView from 1 to ≤37 for API H-M

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -86,7 +86,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -904,7 +904,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -896,7 +896,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3588,7 +3588,7 @@
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": "1"
+                "version_added": "≤37"
               }
             ]
           },

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -612,7 +612,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -577,7 +577,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -969,7 +969,7 @@
               "notes": "Before Samsung Internet 5.0, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Before WebView 50, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             }
           },

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -275,7 +275,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -655,7 +655,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2978,7 +2978,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -87,7 +87,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -228,7 +228,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -513,7 +513,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -560,7 +560,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -795,7 +795,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -313,7 +313,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1510,7 +1510,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2724,7 +2724,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -182,7 +182,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -179,7 +179,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -245,7 +245,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1411,7 +1411,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -145,7 +145,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -337,7 +337,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -818,7 +818,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -1454,7 +1454,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -331,7 +331,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -911,7 +911,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1056,7 +1056,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1105,7 +1105,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1153,7 +1153,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -137,7 +137,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -235,7 +235,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -46,7 +46,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -42,7 +42,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -94,7 +94,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -143,7 +143,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -191,7 +191,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -240,7 +240,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -289,7 +289,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -386,7 +386,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -89,7 +89,7 @@
               "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Prior to version 59, method parameters were optional"
             }
           },
@@ -189,7 +189,7 @@
               "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Prior to version 59, method parameters were optional"
             }
           },

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -302,7 +302,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -401,7 +401,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
A general rule of thumb that I heard and have been going by when updating BCD for WebView Android is that anything added in Chrome 1 will be present in WebView Android 1.  However, looking at the difference in WebKit versions (528 for Chrome 1 vs. 523.12 for WebView Android 1), it's simply not plausible that this statement is true -- and after getting my hands on an Android 1.0 emulator, I've confirmed my suspicions.  A more accurate rule of thumb would be that "anything present in Safari 3 will be in WebView Android 1".

This PR changes various entries set to WebView Android 1.0 to our range of `≤37` instead after running the mdn-bcd-collector in Android 1.0 and comparing the results to our data.  I plan to follow up and replace these ranged values with proper version numbers in the future.

