### PR TITLE
Switch ES spec URLs to multipage version

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -4,7 +4,7 @@
       "AggregateError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError",
-          "spec_url": "https://tc39.es/ecma262/#sec-aggregate-error-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error-objects",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>AggregateError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError",
-            "spec_url": "https://tc39.es/ecma262/#sec-aggregate-error-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error-constructor",
             "support": {
               "chrome": {
                 "version_added": "85"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -4,7 +4,7 @@
       "Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
-          "spec_url": "https://tc39.es/ecma262/#sec-array-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-array-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -160,7 +160,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.concat",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -212,7 +212,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.copywithin",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -264,7 +264,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/entries",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -316,7 +316,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.every",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.every",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -368,7 +368,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fill",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.fill",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -431,7 +431,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.filter",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -483,7 +483,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.find",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -546,7 +546,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.findindex",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findindex",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -609,7 +609,7 @@
         "flat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.flat",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -661,7 +661,7 @@
         "flatMap": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.flatmap",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flatmap",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -713,7 +713,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -765,7 +765,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/from",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.from",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -817,7 +817,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -880,7 +880,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -932,7 +932,7 @@
         "isArray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.isarray",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -984,7 +984,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/join",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.join",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.join",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1036,7 +1036,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/keys",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1088,7 +1088,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1140,7 +1140,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/length",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-array-instances-length",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-array-instances-length",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1192,7 +1192,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.map",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.map",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1244,7 +1244,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/of",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.of",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1296,7 +1296,7 @@
         "pop": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/pop",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.pop",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.pop",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1348,7 +1348,7 @@
         "push": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/push",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.push",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.push",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1400,7 +1400,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduce",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -1452,7 +1452,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduceright",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduceright",
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -1504,7 +1504,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reverse",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1556,7 +1556,7 @@
         "shift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/shift",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.shift",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.shift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1608,7 +1608,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1660,7 +1660,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.some",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.some",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1712,7 +1712,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.sort",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1815,7 +1815,7 @@
         "splice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.splice",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.splice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1869,7 +1869,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-array.prototype.tolocalestring",
+              "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-array.prototype.tolocalestring"
             ],
             "support": {
@@ -2085,7 +2085,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2137,7 +2137,7 @@
         "unshift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.unshift",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.unshift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2189,7 +2189,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -2257,7 +2257,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2337,7 +2337,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-array-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-array-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -2400,7 +2400,7 @@
         "@@unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype-@@unscopables",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@unscopables",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -4,7 +4,7 @@
       "ArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
-          "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-objects",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>ArrayBuffer()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer",
-            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-constructor",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -159,7 +159,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -211,7 +211,7 @@
         "isView": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView",
-            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.isview",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.isview",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -263,7 +263,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice",
-            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "17"
@@ -317,7 +317,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-arraybuffer-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -4,7 +4,7 @@
       "AsyncFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-function-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-async-function-objects",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -4,7 +4,7 @@
       "AsyncGenerator": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator",
-          "spec_url": "https://tc39.es/ecma262/#sec-asyncgenerator-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-objects",
           "support": {
             "chrome": {
               "version_added": "63"
@@ -66,7 +66,7 @@
         "next": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/next",
-            "spec_url": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-next",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -129,7 +129,7 @@
         "return": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/return",
-            "spec_url": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-return",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -192,7 +192,7 @@
         "throw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/throw",
-            "spec_url": "https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-throw",
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -4,7 +4,7 @@
       "AsyncGeneratorFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction",
-          "spec_url": "https://tc39.es/ecma262/#sec-asyncgeneratorfunction-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratorfunction-objects",
           "support": {
             "chrome": {
               "version_added": "63"

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -4,7 +4,7 @@
       "Atomics": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics",
-          "spec_url": "https://tc39.es/ecma262/#sec-atomics-object",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics-object",
           "support": {
             "chrome": [
               {
@@ -180,7 +180,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.add",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.add",
             "support": {
               "chrome": [
                 {
@@ -306,7 +306,7 @@
         "and": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.and",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.and",
             "support": {
               "chrome": [
                 {
@@ -432,7 +432,7 @@
         "compareExchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.compareexchange",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.compareexchange",
             "support": {
               "chrome": [
                 {
@@ -558,7 +558,7 @@
         "exchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.exchange",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.exchange",
             "support": {
               "chrome": [
                 {
@@ -684,7 +684,7 @@
         "isLockFree": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.islockfree",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.islockfree",
             "support": {
               "chrome": [
                 {
@@ -810,7 +810,7 @@
         "load": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.load",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.load",
             "support": {
               "chrome": [
                 {
@@ -936,7 +936,7 @@
         "notify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.notify",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.notify",
             "support": {
               "chrome": [
                 {
@@ -1111,7 +1111,7 @@
         "or": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.or",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.or",
             "support": {
               "chrome": [
                 {
@@ -1237,7 +1237,7 @@
         "store": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.store",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.store",
             "support": {
               "chrome": [
                 {
@@ -1363,7 +1363,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.sub",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.sub",
             "support": {
               "chrome": [
                 {
@@ -1489,7 +1489,7 @@
         "wait": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.wait",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.wait",
             "support": {
               "chrome": [
                 {
@@ -1641,7 +1641,7 @@
         "xor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor",
-            "spec_url": "https://tc39.es/ecma262/#sec-atomics.xor",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.xor",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -4,7 +4,7 @@
       "BigInt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt",
-          "spec_url": "https://tc39.es/ecma262/#sec-bigint-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>BigInt()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-constructor",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -108,7 +108,7 @@
         "asIntN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint.asintn",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.asintn",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -160,7 +160,7 @@
         "asUintN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint.asuintn",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.asuintn",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -364,7 +364,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -416,7 +416,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -4,7 +4,7 @@
       "BigInt64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array",
-          "spec_url": "https://tc39.es/ecma262/#sec-typedarray-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>BigInt64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array/BigInt64Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -4,7 +4,7 @@
       "BigUint64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array",
-          "spec_url": "https://tc39.es/ecma262/#sec-typedarray-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>BigUint64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array/BigUint64Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -4,7 +4,7 @@
       "Boolean": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
-          "spec_url": "https://tc39.es/ecma262/#sec-boolean-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Boolean()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean",
-            "spec_url": "https://tc39.es/ecma262/#sec-boolean-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -161,7 +161,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,7 +213,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -4,7 +4,7 @@
       "DataView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView",
-          "spec_url": "https://tc39.es/ecma262/#sec-dataview-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview-objects",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>DataView()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview-constructor",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -280,7 +280,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/buffer",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -385,7 +385,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteLength",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -437,7 +437,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteOffset",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -489,7 +489,7 @@
         "getBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -541,7 +541,7 @@
         "getBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -593,7 +593,7 @@
         "getFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -645,7 +645,7 @@
         "getFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -697,7 +697,7 @@
         "getInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt16",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint16",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -749,7 +749,7 @@
         "getInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -801,7 +801,7 @@
         "getInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt8",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint8",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -853,7 +853,7 @@
         "getUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint16",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint16",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -905,7 +905,7 @@
         "getUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -957,7 +957,7 @@
         "getUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint8",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint8",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1009,7 +1009,7 @@
         "setBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -1061,7 +1061,7 @@
         "setBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -1113,7 +1113,7 @@
         "setFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1165,7 +1165,7 @@
         "setFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat64",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1217,7 +1217,7 @@
         "setInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt16",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint16",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1269,7 +1269,7 @@
         "setInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1321,7 +1321,7 @@
         "setInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt8",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint8",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1373,7 +1373,7 @@
         "setUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint16",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint16",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1425,7 +1425,7 @@
         "setUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint32",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint32",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1477,7 +1477,7 @@
         "setUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint8",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint8",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint8",
             "support": {
               "chrome": {
                 "version_added": "9"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -4,7 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
-          "spec_url": "https://tc39.es/ecma262/#sec-date-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -57,7 +57,7 @@
           "__compat": {
             "description": "<code>Date()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Date",
-            "spec_url": "https://tc39.es/ecma262/#sec-date-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -109,7 +109,7 @@
         "UTC": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.utc",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.utc",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -161,7 +161,7 @@
         "getDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getdate",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getdate",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,7 +213,7 @@
         "getDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getday",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getday",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -265,7 +265,7 @@
         "getFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getfullyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getfullyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -317,7 +317,7 @@
         "getHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gethours",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gethours",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -369,7 +369,7 @@
         "getMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmilliseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -421,7 +421,7 @@
         "getMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getminutes",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getminutes",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -473,7 +473,7 @@
         "getMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getmonth",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmonth",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -525,7 +525,7 @@
         "getSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -577,7 +577,7 @@
         "getTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gettime",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gettime",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -629,7 +629,7 @@
         "getTimezoneOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gettimezoneoffset",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -681,7 +681,7 @@
         "getUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcdate",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcdate",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -733,7 +733,7 @@
         "getUTCDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcday",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcday",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -785,7 +785,7 @@
         "getUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcfullyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -837,7 +837,7 @@
         "getUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutchours",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutchours",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -889,7 +889,7 @@
         "getUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -941,7 +941,7 @@
         "getUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcminutes",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcminutes",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -993,7 +993,7 @@
         "getUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcmonth",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcmonth",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1045,7 +1045,7 @@
         "getUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1097,7 +1097,7 @@
         "getYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.getyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1149,7 +1149,7 @@
         "now": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/now",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.now",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.now",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1201,7 +1201,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/parse",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.parse",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.parse",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1304,7 +1304,7 @@
         "setDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setdate",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setdate",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1356,7 +1356,7 @@
         "setFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setfullyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setfullyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1408,7 +1408,7 @@
         "setHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.sethours",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.sethours",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1460,7 +1460,7 @@
         "setMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setmilliseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1512,7 +1512,7 @@
         "setMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setminutes",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setminutes",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1564,7 +1564,7 @@
         "setMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setmonth",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setmonth",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1616,7 +1616,7 @@
         "setSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1668,7 +1668,7 @@
         "setTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.settime",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.settime",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1720,7 +1720,7 @@
         "setUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcdate",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcdate",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1772,7 +1772,7 @@
         "setUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcfullyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1824,7 +1824,7 @@
         "setUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutchours",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutchours",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1876,7 +1876,7 @@
         "setUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1928,7 +1928,7 @@
         "setUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcminutes",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcminutes",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1980,7 +1980,7 @@
         "setUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcmonth",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcmonth",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2032,7 +2032,7 @@
         "setUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcseconds",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcseconds",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2084,7 +2084,7 @@
         "setYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setyear",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.setyear",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2136,7 +2136,7 @@
         "toDateString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.todatestring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.todatestring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2188,7 +2188,7 @@
         "toGMTString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.togmtstring",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.togmtstring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2240,7 +2240,7 @@
         "toISOString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.toisostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.toisostring",
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -2292,7 +2292,7 @@
         "toJSON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.tojson",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tojson",
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -2345,7 +2345,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring",
+              "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocaledatestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring"
             ],
             "support": {
@@ -2558,7 +2558,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-date.prototype.tolocalestring",
+              "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocalestring"
             ],
             "support": {
@@ -2771,7 +2771,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring",
+              "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocaletimestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring"
             ],
             "support": {
@@ -3036,7 +3036,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -3088,7 +3088,7 @@
         "toTimeString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.totimestring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.totimestring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -3140,7 +3140,7 @@
         "toUTCString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.toutcstring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.toutcstring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -3192,7 +3192,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -3244,7 +3244,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
-            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype-@@toprimitive",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -4,7 +4,7 @@
       "Error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
-          "spec_url": "https://tc39.es/ecma262/#sec-error-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Error()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error",
-            "spec_url": "https://tc39.es/ecma262/#sec-error-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -261,7 +261,7 @@
         "message": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/message",
-            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.message",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.message",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -313,7 +313,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/name",
-            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.name",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.name",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -469,7 +469,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -4,7 +4,7 @@
       "EvalError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-evalerror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>EvalError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError/EvalError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -4,7 +4,7 @@
       "FinalizationRegistry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry",
-          "spec_url": "https://tc39.es/ecma262/#sec-finalization-registry-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-objects",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -67,7 +67,7 @@
           "__compat": {
             "description": "<code>FinalizationRegistry()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/FinalizationRegistry",
-            "spec_url": "https://tc39.es/ecma262/#sec-finalization-registry-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-constructor",
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -130,7 +130,7 @@
         "register": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register",
-            "spec_url": "https://tc39.es/ecma262/#sec-finalization-registry.prototype.register",
+            "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.register",
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -193,7 +193,7 @@
         "unregister": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/unregister",
-            "spec_url": "https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister",
+            "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.unregister",
             "support": {
               "chrome": {
                 "version_added": "84"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -4,7 +4,7 @@
       "Float32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Float32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array/Float32Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -4,7 +4,7 @@
       "Float64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Float64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array/Float64Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -4,7 +4,7 @@
       "Function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function",
-          "spec_url": "https://tc39.es/ecma262/#sec-function-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Function()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Function",
-            "spec_url": "https://tc39.es/ecma262/#sec-function-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/apply",
-            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.apply",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.apply",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -262,7 +262,7 @@
         "bind": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
-            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.bind",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.bind",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -314,7 +314,7 @@
         "call": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/call",
-            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.call",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.call",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -468,7 +468,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/length",
-            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-length",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-instances-length",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -571,7 +571,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/name",
-            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-name",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-instances-name",
             "support": {
               "chrome": {
                 "version_added": "15"
@@ -791,7 +791,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -4,7 +4,7 @@
       "Generator": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator",
-          "spec_url": "https://tc39.es/ecma262/#sec-generator-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator-objects",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -66,7 +66,7 @@
         "next": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/next",
-            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.next",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.next",
             "support": {
               "chrome": {
                 "version_added": "39"
@@ -129,7 +129,7 @@
         "return": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/return",
-            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.return",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.return",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -181,7 +181,7 @@
         "throw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw",
-            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.throw",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.throw",
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -4,7 +4,7 @@
       "GeneratorFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction",
-          "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generatorfunction-objects",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -4,7 +4,7 @@
       "Int16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Int16Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array/Int16Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -4,7 +4,7 @@
       "Int32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Int32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array/Int32Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -4,7 +4,7 @@
       "Int8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Int8Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array/Int8Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -4,7 +4,7 @@
       "JSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON",
-          "spec_url": "https://tc39.es/ecma262/#sec-json-object",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json-object",
           "support": {
             "chrome": {
               "version_added": "3"
@@ -107,7 +107,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse",
-            "spec_url": "https://tc39.es/ecma262/#sec-json.parse",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json.parse",
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -159,7 +159,7 @@
         "stringify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify",
-            "spec_url": "https://tc39.es/ecma262/#sec-json.stringify",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json.stringify",
             "support": {
               "chrome": {
                 "version_added": "3"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -4,7 +4,7 @@
       "Map": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map",
-          "spec_url": "https://tc39.es/ecma262/#sec-map-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -67,7 +67,7 @@
           "__compat": {
             "description": "<code>Map()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
-            "spec_url": "https://tc39.es/ecma262/#sec-map-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -294,7 +294,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.clear",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -346,7 +346,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/delete",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -409,7 +409,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/entries",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -461,7 +461,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -513,7 +513,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.get",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -576,7 +576,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/has",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -690,7 +690,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/keys",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -742,7 +742,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/set",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.set",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -807,7 +807,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/size",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-map.prototype.size",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -861,7 +861,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/values",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -913,7 +913,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -993,7 +993,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-map-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -1056,7 +1056,7 @@
         "@@toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype-@@tostringtag",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@tostringtag",
             "support": {
               "chrome": {
                 "version_added": "44"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -5,7 +5,7 @@
         "E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/E",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.e",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.e",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -57,7 +57,7 @@
         "LN2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.ln2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -109,7 +109,7 @@
         "LN10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN10",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.ln10",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln10",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -161,7 +161,7 @@
         "LOG2E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log2e",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2e",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,7 +213,7 @@
         "LOG10E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log10e",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10e",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -265,7 +265,7 @@
         "PI": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/PI",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.pi",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.pi",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -317,7 +317,7 @@
         "SQRT1_2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt1_2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt1_2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -369,7 +369,7 @@
         "SQRT2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT2",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -421,7 +421,7 @@
         "abs": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/abs",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.abs",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.abs",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -473,7 +473,7 @@
         "acos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acos",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.acos",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.acos",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -525,7 +525,7 @@
         "acosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.acosh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.acosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -577,7 +577,7 @@
         "asin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asin",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.asin",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.asin",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -629,7 +629,7 @@
         "asinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.asinh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.asinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -681,7 +681,7 @@
         "atan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.atan",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atan",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -733,7 +733,7 @@
         "atan2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.atan2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atan2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -785,7 +785,7 @@
         "atanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.atanh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -837,7 +837,7 @@
         "cbrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.cbrt",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cbrt",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -889,7 +889,7 @@
         "ceil": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.ceil",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ceil",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -941,7 +941,7 @@
         "clz32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.clz32",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.clz32",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -993,7 +993,7 @@
         "cos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cos",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.cos",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cos",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1045,7 +1045,7 @@
         "cosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.cosh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1097,7 +1097,7 @@
         "exp": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/exp",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.exp",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.exp",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1149,7 +1149,7 @@
         "expm1": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.expm1",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.expm1",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1201,7 +1201,7 @@
         "floor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/floor",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.floor",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.floor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1253,7 +1253,7 @@
         "fround": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/fround",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.fround",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.fround",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1305,7 +1305,7 @@
         "hypot": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.hypot",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.hypot",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1357,7 +1357,7 @@
         "imul": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.imul",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.imul",
             "support": {
               "chrome": {
                 "version_added": "28"
@@ -1409,7 +1409,7 @@
         "log": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1461,7 +1461,7 @@
         "log1p": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log1p",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log1p",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1513,7 +1513,7 @@
         "log2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1565,7 +1565,7 @@
         "log10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.log10",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1617,7 +1617,7 @@
         "max": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/max",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.max",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.max",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1669,7 +1669,7 @@
         "min": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/min",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.min",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.min",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1721,7 +1721,7 @@
         "pow": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/pow",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.pow",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.pow",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1773,7 +1773,7 @@
         "random": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/random",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.random",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.random",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1825,7 +1825,7 @@
         "round": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/round",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.round",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.round",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1877,7 +1877,7 @@
         "sign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sign",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sign",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1929,7 +1929,7 @@
         "sin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sin",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sin",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sin",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1981,7 +1981,7 @@
         "sinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sinh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2033,7 +2033,7 @@
         "sqrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2085,7 +2085,7 @@
         "tan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tan",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.tan",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.tan",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2137,7 +2137,7 @@
         "tanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.tanh",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.tanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2189,7 +2189,7 @@
         "trunc": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
-            "spec_url": "https://tc39.es/ecma262/#sec-math.trunc",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.trunc",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -4,7 +4,7 @@
       "Number": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
-          "spec_url": "https://tc39.es/ecma262/#sec-number-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -55,7 +55,7 @@
         "EPSILON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.epsilon",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.epsilon",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -107,7 +107,7 @@
         "MAX_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.max_safe_integer",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -159,7 +159,7 @@
         "MAX_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.max_value",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_value",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -211,7 +211,7 @@
         "MIN_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.min_safe_integer",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -263,7 +263,7 @@
         "MIN_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.min_value",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_value",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -315,7 +315,7 @@
         "NaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.nan",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.nan",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -367,7 +367,7 @@
         "NEGATIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.negative_infinity",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.negative_infinity",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -420,7 +420,7 @@
           "__compat": {
             "description": "<code>Number()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/Number",
-            "spec_url": "https://tc39.es/ecma262/#sec-number-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -472,7 +472,7 @@
         "POSITIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.positive_infinity",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.positive_infinity",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -524,7 +524,7 @@
         "isFinite": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.isfinite",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isfinite",
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -576,7 +576,7 @@
         "isInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.isinteger",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isinteger",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -628,7 +628,7 @@
         "isNaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.isnan",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isnan",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -680,7 +680,7 @@
         "isSafeInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.issafeinteger",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.issafeinteger",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -732,7 +732,7 @@
         "parseFloat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.parsefloat",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.parsefloat",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -784,7 +784,7 @@
         "parseInt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.parseint",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.parseint",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -836,7 +836,7 @@
         "toExponential": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toexponential",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toexponential",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -888,7 +888,7 @@
         "toFixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tofixed",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tofixed",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -941,7 +941,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-number.prototype.tolocalestring",
+              "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-number.prototype.tolocalestring"
             ],
             "support": {
@@ -1104,7 +1104,7 @@
         "toPrecision": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toprecision",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toprecision",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1209,7 +1209,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1261,7 +1261,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -4,7 +4,7 @@
       "Object": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
-          "spec_url": "https://tc39.es/ecma262/#sec-object-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Object()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/Object",
-            "spec_url": "https://tc39.es/ecma262/#sec-object-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
         "assign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.assign",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -160,7 +160,7 @@
         "constructor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -212,7 +212,7 @@
         "create": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/create",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.create",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.create",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -265,7 +265,7 @@
           "__compat": {
             "description": "<code>__defineGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-object.prototype.__defineGetter__",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -318,7 +318,7 @@
         "defineProperties": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.defineproperties",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.defineproperties",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -370,7 +370,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.defineproperty",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -432,7 +432,7 @@
           "__compat": {
             "description": "<code>__defineSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-object.prototype.__defineSetter__",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -485,7 +485,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/entries",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.entries",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.entries",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -548,7 +548,7 @@
         "freeze": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.freeze",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.freeze",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -600,7 +600,7 @@
         "fromEntries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.fromentries",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.fromentries",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -652,7 +652,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -711,7 +711,7 @@
         "getOwnPropertyDescriptors": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertydescriptors",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -774,7 +774,7 @@
         "getOwnPropertyNames": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertynames",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertynames",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -826,7 +826,7 @@
         "getOwnPropertySymbols": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertysymbols",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertysymbols",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -878,7 +878,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.getprototypeof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -930,7 +930,7 @@
         "hasOwnProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.hasownproperty",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.hasownproperty",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -982,7 +982,7 @@
         "is": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/is",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.is",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.is",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -1034,7 +1034,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.isextensible",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.isextensible",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1086,7 +1086,7 @@
         "isFrozen": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.isfrozen",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.isfrozen",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1138,7 +1138,7 @@
         "isPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.isprototypeof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.isprototypeof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1190,7 +1190,7 @@
         "isSealed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.issealed",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.issealed",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1242,7 +1242,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.keys",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1295,7 +1295,7 @@
           "__compat": {
             "description": "<code>__lookupGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-object.prototype.__lookupGetter__",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1348,7 +1348,7 @@
           "__compat": {
             "description": "<code>__lookupSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-object.prototype.__lookupSetter__",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1400,7 +1400,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.preventextensions",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1503,7 +1503,7 @@
         "propertyIsEnumerable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.propertyisenumerable",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1556,7 +1556,7 @@
           "__compat": {
             "description": "<code>__proto__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/proto",
-            "spec_url": "https://tc39.es/ecma262/#sec-additional-properties-of-the-object.prototype-object",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-object.prototype-object",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1608,7 +1608,7 @@
         "seal": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/seal",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.seal",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.seal",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1660,7 +1660,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.setprototypeof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1712,7 +1712,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tolocalestring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1817,7 +1817,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.tostring",
             "description": "<code>toString()</code>",
             "support": {
               "chrome": {
@@ -1870,7 +1870,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1922,7 +1922,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/values",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.values",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.values",
             "support": {
               "chrome": {
                 "version_added": "54"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -4,7 +4,7 @@
       "Promise": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-          "spec_url": "https://tc39.es/ecma262/#sec-promise-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Promise()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-constructor",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -113,7 +113,7 @@
         "all": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.all",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.all",
             "description": "<code>all()</code>",
             "support": {
               "chrome": {
@@ -166,7 +166,7 @@
         "allSettled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.allsettled",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled",
             "description": "<code>allSettled()</code>",
             "support": {
               "chrome": {
@@ -219,7 +219,7 @@
         "any": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.any",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any",
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -271,7 +271,7 @@
         "catch": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.catch",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.catch",
             "description": "<code>catch()</code>",
             "support": {
               "chrome": {
@@ -324,7 +324,7 @@
         "finally": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.finally",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.finally",
             "description": "<code>finally()</code>",
             "support": {
               "chrome": {
@@ -430,7 +430,7 @@
         "race": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.race",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.race",
             "description": "<code>race()</code>",
             "support": {
               "chrome": {
@@ -483,7 +483,7 @@
         "reject": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.reject",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.reject",
             "description": "<code>reject()</code>",
             "support": {
               "chrome": {
@@ -536,7 +536,7 @@
         "resolve": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.resolve",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.resolve",
             "description": "<code>resolve()</code>",
             "support": {
               "chrome": {
@@ -589,7 +589,7 @@
         "then": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.then",
+            "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.then",
             "description": "<code>then()</code>",
             "support": {
               "chrome": {

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -4,7 +4,7 @@
       "Proxy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
-          "spec_url": "https://tc39.es/ecma262/#sec-proxy-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy-objects",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Proxy()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy",
-            "spec_url": "https://tc39.es/ecma262/#sec-proxy-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy-constructor",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -109,7 +109,7 @@
           "apply": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/apply",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -161,7 +161,7 @@
           "construct": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/construct",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -213,7 +213,7 @@
           "defineProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -265,7 +265,7 @@
           "deleteProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -317,7 +317,7 @@
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -369,7 +369,7 @@
           "getOwnPropertyDescriptor": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -421,7 +421,7 @@
           "getPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -473,7 +473,7 @@
           "has": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -525,7 +525,7 @@
           "isExtensible": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/isExtensible",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -577,7 +577,7 @@
           "ownKeys": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -631,7 +631,7 @@
           "preventExtensions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -683,7 +683,7 @@
           "set": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -735,7 +735,7 @@
           "setPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/setPrototypeOf",
-              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
+              "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -788,7 +788,7 @@
         "revocable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable",
-            "spec_url": "https://tc39.es/ecma262/#sec-proxy.revocable",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy.revocable",
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -4,7 +4,7 @@
       "RangeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-rangeerror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>RangeError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError/RangeError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -4,7 +4,7 @@
       "ReferenceError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-referenceerror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>ReferenceError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError/ReferenceError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -4,7 +4,7 @@
       "Reflect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect",
-          "spec_url": "https://tc39.es/ecma262/#sec-reflect-object",
+          "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect-object",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -55,7 +55,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.apply",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.apply",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -107,7 +107,7 @@
         "construct": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.construct",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.construct",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -159,7 +159,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.defineproperty",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -211,7 +211,7 @@
         "deleteProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.deleteproperty",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.deleteproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -263,7 +263,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.get",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.get",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -315,7 +315,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.getownpropertydescriptor",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -367,7 +367,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.getprototypeof",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -419,7 +419,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/has",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.has",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.has",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -471,7 +471,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.isextensible",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.isextensible",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -523,7 +523,7 @@
         "ownKeys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.ownkeys",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.ownkeys",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -575,7 +575,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.preventextensions",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -627,7 +627,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.set",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.set",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -679,7 +679,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-reflect.setprototypeof",
+            "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -4,7 +4,7 @@
       "RegExp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
-          "spec_url": "https://tc39.es/ecma262/#sec-regexp-regular-expression-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>RegExp()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.compile",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-regexp.prototype.compile",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -160,7 +160,7 @@
         "dotAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.dotAll",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.dotAll",
             "support": {
               "chrome": {
                 "version_added": "62"
@@ -223,7 +223,7 @@
         "exec": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.exec",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.exec",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -275,7 +275,7 @@
         "flags": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.flags",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.flags",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -327,7 +327,7 @@
         "global": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.global",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.global",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -482,7 +482,7 @@
         "ignoreCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.ignorecase",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -637,7 +637,7 @@
         "lastIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-regexp-instances",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-properties-of-regexp-instances",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -896,7 +896,7 @@
         "multiline": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.multiline",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1052,7 +1052,7 @@
         "named_capture_groups": {
           "__compat": {
             "description": "Named capture groups",
-            "spec_url": "https://tc39.es/ecma262/#sec-patterns",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -1229,7 +1229,7 @@
         "source": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.source",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.source",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1434,7 +1434,7 @@
         "sticky": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.sticky",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1588,7 +1588,7 @@
         "test": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.test",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.test",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1693,7 +1693,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1796,7 +1796,7 @@
         "unicode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.unicode",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1850,7 +1850,7 @@
         "@@match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@match",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@match",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1902,7 +1902,7 @@
         "@@matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp-prototype-matchall",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-prototype-matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -1954,7 +1954,7 @@
         "@@replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@replace",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@replace",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -2006,7 +2006,7 @@
         "@@search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@search",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@search",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -2058,7 +2058,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp-@@species",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -2121,7 +2121,7 @@
         "@@split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@split",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@split",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -4,7 +4,7 @@
       "Set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set",
-          "spec_url": "https://tc39.es/ecma262/#sec-set-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -67,7 +67,7 @@
           "__compat": {
             "description": "<code>Set()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
-            "spec_url": "https://tc39.es/ecma262/#sec-set-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -294,7 +294,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.add",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -359,7 +359,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/clear",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.clear",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -411,7 +411,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/delete",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -474,7 +474,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/entries",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -526,7 +526,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -578,7 +578,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/has",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -692,7 +692,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-set.prototype.size",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -746,7 +746,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.values",
             "support": {
               "chrome": [
                 {
@@ -870,7 +870,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -950,7 +950,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-set-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -4,7 +4,7 @@
       "SharedArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer",
-          "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-objects",
           "support": {
             "chrome": [
               {
@@ -139,7 +139,7 @@
           "__compat": {
             "description": "<code>SharedArrayBuffer()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer",
-            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-constructor",
             "support": {
               "chrome": [
                 {
@@ -274,7 +274,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.bytelength",
             "support": {
               "chrome": [
                 {
@@ -409,7 +409,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice",
-            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer.prototype.slice",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -4,7 +4,7 @@
       "String": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
-          "spec_url": "https://tc39.es/ecma262/#sec-string-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>String()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/String",
-            "spec_url": "https://tc39.es/ecma262/#sec-string-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -108,7 +108,7 @@
         "anchor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/anchor",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.anchor",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.anchor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,7 +213,7 @@
         "big": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/big",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.big",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.big",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -265,7 +265,7 @@
         "blink": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/blink",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.blink",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.blink",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -317,7 +317,7 @@
         "bold": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/bold",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.bold",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.bold",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -369,7 +369,7 @@
         "charAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charAt",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charat",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.charat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -421,7 +421,7 @@
         "charCodeAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charcodeat",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.charcodeat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -473,7 +473,7 @@
         "codePointAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.codepointat",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.codepointat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -536,7 +536,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/concat",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.concat",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -588,7 +588,7 @@
         "endsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.endswith",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.endswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -651,7 +651,7 @@
         "fixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fixed",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fixed",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fixed",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -703,7 +703,7 @@
         "fontcolor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontcolor",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontcolor",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontcolor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -755,7 +755,7 @@
         "fontsize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontsize",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontsize",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontsize",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -807,7 +807,7 @@
         "fromCharCode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcharcode",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.fromcharcode",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -859,7 +859,7 @@
         "fromCodePoint": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcodepoint",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.fromcodepoint",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -922,7 +922,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/includes",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -988,7 +988,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1040,7 +1040,7 @@
         "italics": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/italics",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.italics",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.italics",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1092,7 +1092,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1144,7 +1144,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/length",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-string-instances-length",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-properties-of-string-instances-length",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1196,7 +1196,7 @@
         "link": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/link",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.link",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.link",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1249,7 +1249,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-string.prototype.localecompare",
+              "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.localecompare",
               "https://tc39.es/ecma402/#sup-String.prototype.localeCompare"
             ],
             "support": {
@@ -1410,7 +1410,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/match",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.match",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.match",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1462,7 +1462,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.matchall",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -1514,7 +1514,7 @@
         "normalize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.normalize",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.normalize",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1566,7 +1566,7 @@
         "padEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.padend",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.padend",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1629,7 +1629,7 @@
         "padStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padStart",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.padstart",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.padstart",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1692,7 +1692,7 @@
         "raw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/raw",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.raw",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.raw",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1744,7 +1744,7 @@
         "repeat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/repeat",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.repeat",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.repeat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1807,7 +1807,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replace",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.replace",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replace",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1867,7 +1867,7 @@
         "replaceAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.replaceall",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replaceall",
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -1919,7 +1919,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/search",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.search",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.search",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2023,7 +2023,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/slice",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2075,7 +2075,7 @@
         "small": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/small",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.small",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.small",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2127,7 +2127,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.split",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.split",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2179,7 +2179,7 @@
         "startsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.startswith",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.startswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -2242,7 +2242,7 @@
         "strike": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/strike",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.strike",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.strike",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2294,7 +2294,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sub",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sub",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sub",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2346,7 +2346,7 @@
         "substr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substr",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substr",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.substr",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2398,7 +2398,7 @@
         "substring": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substring",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substring",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.substring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2450,7 +2450,7 @@
         "sup": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sup",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sup",
+            "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sup",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2503,7 +2503,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-string.prototype.tolocalelowercase",
+              "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolocalelowercase",
               "https://tc39.es/ecma402/#sup-string.prototype.tolocalelowercase"
             ],
             "support": {
@@ -2615,7 +2615,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-string.prototype.tolocaleuppercase",
+              "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolocaleuppercase",
               "https://tc39.es/ecma402/#sup-string.prototype.tolocaleuppercase"
             ],
             "support": {
@@ -2726,7 +2726,7 @@
         "toLowerCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tolowercase",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolowercase",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2831,7 +2831,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2883,7 +2883,7 @@
         "toUpperCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.touppercase",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.touppercase",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2935,7 +2935,7 @@
         "trim": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trim",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trim",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trim",
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -2987,7 +2987,7 @@
         "trimEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimend",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trimend",
             "support": {
               "chrome": [
                 {
@@ -3094,7 +3094,7 @@
         "trimStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimstart",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trimstart",
             "support": {
               "chrome": [
                 {
@@ -3252,7 +3252,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -3304,7 +3304,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -4,7 +4,7 @@
       "Symbol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol",
-          "spec_url": "https://tc39.es/ecma262/#sec-symbol-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -57,7 +57,7 @@
           "__compat": {
             "description": "<code>Symbol()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -109,7 +109,7 @@
         "asyncIterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.asynciterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.asynciterator",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -161,7 +161,7 @@
         "description": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.description",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.description",
             "support": {
               "chrome": {
                 "version_added": "70"
@@ -227,7 +227,7 @@
         "for": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.for",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.for",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -279,7 +279,7 @@
         "hasInstance": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.hasinstance",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.hasinstance",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -342,7 +342,7 @@
         "isConcatSpreadable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.isconcatspreadable",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.isconcatspreadable",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -394,7 +394,7 @@
         "iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.iterator",
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -446,7 +446,7 @@
         "keyFor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.keyfor",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.keyfor",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -498,7 +498,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.match",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.match",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -550,7 +550,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.matchall",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -602,7 +602,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.replace",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.replace",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -654,7 +654,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.search",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.search",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -706,7 +706,7 @@
         "species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.species",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -769,7 +769,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.split",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.split",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -821,7 +821,7 @@
         "toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.toprimitive",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.toprimitive",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -926,7 +926,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -978,7 +978,7 @@
         "toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.tostringtag",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.tostringtag",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1093,7 +1093,7 @@
         "unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.unscopables",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.unscopables",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1145,7 +1145,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1197,7 +1197,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -4,7 +4,7 @@
       "SyntaxError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-syntaxerror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>SyntaxError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError/SyntaxError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -4,7 +4,7 @@
       "TypeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-typeerror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>TypeError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError/TypeError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -4,7 +4,7 @@
       "TypedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
-          "spec_url": "https://tc39.es/ecma262/#sec-typedarray-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,7 +55,7 @@
         "BYTES_PER_ELEMENT": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray.bytes_per_element",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray.bytes_per_element",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -159,7 +159,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -211,7 +211,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -263,7 +263,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -366,7 +366,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -418,7 +418,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -470,7 +470,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/every",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.every",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.every",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -522,7 +522,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -574,7 +574,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/filter",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -626,7 +626,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/find",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.find",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.find",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -678,7 +678,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findindex",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -730,7 +730,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -782,7 +782,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.from",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -834,7 +834,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -959,7 +959,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1064,7 +1064,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.join",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.join",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1116,7 +1116,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1168,7 +1168,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1222,7 +1222,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.length",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1274,7 +1274,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/map",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.map",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.map",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1326,7 +1326,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-the-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1480,7 +1480,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.of",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1532,7 +1532,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1584,7 +1584,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduceright",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1636,7 +1636,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reverse",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1688,7 +1688,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.set-array-offset",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.set-array-offset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1740,7 +1740,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1792,7 +1792,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/some",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.some",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.some",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1844,7 +1844,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1896,7 +1896,7 @@
         "subarray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.subarray",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1948,7 +1948,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -2000,7 +2000,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -2052,7 +2052,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2104,7 +2104,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2184,7 +2184,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@species",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%-@@species",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -4,7 +4,7 @@
       "URIError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError",
-          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror",
+          "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-urierror",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>URIError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError/URIError",
-            "spec_url": "https://tc39.es/ecma262/#sec-nativeerror-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -4,7 +4,7 @@
       "Uint16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Uint16Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -4,7 +4,7 @@
       "Uint32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Uint32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -4,7 +4,7 @@
       "Uint8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Uint8Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -4,7 +4,7 @@
       "Uint8ClampedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
-          "spec_url": "https://tc39.es/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Uint8ClampedArray()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray",
-            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -4,7 +4,7 @@
       "WeakMap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
-          "spec_url": "https://tc39.es/ecma262/#sec-weakmap-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -67,7 +67,7 @@
           "__compat": {
             "description": "<code>WeakMap()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap-constructor",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -356,7 +356,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -421,7 +421,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.get",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -486,7 +486,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -551,7 +551,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.set",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -4,7 +4,7 @@
       "WeakRef": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef",
-          "spec_url": "https://tc39.es/ecma262/#sec-weak-ref-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-objects",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -67,7 +67,7 @@
           "__compat": {
             "description": "<code>WeakRef()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef",
-            "spec_url": "https://tc39.es/ecma262/#sec-weak-ref-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-constructor",
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -130,7 +130,7 @@
         "deref": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/deref",
-            "spec_url": "https://tc39.es/ecma262/#sec-weak-ref.prototype.deref",
+            "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref.prototype.deref",
             "support": {
               "chrome": {
                 "version_added": "84"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -4,7 +4,7 @@
       "WeakSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
-          "spec_url": "https://tc39.es/ecma262/#sec-weakset-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>WeakSet()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset-constructor",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset-constructor",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -210,7 +210,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.add",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -262,7 +262,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -314,7 +314,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -4,7 +4,7 @@
       "Infinity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Infinity",
-          "spec_url": "https://tc39.es/ecma262/#sec-value-properties-of-the-global-object-infinity",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-infinity",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -56,7 +56,7 @@
       "NaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN",
-          "spec_url": "https://tc39.es/ecma262/#sec-value-properties-of-the-global-object-nan",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-nan",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -108,7 +108,7 @@
       "decodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURI",
-          "spec_url": "https://tc39.es/ecma262/#sec-decodeuri-encodeduri",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-decodeuri-encodeduri",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -160,7 +160,7 @@
       "decodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent",
-          "spec_url": "https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-decodeuricomponent-encodeduricomponent",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -212,7 +212,7 @@
       "encodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURI",
-          "spec_url": "https://tc39.es/ecma262/#sec-encodeuri-uri",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuri-uri",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -264,7 +264,7 @@
       "encodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent",
-          "spec_url": "https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuricomponent-uricomponent",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -316,7 +316,7 @@
       "escape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/escape",
-          "spec_url": "https://tc39.es/ecma262/#sec-escape-string",
+          "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-escape-string",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -368,7 +368,7 @@
       "eval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval",
-          "spec_url": "https://tc39.es/ecma262/#sec-eval-x",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-eval-x",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -420,7 +420,7 @@
       "globalThis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis",
-          "spec_url": "https://tc39.es/ecma262/#sec-globalthis",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-globalthis",
           "support": {
             "chrome": {
               "version_added": "71"
@@ -472,7 +472,7 @@
       "isFinite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isFinite",
-          "spec_url": "https://tc39.es/ecma262/#sec-isfinite-number",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-isfinite-number",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -524,7 +524,7 @@
       "isNaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isNaN",
-          "spec_url": "https://tc39.es/ecma262/#sec-isnan-number",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-isnan-number",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -576,7 +576,7 @@
       "null": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/null",
-          "spec_url": "https://tc39.es/ecma262/#sec-null-value",
+          "spec_url": "https://tc39.es/ecma262/multipage/overview.html#sec-null-value",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -628,7 +628,7 @@
       "parseFloat": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseFloat",
-          "spec_url": "https://tc39.es/ecma262/#sec-parsefloat-string",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-parsefloat-string",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -680,7 +680,7 @@
       "parseInt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseInt",
-          "spec_url": "https://tc39.es/ecma262/#sec-parseint-string-radix",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-parseint-string-radix",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -783,7 +783,7 @@
       "undefined": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
-          "spec_url": "https://tc39.es/ecma262/#sec-undefined",
+          "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-undefined",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -835,7 +835,7 @@
       "unescape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/unescape",
-          "spec_url": "https://tc39.es/ecma262/#sec-unescape-string",
+          "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-unescape-string",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/builtins/webassembly/CompileError.json
+++ b/javascript/builtins/webassembly/CompileError.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
-              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {
@@ -64,7 +64,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
-                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+                "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/webassembly/LinkError.json
+++ b/javascript/builtins/webassembly/LinkError.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
-              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {
@@ -64,7 +64,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
-                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+                "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/webassembly/RunTimeError.json
+++ b/javascript/builtins/webassembly/RunTimeError.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
-              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {
@@ -64,7 +64,7 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
-                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+                "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"
               ],
               "support": {
                 "chrome": {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -3,7 +3,7 @@
     "classes": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
-        "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
+        "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
         "support": {
           "chrome": [
             {
@@ -160,7 +160,7 @@
       "constructor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
-          "spec_url": "https://tc39.es/ecma262/#sec-static-semantics-constructormethod",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-static-semantics-constructormethod",
           "support": {
             "chrome": [
               {
@@ -318,7 +318,7 @@
       "extends": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
-          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "support": {
             "chrome": [
               {
@@ -624,7 +624,7 @@
       "static": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
-          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "support": {
             "chrome": [
               {

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -3,7 +3,7 @@
     "functions": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions",
-        "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
+        "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -54,7 +54,7 @@
       "arguments": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments",
-          "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -105,7 +105,7 @@
         "callee": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/callee",
-            "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
+            "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -157,7 +157,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/length",
-            "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
+            "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -210,8 +210,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator",
             "spec_url": [
-              "https://tc39.es/ecma262/#sec-createunmappedargumentsobject",
-              "https://tc39.es/ecma262/#sec-createmappedargumentsobject"
+              "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createunmappedargumentsobject",
+              "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createmappedargumentsobject"
             ],
             "support": {
               "chrome": {
@@ -266,7 +266,7 @@
         "__compat": {
           "description": "Arrow functions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
-          "spec_url": "https://tc39.es/ecma262/#sec-arrow-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-arrow-function-definitions",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -453,7 +453,7 @@
         "__compat": {
           "description": "Default parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Default_parameters",
-          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -607,7 +607,7 @@
       "get": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/get",
-          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -711,7 +711,7 @@
         "__compat": {
           "description": "Method definitions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Method_definitions",
-          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -939,7 +939,7 @@
         "__compat": {
           "description": "Rest parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/rest_parameters",
-          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "47"
@@ -1053,7 +1053,7 @@
       "set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/set",
-          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Array literals (<code>[1, 2, 3]</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals",
-          "spec_url": "https://tc39.es/ecma262/#sec-array-initializer",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -58,7 +58,7 @@
         "__compat": {
           "description": "Binary numeric literals (<code>0b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Binary",
-          "spec_url": "https://tc39.es/ecma262/#prod-BinaryIntegerLiteral",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-BinaryIntegerLiteral",
           "support": {
             "chrome": {
               "version_added": "41"
@@ -122,7 +122,7 @@
         "__compat": {
           "description": "Boolean literals (<code>true</code>/<code>false</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Boolean_literal",
-          "spec_url": "https://tc39.es/ecma262/#sec-boolean-literals",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-boolean-literals",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -175,7 +175,7 @@
         "__compat": {
           "description": "Decimal numeric literals (<code>1234567890</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Decimal",
-          "spec_url": "https://tc39.es/ecma262/#prod-DecimalLiteral",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-DecimalLiteral",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -281,7 +281,7 @@
         "__compat": {
           "description": "Hexadecimal escape sequences (<code>'\\xA9'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal_escape_sequences",
-          "spec_url": "https://tc39.es/ecma262/#prod-HexEscapeSequence",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexEscapeSequence",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -334,7 +334,7 @@
         "__compat": {
           "description": "Hexadecimal numeric literals (<code>0xAF</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal",
-          "spec_url": "https://tc39.es/ecma262/#prod-HexIntegerLiteral",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexIntegerLiteral",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -387,7 +387,7 @@
         "__compat": {
           "description": "Null literal (<code>null</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Null_literal",
-          "spec_url": "https://tc39.es/ecma262/#sec-null-literals",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-null-literals",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -440,7 +440,7 @@
         "__compat": {
           "description": "Numeric separators (<code>1_000_000_000_000</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators",
-          "spec_url": "https://tc39.es/ecma262/#prod-NumericLiteralSeparator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-NumericLiteralSeparator",
           "support": {
             "chrome": {
               "version_added": "75"
@@ -504,7 +504,7 @@
         "__compat": {
           "description": "Octal numeric literals (<code>0o</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Octal",
-          "spec_url": "https://tc39.es/ecma262/#prod-OctalIntegerLiteral",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-OctalIntegerLiteral",
           "support": {
             "chrome": {
               "version_added": "41"
@@ -568,7 +568,7 @@
         "__compat": {
           "description": "Regular expression literals (<code>/ab+c/g</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Regular_expression_literals",
-          "spec_url": "https://tc39.es/ecma262/#sec-literals-regular-expression-literals",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-regular-expression-literals",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -621,7 +621,7 @@
         "__compat": {
           "description": "String literals (<code>'Hello world'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#String_literals",
-          "spec_url": "https://tc39.es/ecma262/#sec-literals-string-literals",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-string-literals",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -674,7 +674,7 @@
         "__compat": {
           "description": "Unicode escape sequences (<code>'\\u00A9'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_escape_sequences",
-          "spec_url": "https://tc39.es/ecma262/#sec-unicodeescape",
+          "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-unicodeescape",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -727,7 +727,7 @@
         "__compat": {
           "description": "Unicode point escapes (<code>\\u{}</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_code_point_escapes",
-          "spec_url": "https://tc39.es/ecma262/#prod-UnicodeEscapeSequence",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-UnicodeEscapeSequence",
           "support": {
             "chrome": {
               "version_added": "44"
@@ -831,7 +831,7 @@
         "__compat": {
           "description": "Template literals",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Template_literals",
-          "spec_url": "https://tc39.es/ecma262/#sec-template-literals",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-template-literals",
           "support": {
             "chrome": {
               "version_added": "41"
@@ -947,16 +947,16 @@
           "description": "Trailing commas",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Trailing_commas",
           "spec_url": [
-            "https://tc39.es/ecma262/#prod-Elision",
-            "https://tc39.es/ecma262/#prod-ObjectLiteral",
-            "https://tc39.es/ecma262/#prod-ArrayLiteral",
-            "https://tc39.es/ecma262/#prod-Arguments",
-            "https://tc39.es/ecma262/#prod-FormalParameters",
-            "https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList",
-            "https://tc39.es/ecma262/#prod-NamedImports",
-            "https://tc39.es/ecma262/#prod-NamedExports",
-            "https://tc39.es/ecma262/#prod-QuantifierPrefix",
-            "https://tc39.es/ecma262/#prod-annexB-InvalidBracedQuantifier"
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-Elision",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ObjectLiteral",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArrayLiteral",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-Arguments",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FormalParameters",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-CoverParenthesizedExpressionAndArrowParameterList",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-NamedImports",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-NamedExports",
+            "https://tc39.es/ecma262/multipage/text-processing.html#prod-QuantifierPrefix",
+            "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#prod-annexB-InvalidBracedQuantifier"
           ],
           "support": {
             "chrome": {

--- a/javascript/operators/addition.json
+++ b/javascript/operators/addition.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Addition (<code>+</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Addition",
-          "spec_url": "https://tc39.es/ecma262/#sec-addition-operator-plus",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-addition-operator-plus",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/addition_assignment.json
+++ b/javascript/operators/addition_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Addition assignment (<code>x += y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Addition_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Assignment (<code>x = y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/async_function_.json
+++ b/javascript/operators/async_function_.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>async function</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/async_function",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/async_generator_function.json
+++ b/javascript/operators/async_generator_function.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>async function*</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/async_function*",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "63"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -4,7 +4,7 @@
       "await": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/bitwise_and.json
+++ b/javascript/operators/bitwise_and.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise AND (<code>a &amp; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_AND",
-          "spec_url": "https://tc39.es/ecma262/#prod-BitwiseANDExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseANDExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_and_assignment.json
+++ b/javascript/operators/bitwise_and_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise AND assignment (<code>x &amp;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_not.json
+++ b/javascript/operators/bitwise_not.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise NOT (<code>~a</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT",
-          "spec_url": "https://tc39.es/ecma262/#sec-bitwise-not-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-bitwise-not-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_or.json
+++ b/javascript/operators/bitwise_or.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise OR (<code>a | b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_OR",
-          "spec_url": "https://tc39.es/ecma262/#prod-BitwiseORExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseORExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_or_assignment.json
+++ b/javascript/operators/bitwise_or_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise OR assignment (<code>x |= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_xor.json
+++ b/javascript/operators/bitwise_xor.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise XOR (<code>a ^ b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR",
-          "spec_url": "https://tc39.es/ecma262/#prod-BitwiseXORExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseXORExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_xor_assignment.json
+++ b/javascript/operators/bitwise_xor_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise XOR assignment (<code>x ^= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -4,7 +4,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/class",
-          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Comma operator",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Comma_operator",
-          "spec_url": "https://tc39.es/ecma262/#sec-comma-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-comma-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Conditional operator (<code>c ? t : f</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Conditional_Operator",
-          "spec_url": "https://tc39.es/ecma262/#sec-conditional-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-conditional-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/decrement.json
+++ b/javascript/operators/decrement.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Decrement (<code>--</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Decrement",
-          "spec_url": "https://tc39.es/ecma262/#sec-postfix-decrement-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-postfix-decrement-operator",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -4,7 +4,7 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/delete",
-          "spec_url": "https://tc39.es/ecma262/#sec-delete-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-delete-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Destructuring assignment",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-destructuring-assignment",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-destructuring-assignment",
           "support": {
             "chrome": {
               "version_added": "49"

--- a/javascript/operators/division.json
+++ b/javascript/operators/division.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Division (<code>/</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Division",
-          "spec_url": "https://tc39.es/ecma262/#sec-multiplicative-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/division_assignment.json
+++ b/javascript/operators/division_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Division assignment (<code>x /= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Division_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/equality.json
+++ b/javascript/operators/equality.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Equality (<code>a == b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Equality",
-          "spec_url": "https://tc39.es/ecma262/#sec-equality-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/exponentiation.json
+++ b/javascript/operators/exponentiation.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Exponentiation (<code>**</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Exponentiation",
-          "spec_url": "https://tc39.es/ecma262/#sec-exp-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-exp-operator",
           "support": {
             "chrome": {
               "version_added": "52"

--- a/javascript/operators/exponentiation_assignment.json
+++ b/javascript/operators/exponentiation_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Exponentiation assignment (<code>x **= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "52"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>function</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function",
-          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/generator_function.json
+++ b/javascript/operators/generator_function.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>function*</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function*",
-          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "49"

--- a/javascript/operators/greater_than.json
+++ b/javascript/operators/greater_than.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Greater than (<code>a &gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Greater_than",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/greater_than_or_equal.json
+++ b/javascript/operators/greater_than_or_equal.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Greater than or equal (<code>a &gt;= b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Grouping operator <code>()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Grouping",
-          "spec_url": "https://tc39.es/ecma262/#sec-grouping-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-grouping-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -4,7 +4,7 @@
       "in": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/in",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/increment.json
+++ b/javascript/operators/increment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Increment (<code>++</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Increment",
-          "spec_url": "https://tc39.es/ecma262/#sec-postfix-increment-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-postfix-increment-operator",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/javascript/operators/inequality.json
+++ b/javascript/operators/inequality.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Inequality (<code>a != b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Inequality",
-          "spec_url": "https://tc39.es/ecma262/#sec-equality-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -4,7 +4,7 @@
       "instanceof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/instanceof",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/left_shift.json
+++ b/javascript/operators/left_shift.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise left shift (<code>a &lt;&lt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Left_shift",
-          "spec_url": "https://tc39.es/ecma262/#sec-left-shift-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-left-shift-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/left_shift_assignment.json
+++ b/javascript/operators/left_shift_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Left shift assignment (<code>x &lt;&lt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Left_shift_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/less_than.json
+++ b/javascript/operators/less_than.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Less than (<code>a &lt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Less_than",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/less_than_or_equal.json
+++ b/javascript/operators/less_than_or_equal.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Less than or equal (<code>a &lt;= b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal",
-          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_and.json
+++ b/javascript/operators/logical_and.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical AND (<code>&amp;&amp;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_AND",
-          "spec_url": "https://tc39.es/ecma262/#prod-LogicalANDExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalANDExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_and_assignment.json
+++ b/javascript/operators/logical_and_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical AND assignment (<code>x &amp;&amp;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/javascript/operators/logical_not.json
+++ b/javascript/operators/logical_not.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical NOT (<code>!</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_NOT",
-          "spec_url": "https://tc39.es/ecma262/#sec-logical-not-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-logical-not-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_nullish_assignment.json
+++ b/javascript/operators/logical_nullish_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical nullish assignment (<code>x ??= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/javascript/operators/logical_or.json
+++ b/javascript/operators/logical_or.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical OR (<code>||</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_OR",
-          "spec_url": "https://tc39.es/ecma262/#prod-LogicalORExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalORExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_or_assignment.json
+++ b/javascript/operators/logical_or_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Logical OR assignment (<code>x ||= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/javascript/operators/multiplication.json
+++ b/javascript/operators/multiplication.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Multiplication (<code>*</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Multiplication",
-          "spec_url": "https://tc39.es/ecma262/#sec-multiplicative-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/multiplication_assignment.json
+++ b/javascript/operators/multiplication_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Multiplication assignment (<code>x *= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -4,7 +4,7 @@
       "new": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new",
-          "spec_url": "https://tc39.es/ecma262/#sec-new-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-new-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>new.target</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new.target",
-          "spec_url": "https://tc39.es/ecma262/#sec-built-in-function-objects",
+          "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Nullish coalescing operator (<code>??</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator",
-          "spec_url": "https://tc39.es/ecma262/#prod-CoalesceExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-CoalesceExpression",
           "support": {
             "chrome": {
               "version_added": "80"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Object initializer",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer",
-          "spec_url": "https://tc39.es/ecma262/#sec-object-initializer",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-object-initializer",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Optional chaining operator (<code>?.</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining",
-          "spec_url": "https://tc39.es/ecma262/#prod-OptionalExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-OptionalExpression",
           "support": {
             "chrome": [
               {

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Property accessors",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_Accessors",
-          "spec_url": "https://tc39.es/ecma262/#sec-property-accessors",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-property-accessors",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/remainder.json
+++ b/javascript/operators/remainder.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Remainder (<code>%</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Remainder",
-          "spec_url": "https://tc39.es/ecma262/#sec-multiplicative-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/remainder_assignment.json
+++ b/javascript/operators/remainder_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Remainder assignment (<code>x %= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Remainder_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/right_shift.json
+++ b/javascript/operators/right_shift.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise right shift (<code>a &gt;&gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift",
-          "spec_url": "https://tc39.es/ecma262/#prod-BitwiseORExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseORExpression",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/right_shift_assignment.json
+++ b/javascript/operators/right_shift_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Right shift assignment (<code>x &gt;&gt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -6,7 +6,7 @@
           "__compat": {
             "description": "Spread in array literals",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_array_literals",
-            "spec_url": "https://tc39.es/ecma262/#sec-array-initializer",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -133,7 +133,7 @@
           "__compat": {
             "description": "Spread in object literals",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals",
-            "spec_url": "https://tc39.es/ecma262/#sec-object-initializer",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-object-initializer",
             "support": {
               "chrome": {
                 "version_added": "60"

--- a/javascript/operators/strict_equality.json
+++ b/javascript/operators/strict_equality.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Strict equality (<code>a === b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Strict_equality",
-          "spec_url": "https://tc39.es/ecma262/#sec-equality-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/strict_inequality.json
+++ b/javascript/operators/strict_inequality.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Strict inequality (<code>a !== b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Strict_inequality",
-          "spec_url": "https://tc39.es/ecma262/#sec-equality-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/subtraction.json
+++ b/javascript/operators/subtraction.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Subtraction (<code>-</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction",
-          "spec_url": "https://tc39.es/ecma262/#sec-subtraction-operator-minus",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-subtraction-operator-minus",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/subtraction_assignment.json
+++ b/javascript/operators/subtraction_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Subtraction assignment (<code>x -= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -4,7 +4,7 @@
       "super": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/super",
-          "spec_url": "https://tc39.es/ecma262/#sec-super-keyword",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-super-keyword",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -4,7 +4,7 @@
       "this": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/this",
-          "spec_url": "https://tc39.es/ecma262/#sec-this-keyword",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-this-keyword",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -4,7 +4,7 @@
       "typeof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof",
-          "spec_url": "https://tc39.es/ecma262/#sec-typeof-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-typeof-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unary_negation.json
+++ b/javascript/operators/unary_negation.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Unary negation (<code>-</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unary_negation",
-          "spec_url": "https://tc39.es/ecma262/#sec-unary-minus-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-minus-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unary_plus.json
+++ b/javascript/operators/unary_plus.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Unary plus (<code>+</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unary_plus",
-          "spec_url": "https://tc39.es/ecma262/#sec-unary-plus-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-plus-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unsigned_right_shift.json
+++ b/javascript/operators/unsigned_right_shift.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise unsigned right shift (<code>a &gt;&gt;&gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift",
-          "spec_url": "https://tc39.es/ecma262/#sec-unsigned-right-shift-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unsigned-right-shift-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unsigned_right_shift_assignment.json
+++ b/javascript/operators/unsigned_right_shift_assignment.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Unsigned right shift assignment (<code>x &gt;&gt;&gt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment",
-          "spec_url": "https://tc39.es/ecma262/#sec-assignment-operators",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -4,7 +4,7 @@
       "void": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void",
-          "spec_url": "https://tc39.es/ecma262/#sec-void-operator",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-void-operator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -4,7 +4,7 @@
       "yield": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield",
-          "spec_url": "https://tc39.es/ecma262/#prod-YieldExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-YieldExpression",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>yield*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield*",
-          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions-runtime-semantics-evaluation",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>async function</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -69,7 +69,7 @@
         "__compat": {
           "description": "<code>async function*</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function*",
-          "spec_url": "https://tc39.es/ecma262/#sec-async-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "63"
@@ -132,7 +132,7 @@
       "block": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/block",
-          "spec_url": "https://tc39.es/ecma262/#sec-block",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-block",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -184,7 +184,7 @@
       "break": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/break",
-          "spec_url": "https://tc39.es/ecma262/#sec-break-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-break-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -236,7 +236,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/class",
-          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "support": {
             "chrome": [
               {
@@ -374,7 +374,7 @@
       "const": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/const",
-          "spec_url": "https://tc39.es/ecma262/#sec-let-and-const-declarations",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations",
           "support": {
             "chrome": {
               "version_added": "21"
@@ -434,7 +434,7 @@
       "continue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/continue",
-          "spec_url": "https://tc39.es/ecma262/#sec-continue-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-continue-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -486,7 +486,7 @@
       "debugger": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/debugger",
-          "spec_url": "https://tc39.es/ecma262/#sec-debugger-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-debugger-statement",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -539,7 +539,7 @@
         "__compat": {
           "description": "<code>do...while</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/do...while",
-          "spec_url": "https://tc39.es/ecma262/#sec-do-while-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-do-while-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -592,7 +592,7 @@
         "__compat": {
           "description": "Empty statement (<code>;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/Empty",
-          "spec_url": "https://tc39.es/ecma262/#sec-empty-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-empty-statement",
           "support": {
             "chrome": {
               "version_added": "3"
@@ -644,7 +644,7 @@
       "export": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
-          "spec_url": "https://tc39.es/ecma262/#sec-exports",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -754,7 +754,7 @@
           "__compat": {
             "description": "<code>default</code> keyword with <code>export</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
-            "spec_url": "https://tc39.es/ecma262/#sec-exports",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -865,7 +865,7 @@
           "__compat": {
             "description": "<code>export * as namespace</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
-            "spec_url": "https://tc39.es/ecma262/#sec-exports",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
             "support": {
               "chrome": {
                 "version_added": "72"
@@ -918,7 +918,7 @@
       "for": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for",
-          "spec_url": "https://tc39.es/ecma262/#sec-for-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -971,7 +971,7 @@
         "__compat": {
           "description": "<code>for await...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of",
-          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "63"
@@ -1036,7 +1036,7 @@
         "__compat": {
           "description": "<code>for...in</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...in",
-          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1089,7 +1089,7 @@
         "__compat": {
           "description": "<code>for...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...of",
-          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -1246,7 +1246,7 @@
         "__compat": {
           "description": "<code>function</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
-          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1350,7 +1350,7 @@
         "__compat": {
           "description": "<code>function*</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function*",
-          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -1567,7 +1567,7 @@
         "__compat": {
           "description": "<code>if...else</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/if...else",
-          "spec_url": "https://tc39.es/ecma262/#sec-if-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-if-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1619,7 +1619,7 @@
       "import": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import",
-          "spec_url": "https://tc39.es/ecma262/#sec-imports",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-imports",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -1907,7 +1907,7 @@
           "description": "<code>import.meta</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import.meta",
           "spec_url": [
-            "https://tc39.es/ecma262/#prod-ImportMeta",
+            "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ImportMeta",
             "https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties"
           ],
           "support": {
@@ -1961,7 +1961,7 @@
       "label": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/label",
-          "spec_url": "https://tc39.es/ecma262/#sec-labelled-statements",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-labelled-statements",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2013,7 +2013,7 @@
       "let": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let",
-          "spec_url": "https://tc39.es/ecma262/#sec-let-and-const-declarations",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations",
           "support": {
             "chrome": [
               {
@@ -2139,7 +2139,7 @@
       "return": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/return",
-          "spec_url": "https://tc39.es/ecma262/#sec-return-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-return-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2191,7 +2191,7 @@
       "switch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/switch",
-          "spec_url": "https://tc39.es/ecma262/#sec-switch-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-switch-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2243,7 +2243,7 @@
       "throw": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/throw",
-          "spec_url": "https://tc39.es/ecma262/#sec-throw-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-throw-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2296,7 +2296,7 @@
         "__compat": {
           "description": "<code>try...catch</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/try...catch",
-          "spec_url": "https://tc39.es/ecma262/#sec-try-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-try-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2399,7 +2399,7 @@
       "var": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/var",
-          "spec_url": "https://tc39.es/ecma262/#sec-variable-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-variable-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2451,7 +2451,7 @@
       "while": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/while",
-          "spec_url": "https://tc39.es/ecma262/#sec-while-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-while-statement",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2503,7 +2503,7 @@
       "with": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/with",
-          "spec_url": "https://tc39.es/ecma262/#sec-with-statement",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-with-statement",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This change switches all spec URLs from the ES spec to the multipage version of the spec at https://tc39.es/ecma262/multipage/ (rather than the single-page version). The changes were generated using the script at https://gist.github.com/sideshowbarker/9941751896b23b5465a0469f41255e3c