### PR TITLE
Added Opera Android support for ::target-text

### DIFF
--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -29,7 +29,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

With the release of Opera Android 63, it's now based on Chromium 89 which added support for the `::target-text` pseudo element.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on Opera Android 63.3.3216 with this demo: https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance
