### PR TITLE
Replace Opera ≤15 versions with something more precise

### DIFF
--- a/css/properties/-webkit-tap-highlight-color.json
+++ b/css/properties/-webkit-tap-highlight-color.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -25,10 +25,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"


### PR DESCRIPTION
http://mdn-bcd-collector.appspot.com/tests/api/SVGFECompositeElement
shows support for the interface corresponding to SVG's <feComposite>
element.

http://mdn-bcd-collector.appspot.com/tests/css/properties/-webkit-tap-highlight-color
shows no support in Presto, but it is in Opera 15.

Tested on Opera 12.16 + 15 on Windows 7.