### PR TITLE
Improve XSLTProcessor notes

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -108,7 +108,8 @@
               "notes": "Chrome only supports string values."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Edge only supports string values."
             },
             "firefox": {
               "version_added": true
@@ -128,10 +129,12 @@
               "notes": "Opera only supports string values."
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Safari only supports string values."
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "2",
+              "notes": "Safari only supports string values."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -139,7 +142,7 @@
             },
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Chrome only supports string values."
+              "notes": "WebView only supports string values."
             }
           },
           "status": {
@@ -306,7 +309,8 @@
               "notes": "Chrome only supports string values."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Edge only supports string values."
             },
             "firefox": {
               "version_added": true
@@ -326,10 +330,12 @@
               "notes": "Opera only supports string values."
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Safari only supports string values."
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "2",
+              "notes": "Safari only supports string values."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -337,7 +343,7 @@
             },
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Chrome only supports string values."
+              "notes": "WebView only supports string values."
             }
           },
           "status": {
@@ -353,14 +359,15 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "Chrome returns <code>null</code> if an error occurs."
             },
             "chrome_android": {
               "version_added": "18",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "Chrome returns <code>null</code> if an error occurs."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Edge returns <code>null</code> if an error occurs."
             },
             "firefox": {
               "version_added": true,
@@ -375,25 +382,33 @@
             },
             "opera": {
               "version_added": "≤12.1",
-              "notes": "Opera returns <code>null</code>if an error occurs."
+              "notes": [
+                "Opera 12.1 and earlier throws an exception if an error occurs.",
+                "Opera 15 and later returns <code>null</code> if an error occurs."
+              ]
             },
             "opera_android": {
               "version_added": "≤12.1",
-              "notes": "Opera returns <code>null</code>if an error occurs."
+              "notes": [
+                "Opera Android 12.1 and earlier throws an exception if an error occurs.",
+                "Opera Android 14 and later returns <code>null</code> if an error occurs."
+              ]
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Safari returns <code>null</code> if an error occurs."
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "2",
+              "notes": "Safari returns <code>null</code> if an error occurs."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
-              "notes": "Samsung Internet returns <code>null</code>if an error occurs."
+              "notes": "Samsung Internet returns <code>null</code> if an error occurs."
             },
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "WebView returns <code>null</code> if an error occurs."
             }
           },
           "status": {
@@ -409,14 +424,15 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "Chrome returns <code>null</code> if an error occurs."
             },
             "chrome_android": {
               "version_added": "18",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "Chrome returns <code>null</code> if an error occurs."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Edge returns <code>null</code> if an error occurs."
             },
             "firefox": {
               "version_added": true,
@@ -431,25 +447,33 @@
             },
             "opera": {
               "version_added": "≤12.1",
-              "notes": "Opera returns <code>null</code>if an error occurs."
+              "notes": [
+                "Opera 12.1 and earlier throws an exception if an error occurs.",
+                "Opera 15 and later returns <code>null</code> if an error occurs."
+              ]
             },
             "opera_android": {
               "version_added": "≤12.1",
-              "notes": "Opera returns <code>null</code>if an error occurs."
+              "notes": [
+                "Opera Android 12.1 and earlier throws an exception if an error occurs.",
+                "Opera Android 14 and later returns <code>null</code> if an error occurs."
+              ]
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Safari returns <code>null</code> if an error occurs."
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "2",
+              "notes": "Safari returns <code>null</code> if an error occurs."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
-              "notes": "Samsung Internet returns <code>null</code>if an error occurs."
+              "notes": "Samsung Internet returns <code>null</code> if an error occurs."
             },
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Chrome returns <code>null</code>if an error occurs."
+              "notes": "WebView returns <code>null</code> if an error occurs."
             }
           },
           "status": {


### PR DESCRIPTION
A space after &lt;/code> was missing, but while in the area...

Test for whether non-string parameters are supported:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9342

Test for whether transformTo* throws or return null on error:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9344

Testing revealed the following:
- Safari 14.1 only supports string values and return null on error.
  This matches Chrome, as expected since this started out in WebKit.
- Edge 18 only supports string values and return null on error.
- Opera 12.16 only supports string values, but throws on error.

This unfortunately requires more notes for Opera in order to capture
what happened.