### PR TITLE
Added Opera Android support for ::file-selector-button

### DIFF
--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -54,7 +54,7 @@
             ],
             "opera_android": [
               {
-                "version_added": false
+                "version_added": "63"
               },
               {
                 "version_added": "14",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

With the release of Opera Android 63, it's now based on Chromium 89 which added support for the `::file-selector-button` pseudo element.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on Opera Android 63.3.3216 with this jsfiddle: https://jsfiddle.net/jtcnurwo/
