### PR TITLE
Add Opera 75, Opera Android 63 and Edge 89 support for top level await

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -109,6 +109,7 @@
                 },
                 {
                   "version_added": "73",
+                  "version_removed": "75",
                   "flags": [
                     {
                       "type": "preference",

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -76,7 +76,7 @@
                 "version_added": "89"
               },
               "edge": {
-                "version_added": false
+                "version_added": "89"
               },
               "firefox": {
                 "version_added": "89"
@@ -103,17 +103,22 @@
                   "notes": "Not supported in CommonJS modules."
                 }
               ],
-              "opera": {
-                "version_added": "73",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-javascript-harmony"
-                  }
-                ]
-              },
+              "opera": [
+                {
+                  "version_added": "75"
+                },
+                {
+                  "version_added": "73",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony"
+                    }
+                  ]
+                }
+              ],
               "opera_android": {
-                "version_added": false
+                "version_added": "63"
               },
               "safari": {
                 "version_added": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds Opera 75, Opera Android 63 and Edge 89 (which are all based on Chromium 89) support for await at the top level of a module.

#### Test results and supporting details
Tested in Opera 75 and Edge 92 (which are the version I have access to)
