### PR TITLE
Test for outdated spec URLs that aren't in w3c/browser-specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -213,6 +213,12 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-specs": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/browser-specs/-/browser-specs-1.38.1.tgz",
+      "integrity": "sha512-AlsiRTsTepSTPg6+GaMBh0fKOuwl02np4jBg8oPFrR6K5l+N7f0SsR7daIOGFC36zzB4aeYFcp6rG468EbMYsw==",
+      "dev": true
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "ajv": "~6.12.2",
     "better-ajv-errors": "~0.7.0",
+    "browser-specs": "~1.38.1",
     "chalk": "~4.1.0",
     "compare-versions": "~3.6.0",
     "mdn-confluence": "~2.2.2",

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -1,0 +1,96 @@
+'use strict';
+const assert = require('assert');
+const specData = require('browser-specs');
+const { visit } = require('../utils');
+
+describe('spec_url data', () => {
+  it('spec_url specifications only use allow listed hosts by w3c/browser-specs (and those we allow list for now)', () => {
+    const toVisit = [
+      'api',
+      'css',
+      'html',
+      'http',
+      'javascript',
+      'mathml',
+      'svg',
+      'webdriver',
+    ];
+
+    let specURLs = [];
+    for (const key of toVisit) {
+      visit(
+        (path, feature) => {
+          if (feature.spec_url) {
+            if (Array.isArray(feature.spec_url)) {
+              specURLs.push(...feature.spec_url);
+            } else {
+              specURLs.push(feature.spec_url);
+            }
+          }
+        },
+        {
+          entryPoint: key,
+        },
+      );
+    }
+
+    let specsNotInBrowserSpecs = [];
+    specURLs.forEach(url => {
+      let spec = specData.find(
+        spec =>
+          url.startsWith(spec.url) ||
+          url.startsWith(spec.nightly.url) ||
+          url.startsWith(spec.series.nightlyUrl),
+      );
+      if (!spec) {
+        specsNotInBrowserSpecs.push(url.split('#')[0]);
+      }
+    });
+
+    let uniqueSpecsNotInBrowserSpecs = [
+      ...new Set(specsNotInBrowserSpecs.sort()),
+    ];
+
+    let temporaryAllowList = [
+      'https://wicg.github.io/controls-list/',
+      'https://w3c.github.io/webrtc-extensions/',
+      'https://w3c.github.io/setImmediate/',
+      'https://datatracker.ietf.org/doc/html/rfc2397',
+      'https://datatracker.ietf.org/doc/html/rfc8942',
+      'https://datatracker.ietf.org/doc/html/rfc7231',
+      'https://datatracker.ietf.org/doc/html/rfc7233',
+      'https://datatracker.ietf.org/doc/html/rfc7234',
+      'https://datatracker.ietf.org/doc/html/rfc7838',
+      'https://datatracker.ietf.org/doc/html/rfc8246',
+      'https://datatracker.ietf.org/doc/html/rfc7230',
+      'https://datatracker.ietf.org/doc/html/rfc6266',
+      'https://datatracker.ietf.org/doc/html/rfc7578',
+      'https://datatracker.ietf.org/doc/html/rfc6265',
+      'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05',
+      'https://datatracker.ietf.org/doc/html/rfc8470',
+      'https://datatracker.ietf.org/doc/html/rfc7232',
+      'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08',
+      'https://datatracker.ietf.org/doc/html/rfc7239',
+      'https://datatracker.ietf.org/doc/html/draft-thomson-hybi-http-timeout-03',
+      'https://datatracker.ietf.org/doc/html/rfc6454',
+      'https://datatracker.ietf.org/doc/html/rfc7235',
+      'https://datatracker.ietf.org/doc/html/rfc7469',
+      'https://datatracker.ietf.org/doc/html/rfc6797',
+      'https://datatracker.ietf.org/doc/html/rfc7540',
+      'https://datatracker.ietf.org/doc/html/rfc7034',
+      'https://datatracker.ietf.org/doc/html/rfc7538',
+      'https://datatracker.ietf.org/doc/html/rfc2324',
+      'https://datatracker.ietf.org/doc/html/rfc7725',
+      'https://github.com/tc39/proposal-regexp-legacy-features/',
+      'https://webassembly.github.io/threads/js-api/',
+      'https://tc39.es/proposal-hashbang/out.html',
+      'https://tc39.es/proposal-pipeline-operator/',
+      'https://mathml-refresh.github.io/mathml/',
+    ].sort();
+
+    // Ideally browser-specs has all relevant specs included
+    // and so uniqueSpecsNotInBrowserSpecs should be []
+    // However, for the moment we need an allow list
+    assert.deepStrictEqual(uniqueSpecsNotInBrowserSpecs, temporaryAllowList);
+  });
+});

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -52,7 +52,6 @@ describe('spec_url data', () => {
       'https://github.com/tc39/proposal-regexp-legacy-features/',
       'https://webassembly.github.io/threads/js-api/',
       'https://tc39.es/proposal-hashbang/out.html',
-      'https://tc39.es/proposal-pipeline-operator/',
       'https://mathml-refresh.github.io/mathml/',
       'https://www.w3.org/TR/xpath-31/',
       'https://www.w3.org/TR/xslt-30/',

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -21,7 +21,6 @@ describe('spec_url data', () => {
 
     const specsExceptions = [
       'https://wicg.github.io/controls-list/',
-      'https://w3c.github.io/webrtc-extensions/',
       'https://w3c.github.io/setImmediate/',
       'https://datatracker.ietf.org/doc/html/rfc2397',
       'https://datatracker.ietf.org/doc/html/rfc8942',


### PR DESCRIPTION
We need to keep our specification URLs current to always provide the recommended and most up-to-date spec_urls as specified by w3c/browser-specs.

Therefore we should check all of our spec_urls against the w3c/browser-spec repository. The repo includes almost all of the BCD spec hosts but a few are missing still and so I've added a temporal allow list.

This PR fails because in main BCD doesn't use the recommend spec for ECMAScript right now. https://github.com/mdn/browser-compat-data/pull/10615 fixes that.

This adds a dev dependency to w3c/browser-specs. Sometimes, when dependabot asks us to update to a new version of browser-specs, it might fail the build because there a recommended spec from browser-specs has changed. Just like it is the case now with ECMAScript. So the idea is that this will add a mechanism that keeps spec urls up to date and relevant.

(I've never written a mocha test for BCD, please take it apart. Edit: I'm not happy with the error message, so maybe we can improve that if the overall approach of this PR makes sense.)