### PR TITLE
Add exact versions for insertRule optional index

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -305,22 +305,22 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "55"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "≤15"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": "≤14"
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "1"


### PR DESCRIPTION
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9347 was
used to confirm it was optional in the following browsers:
 - Chrome ≤15
 - Edge ≤13 (not optional in IE11)
 - Firefox 55 (not optional in 54)
 - Opera 15 (not optional in 12.16)
 - Safari ≤4

Assumed/mirrored data:
 - Edge 12
 - Firefox for Android 55
 - Opera for Android 14