### PR TITLE
Upgrades Edge to version 91

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -126,19 +126,26 @@
         "90": {
           "release_date": "2021-04-15",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-90081839-april-15",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
-          "status": "beta",
+          "release_date": "2021-05-27",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-91086437-may-27",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "93": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "93"
         }
       }
     }


### PR DESCRIPTION
According to the [release notes](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-91086437-may-27), Edge has been updated to version 91.

This PR keeps the `browsers/edge.json` file up to date.

Closes #10669.