### PR TITLE
Mirror Opera Android and Samsung Internet support for flex gap

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -30,7 +30,7 @@
                 "version_added": "70"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "14.1"
@@ -39,7 +39,7 @@
                 "version_added": "14.5"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "84"

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -30,7 +30,7 @@
                 "version_added": "70"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "14.1"
@@ -39,7 +39,7 @@
                 "version_added": "14.5"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "84"


### PR DESCRIPTION
This is incorrectly making support seem less complete than it is:
https://developer.mozilla.org/en-US/docs/Web/CSS/gap#support_in_flex_layout