### PR TITLE
Update `text-indent` `each-line` and `hanging` keywords for Safari TP

### DIFF
--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "TP"
               },
               "safari_ios": {
                 "version_added": false
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "TP"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "TP"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "TP"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Added TP for Safari as Release 124 resolves `each-line` and `hanging` keywords for `text-indent` property

#### Test results and supporting details
https://bugs.webkit.org/show_bug.cgi?id=223851
