### PR TITLE
Change Android WebView from 1 to ≤37 for API U-Z

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -88,7 +88,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -351,7 +351,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": "1",
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -431,7 +431,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": "1",
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -511,7 +511,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": "1",
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -6858,7 +6858,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -252,7 +252,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -85,7 +85,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -138,7 +138,7 @@
               "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Chrome only supports string values."
             }
           },
@@ -187,7 +187,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -235,7 +235,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -283,7 +283,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -336,7 +336,7 @@
               "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Chrome only supports string values."
             }
           },
@@ -392,7 +392,7 @@
               "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             }
           },
@@ -448,7 +448,7 @@
               "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
-              "version_added": "1",
+              "version_added": "≤37",
               "notes": "Chrome returns <code>null</code>if an error occurs."
             }
           },


### PR DESCRIPTION
A general rule of thumb that I heard and have been going by when updating BCD for WebView Android is that anything added in Chrome 1 will be present in WebView Android 1.  However, looking at the difference in WebKit versions (528 for Chrome 1 vs. 523.12 for WebView Android 1), it's simply not plausible that this statement is true -- and after getting my hands on an Android 1.0 emulator, I've confirmed my suspicions.  A more accurate rule of thumb would be that "anything present in Safari 3 will be in WebView Android 1".

This PR changes various entries set to WebView Android 1.0 to our range of `≤37` instead after running the mdn-bcd-collector in Android 1.0 and comparing the results to our data.  I plan to follow up and replace these ranged values with proper version numbers in the future.

