### PR TITLE
Add support of WebKitCSSMatrix alias in Firefox

### DIFF
--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -23,10 +23,10 @@
             }
           ],
           "firefox": {
-            "version_added": null
+            "version_added": "49"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "49"
           },
           "ie": [
             {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added support info in Firefox for WebKitCSSMatrix

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=717722#c37 for the info about the pref guarding it.
https://bugzilla.mozilla.org/show_bug.cgi?id=1259345 for the prefix to be pref'ed on.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
