### PR TITLE
adding note to clarify execCommand() behavior on input and textarea

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4247,7 +4247,7 @@
               "version_added": "1",
               "notes": [
                 "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>.",
-                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
               ]
             },
             "firefox_android": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -4245,11 +4245,17 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
+              "notes": [
+                "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>.",
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+              ]
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>."
+              "notes": [
+                "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>.",
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+              ]
             },
             "ie": {
               "version_added": "4"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4254,7 +4254,7 @@
               "version_added": "4",
               "notes": [
                 "From Firefox 82, nested calls are not supported (return <code>false</code>). See <a href='https://bugzil.la/1634262'>bug 1634262</a>.",
-                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
               ]
             },
             "ie": {

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -21,7 +21,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
             },
             "ie": {
               "version_added": true

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -16,10 +16,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
             },
             "ie": {
               "version_added": true

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -17,7 +17,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+              "notes": "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
             },
             "firefox_android": {
               "version_added": "4",

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -19,14 +19,16 @@
               "version_added": true,
               "notes": [
                 "Before Firefox 6, when a <code>&lt;textarea&gt;</code> was focused, the insertion point was placed at the end of the text by default. Other major browsers place the insertion point at the beginning of the text.",
-                "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>."
+                "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>.",
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
               ]
             },
             "firefox_android": {
               "version_added": true,
               "notes": [
                 "Before Firefox 6, when a <code>&lt;textarea&gt;</code> was focused, the insertion point was placed at the end of the text by default. Other major browsers place the insertion point at the beginning of the text.",
-                "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>."
+                "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>.",
+                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
               ]
             },
             "ie": {

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -20,7 +20,7 @@
               "notes": [
                 "Before Firefox 6, when a <code>&lt;textarea&gt;</code> was focused, the insertion point was placed at the end of the text by default. Other major browsers place the insertion point at the beginning of the text.",
                 "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>.",
-                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+                "Before Firefox 89, manipulating the content of <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
               ]
             },
             "firefox_android": {

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -28,7 +28,7 @@
               "notes": [
                 "Before Firefox 6, when a <code>&lt;textarea&gt;</code> was focused, the insertion point was placed at the end of the text by default. Other major browsers place the insertion point at the beginning of the text.",
                 "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>.",
-                "Before Firefox 89, manipulating the content of <code>&lt;input&gt;</code> and <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands required workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a> for details)."
+                "Before Firefox 89, manipulating the content of <code>&lt;textarea&gt;</code> elements using <code>Document.execCommand()</code> commands requires workarounds (see <a href='https://bugzil.la/1220696'>bug 1220696</a>)."
               ]
             },
             "ie": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1220696

Discussed with @ddbeck over slack.