### PR TITLE
Add exact versions for toggle force argument

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -790,7 +790,7 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "24"
@@ -802,10 +802,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "≤15"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": "≤14"
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6.1"


### PR DESCRIPTION
Follow-up to https://github.com/mdn/browser-compat-data/pull/8482, using
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=8808 to
confirm support in Edge 13 and Opera 15, and a lack of support in Opera
12.16. Edge 12 is assumed but not confirmed with the test.