### PR TITLE
Added Edge support for ::backdrop

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -30,10 +30,16 @@
                 "version_added": "32"
               }
             ],
-            "edge": {
-              "prefix": "-ms-",
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "47"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added Edge support for the standard ::backdrop pseudo element as of version 79 (when Edge migrated to chromium).

Also marked ms prefix as not supported from version 79.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Chrome has supported this since version 37.
