### PR TITLE
Add Chromium versions for api.Request.Request.referrer_init

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -255,10 +255,10 @@
             "description": "<code>referrer</code> init option",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "47"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "47"
               },
               "edge": {
                 "version_added": "15"
@@ -273,10 +273,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "34"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "34"
               },
               "safari": {
                 "version_added": "10.1"
@@ -285,10 +285,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "47"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Request.referrer_init` member of the `Request` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/6b3.html#6b324faa61bbfbf09ca255a14078992a17af3e59
