### PR TITLE
Added compat info for lab(), lch(), color()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -594,7 +594,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -196,7 +196,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "TP"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false
@@ -441,7 +441,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "TP"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false
@@ -491,7 +491,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "TP"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -196,7 +196,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "TP"
               },
               "safari_ios": {
                 "version_added": false
@@ -410,6 +410,106 @@
             }
           }
         },
+        "lab": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/lab()",
+            "spec_url": "https://drafts.csswg.org/css-color-4/#specifying-lab-lch",
+            "description": "Lab color values (<code>lab()</code>)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "TP"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "lch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/lch()",
+            "spec_url": "https://drafts.csswg.org/css-color-4/#specifying-lab-lch",
+            "description": "LCH color values (<code>lch()</code>)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "TP"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "keyword_color_values": {
           "__compat": {
             "description": "Keyword color values",
@@ -455,6 +555,56 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "color_function": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color()",
+            "spec_url": "https://drafts.csswg.org/css-color-4/#icc-colors",
+            "description": "<code>color()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

I used `"TP"` for features that are in Safari TP and have not yet shipped. I also asked [here](https://github.com/mdn/browser-compat-data/issues/2991#issuecomment-850355950).
Note that Safari 10 only supported color(display-p3). The other predefined color spaces were added recently and are still in TP. We can iterate on breaking this down in future PRs.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
[Testcase for `color(display-p3)`](https://result.dabblet.com/gist/f491f94dba0af1dfccffa24c46e770e5/7e79347a06ba4256297cc593dd24845d79efd0dd)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://webkit.org/blog/11555/release-notes-for-safari-technology-preview-121/
https://webkit.org/blog/11548/release-notes-for-safari-technology-preview-120/
https://webkit.org/blog/7477/new-web-features-in-safari-10-1/#:~:text=css%20wide-gamut%20colors

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
