### PR TITLE
Add notes to Barcode Detector API compatibility

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -6,13 +6,17 @@
         "spec_url": "https://wicg.github.io/shape-detection-api/#barcode-detection-api",
         "support": {
           "chrome": {
-            "version_added": "83"
+            "version_added": "83",
+            "partial_implementation": true,
+            "notes": "Supported on macOS only."
           },
           "chrome_android": {
             "version_added": "83"
           },
           "edge": {
-            "version_added": "83"
+            "version_added": "83",
+            "partial_implementation": true,
+            "notes": "Supported on macOS only."
           },
           "firefox": {
             "version_added": false
@@ -24,7 +28,9 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": true,
+            "partial_implementation": true,
+            "notes": "Supported on macOS only."
           },
           "opera_android": {
             "version_added": true
@@ -55,13 +61,17 @@
           "description": "<code>BarcodeDetector()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "chrome_android": {
               "version_added": "83"
             },
             "edge": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "firefox": {
               "version_added": false
@@ -73,7 +83,9 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "opera_android": {
               "version_added": true
@@ -104,13 +116,17 @@
           "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-detect",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "chrome_android": {
               "version_added": "83"
             },
             "edge": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "firefox": {
               "version_added": false
@@ -122,7 +138,9 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "opera_android": {
               "version_added": true
@@ -153,13 +171,17 @@
           "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-getsupportedformats",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "chrome_android": {
               "version_added": "83"
             },
             "edge": {
-              "version_added": "83"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "firefox": {
               "version_added": false
@@ -171,7 +193,9 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
             },
             "opera_android": {
               "version_added": true


### PR DESCRIPTION
#### Summary

Note that the Barcode Detector API is only available in Chrome on Android and macOS.

#### Test results and supporting details

See #10649

https://www.chromestatus.com/feature/4757990523535360

#### Related issues

Fixes #7184
Fixes #9030
Fixes #10649


