### PR TITLE
Update FetchEvent for Safari 11.1

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -34,7 +34,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -84,7 +84,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -427,7 +427,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -486,7 +486,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -632,7 +632,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -31,7 +31,7 @@
             "version_added": "27"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
             "version_added": false
@@ -81,7 +81,7 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false
@@ -424,7 +424,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false
@@ -483,7 +483,7 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false
@@ -629,7 +629,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Added what is in the prototype on Safari 11.1.2

#### Summary
I noticed there's a mismatch between [caniuse/mdn](https://caniuse.com/mdn-api_fetchevent_respondwith) and [Jake's website](https://jakearchibald.github.io/isserviceworkerready/#fetchevent.request) on the `FetchEvent#respondWith`. I have added what I noticed is present in the Safari 11.1 FetchEvent prototype. 

#### Test results and supporting details
I used [Jake Archibald's website](https://jakearchibald.github.io/isserviceworkerready/#fetchevent.request) to test in browserstack, then set a debug point to get the prototype of the FetchEvent

Here's a screenshot of using browserstack showcasing:

- FetchEvent prototype
- Safari 11.1.2 versions

![image](https://user-images.githubusercontent.com/47995834/120145584-195d7380-c227-11eb-8778-bf1eb2674f00.png)

#### Related issues
<!-- ✅ After submitting, review the results of the "Checks" tab! -->


