### PR TITLE
Set Chrome 91 as stable chrome.

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -623,19 +623,26 @@
         "90": {
           "release_date": "2021-04-13",
           "release_notes": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop_14.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
-          "status": "beta",
+          "release_date": "2021-05-25",
+          "release_notes": "https://chromereleases.googleblog.com/2021/05/stable-channel-update-for-desktop_25.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "93": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "93"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -460,19 +460,26 @@
         "90": {
           "release_date": "2021-04-13",
           "release_notes": "https://chromereleases.googleblog.com/2021/04/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
-          "status": "beta",
+          "release_date": "2021-05-25",
+          "release_notes": "https://chromereleases.googleblog.com/2021/05/chrome-for-android-update_01607414128.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "93": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "93"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -424,19 +424,26 @@
         "90": {
           "release_date": "2021-04-13",
           "release_notes": "https://chromereleases.googleblog.com/2021/04/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
-          "status": "beta",
+          "release_date": "2021-05-25",
+          "release_notes": "https://chromereleases.googleblog.com/2021/05/chrome-for-android-update_01607414128.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "93": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "93"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 91 was just launched to stable channel.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://chromereleases.googleblog.com/2021/05/stable-channel-update-for-desktop_25.html

https://chromereleases.googleblog.com/2021/05/chrome-for-android-update_01607414128.html

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
