### PR TITLE
Add Chromium versions for SVGAltGlyphItemElement API

### DIFF
--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "≤15",
+            "version_added": "15",
             "version_removed": "27"
           },
           "opera_android": {

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -30,7 +30,7 @@
             "version_removed": "27"
           },
           "opera_android": {
-            "version_added": "≤14",
+            "version_added": "14",
             "version_removed": "27"
           },
           "safari": {

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -6,10 +6,12 @@
         "spec_url": "https://www.w3.org/TR/SVG11/text.html#InterfaceSVGAltGlyphItemElement",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "14",
+            "version_removed": "40"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18",
+            "version_removed": "40"
           },
           "edge": {
             "version_added": false
@@ -24,10 +26,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "≤15",
+            "version_removed": "27"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "≤14",
+            "version_removed": "27"
           },
           "safari": {
             "version_added": "6"
@@ -36,10 +40,12 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "version_removed": "4.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "≤37",
+            "version_removed": "40"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAltGlyphItemElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAltGlyphItemElement
