### PR TITLE
Set {before,after}scriptexecute_event to unsupported in IE

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -624,7 +624,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -1421,7 +1421,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
#### Summary

IE doesn't support the Firefox-only `beforescriptexecute` and `afterscriptexecute` events.

Also, I hadn't opened a PR with the new PR template and I wanted to see what it was like.

#### Test results and supporting details

There's [an example on MDN](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html) which I lightly modified to run on IE 11. It failed, unsurprisingly. This aligns with the data for the event handlers, which also report no IE support.

#### Related issues

Fixes #10298.