### PR TITLE
Add Chromium versions for api.CloseEvent.CloseEvent

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -59,10 +59,10 @@
           "description": "<code>CloseEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": null
@@ -89,10 +89,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CloseEvent` member of the `CloseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent/CloseEvent
