### PR TITLE
Demix ElementCSSInlineStyle

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1252,54 +1252,6 @@
           }
         }
       },
-      "attributeStyleMap": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attributeStyleMap",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "auxclick_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/auxclick_event",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3201,55 +3201,6 @@
           }
         }
       },
-      "style": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementCSSInlineStyle/style",
-          "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "5.5"
-            },
-            "opera": {
-              "version_added": "8"
-            },
-            "opera_android": {
-              "version_added": "10.1"
-            },
-            "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "tabIndex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/tabIndex",

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -18,7 +18,7 @@
             "version_added": "71"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -30,10 +30,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": false

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -15,7 +15,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1"
+            "version_added": "1.5"
           },
           "firefox_android": {
             "version_added": "4"

--- a/api/_mixins/ElementCSSInlineStyle__HTMLElement.json
+++ b/api/_mixins/ElementCSSInlineStyle__HTMLElement.json
@@ -1,0 +1,103 @@
+{
+  "api": {
+    "HTMLElement": {
+      "attributeStyleMap": {
+        "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-elementcssinlinestyle-attributestylemap",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "5.5"
+            },
+            "opera": {
+              "version_added": "8"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/_mixins/ElementCSSInlineStyle__MathMLElement.json
+++ b/api/_mixins/ElementCSSInlineStyle__MathMLElement.json
@@ -1,0 +1,54 @@
+{
+  "api": {
+    "MathMLElement": {
+      "style": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "79"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.4"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/_mixins/ElementCSSInlineStyle__SVGElement.json
+++ b/api/_mixins/ElementCSSInlineStyle__SVGElement.json
@@ -1,0 +1,102 @@
+{
+  "api": {
+    "SVGElement": {
+      "attributeStyleMap": {
+        "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-elementcssinlinestyle-attributestylemap",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Tests used (staging because a test bug was just fixed):
http://staging-dot-mdn-bcd-collector.appspot.com/tests/api/HTMLElement
http://staging-dot-mdn-bcd-collector.appspot.com/tests/api/MathMLElement
http://staging-dot-mdn-bcd-collector.appspot.com/tests/api/SVGElement

As a starting point, the existing api.Element.attributeStyleMap and
api.HTMLElement.style entries were combined into
ElementCSSInlineStyle__HTMLElement.json without modification.

MathMLElement data is based on mdn-bcd-collector results from Firefox
and Safari desktop. Mobile data was mirrored. The api.MathMLElement
parent entry was also updated. Note that there's no
api.MathMLElement.attributeStyleMap entry because no browser supports
it.

SVGElement data is hard to be 100% confident in because it goes back so
far. api.SVGElement.style support was confirmed in:
 - Chrome ≤15
 - IE 9
 - Firefox ≤4
 - Opera ≤12.1
 - Safari ≤4

The following were assumed/mirrored:
 - Chrome 1 / for Android 18
 - Edge 12
 - Firefox 1.5 / for Android 4
 - Opera for Android ≤12.1
 - Safari 3 / for iOS 1
 - Samsung Internet 1.0
 - WebView 1

SVGElement itself was changed to Firefox 1.5 too, as the only
SVG-related entry marked as shipped in Firefox 1.