### PR TITLE
proxy settings: FTP support removed in FF90

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -534,7 +534,7 @@
               },
               "firefox": {
                 "version_added": "60",
-                "notes": "From version 88, the <code>ftp</code> setting has no effect because FTP is no longer supported (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
+                "notes": "Version 90 removes the <code>ftp</code> setting (see <a href='https://bugzil.la/1574475'>bug 1574475</a>). This setting was disabled in version 88."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
FTP was disabled in FF88 and we added [a note BCD here](https://github.com/mdn/browser-compat-data/blob/main/webextensions/api/proxy.json#L537)

In FF90 the code is actually removed - https://bugzilla.mozilla.org/show_bug.cgi?id=157447

This updates the note.