### PR TITLE
Add Chromium versions for api.FetchEvent.targetClientId

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -56,7 +56,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-fetchevent",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "44"
             },
             "chrome_android": {
               "version_added": "40"
@@ -105,7 +105,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/client",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "44"
@@ -203,7 +203,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/isReload",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": "45"
@@ -254,7 +254,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "59"
@@ -400,7 +400,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-request",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
               "version_added": true
@@ -449,7 +449,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-respondwith",
           "support": {
             "chrome": {
-              "version_added": "42",
+              "version_added": "38> ≤40",
               "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
             },
             "chrome_android": {
@@ -605,13 +605,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/targetClientId",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -623,10 +623,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -635,10 +635,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -56,7 +56,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-fetchevent",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"
@@ -105,7 +105,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/client",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "44"
@@ -203,7 +203,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/isReload",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "45"
             },
             "chrome_android": {
               "version_added": "45"
@@ -254,7 +254,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "59"
             },
             "chrome_android": {
               "version_added": "59"
@@ -400,7 +400,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-request",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
               "version_added": true
@@ -449,7 +449,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-respondwith",
           "support": {
             "chrome": {
-              "version_added": "38> ≤40",
+              "version_added": "42",
               "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
             },
             "chrome_android": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `targetClientId` member of the `FetchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent/targetClientId
