### PR TITLE
Update DOMException versions to show support in Opera 12.1

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -24,10 +24,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "≤15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "≤14"
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1"
@@ -122,10 +122,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -171,10 +171,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -220,10 +220,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"


### PR DESCRIPTION
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9351 causes
a DOMException to be thrown in order to test an instance, showing
support in Opera 12.16 on Windows 7. Support like goes back to much
earlier, but very old versions aren't available on BrowserStack.

mdn-bcd-collector is also being updated to get an instance in this way:
https://github.com/foolip/mdn-bcd-collector/pull/1192