### PR TITLE
Fix release date for Safari 14.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -175,7 +175,7 @@
           "engine_version": "610.1.28"
         },
         "14.1": {
-          "release_date": "2020-04-26",
+          "release_date": "2021-04-26",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "611.1.21.161.3"


### PR DESCRIPTION
Release date for Safari 14.1 was listed as 2020 not 2021. This fixes that.
