### PR TITLE
[Chrome] Bug 1041095: Implement `[attr=val s]`

### DIFF
--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -103,16 +103,31 @@
             "description": "Case-sensitive modifier (<code>s</code>)",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
+                "version_added": "90",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSCaseSensitiveSelector"
+                  }
+                ]
               },
               "chrome_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
+                "version_added": "90",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSCaseSensitiveSelector"
+                  }
+                ]
               },
               "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
+                "version_added": "90",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSCaseSensitiveSelector"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "66"
@@ -124,8 +139,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
+                "version_added": "76",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSCaseSensitiveSelector"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This is now implemented in **Chromium 90**.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- <https://crbug.com/1041095>
- <https://github.com/chromium/chromium/commit/0e98f25e95f15b5cd36ad86d6e1d12872e4c29ed>
- <https://storage.googleapis.com/chromium-find-releases-static/0e9.html#0e98f25e95f15b5cd36ad86d6e1d12872e4c29ed>

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- <https://github.com/mdn/browser-compat-data/pull/5472>

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
