### PR TITLE
Add Chromium versions for ExtendableMessageEvent API

### DIFF
--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/ServiceWorker/#extendablemessageevent-interface",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "51"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "51"
           },
           "edge": {
             "version_added": "17"
@@ -25,10 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "38"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "41"
           },
           "safari": {
             "version_added": false
@@ -37,10 +37,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "51"
           }
         },
         "status": {
@@ -56,10 +56,10 @@
           "description": "<code>ExtendableMessageEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": "17"
@@ -75,10 +75,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -87,10 +87,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -140,7 +140,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -156,10 +156,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#extendablemessage-event-lasteventid",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": "17"
@@ -175,10 +175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -187,10 +187,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -206,10 +206,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#extendablemessage-event-origin",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": "17"
@@ -224,10 +224,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -236,10 +236,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -255,10 +255,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#extendablemessage-event-ports",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": "17"
@@ -274,10 +274,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -286,10 +286,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -305,10 +305,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#extendablemessage-event-source",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "edge": {
               "version_added": "17"
@@ -324,10 +324,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -336,10 +336,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ExtendableMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ExtendableMessageEvent

Note: this also changes WebView from `false` to `51`.  Running the collector on WebView, I confirmed there is support.