### PR TITLE
Adds clear method to MIDIOutput

### DIFF
--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -51,6 +51,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/clear",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-clear",
           "support": {
             "chrome": {
               "version_added": false,

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -3,6 +3,7 @@
     "MIDIOutput": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput",
+        "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIOutput",
         "support": {
           "chrome": {
             "version_added": "43"
@@ -45,6 +46,55 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "clear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/clear",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/471798'>bug 471798</a>."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "send": {


### PR DESCRIPTION
#### Summary

Adds the `clear()` method to MIDIOutput, also adds the spec url.

#### Test results and supporting details

Background info https://github.com/mdn/content/pull/5390
