### PR TITLE
svg.elements.stop.stop-opacity: fix order of support statements

### DIFF
--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -177,11 +177,11 @@
               },
               "safari_ios": [
                 {
-                  "version_added": "3",
-                  "version_removed": "11"
+                  "version_added": "14"
                 },
                 {
-                  "version_added": "14"
+                  "version_added": "3",
+                  "version_removed": "11"
                 }
               ],
               "samsunginternet_android": {


### PR DESCRIPTION

#### Summary

@foolip pointed out that these support statements are out of order in https://github.com/mdn/browser-compat-data/pull/9468/files#r636796045.