### PR TITLE
Firefox 90 supports HTTP Fetch Sec-Fetch- headers

### DIFF
--- a/http/headers/sec-fetch-dest.json
+++ b/http/headers/sec-fetch-dest.json
@@ -16,10 +16,10 @@
               "version_added": "80"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "ie": {
               "version_added": false
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/sec-fetch-mode.json
+++ b/http/headers/sec-fetch-mode.json
@@ -16,10 +16,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "ie": {
               "version_added": false
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/sec-fetch-site.json
+++ b/http/headers/sec-fetch-site.json
@@ -16,10 +16,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "ie": {
               "version_added": false
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/sec-fetch-user.json
+++ b/http/headers/sec-fetch-user.json
@@ -16,10 +16,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "ie": {
               "version_added": false
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Firefox 90 adds support for the Fetch metadata request headers in https://bugzilla.mozilla.org/show_bug.cgi?id=1695911

This PR adds the version support for the four headers for FF90 for desktop and android. As this is now supported by 2 major browsers I have also changed to `experimental: false` (is that OK??)

Associated docs for this will be tracked in https://github.com/mdn/content/issues/5375