### PR TITLE
Safari 14 is not "current" any longer

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -170,7 +170,7 @@
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "610.1.28"
         },

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -154,7 +154,7 @@
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "610.1.28"
         },


### PR DESCRIPTION
This PR fixes a data issue where Safari 14 was left as `current` when Safari 14.1 released.  Caught by the linter introduced in #6167.
