### PR TITLE
Add Chromium versions for RTCPeerConnectionIceErrorEvent API

### DIFF
--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/webrtc-pc/#rtcpeerconnectioniceerrorevent",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "77"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "77"
           },
           "edge": {
             "version_added": "79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "55"
           },
           "safari": {
             "version_added": "14.1"
@@ -36,10 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "12.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "77"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/errorCode",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "77"
             },
             "edge": {
               "version_added": "79"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": "14.1"
@@ -83,10 +83,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "77"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/errorText",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "77"
             },
             "edge": {
               "version_added": "79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": "14.1"
@@ -131,10 +131,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "77"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/hostCandidate",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "77"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -179,10 +179,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "77"
             }
           },
           "status": {
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/url",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "77"
             },
             "edge": {
               "version_added": "79"
@@ -215,10 +215,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "safari": {
               "version_added": "14.1"
@@ -227,10 +227,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "77"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCPeerConnectionIceErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnectionIceErrorEvent
