### PR TITLE
Add Chromium versions for api.ServiceWorkerGlobalScope

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -694,40 +694,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/oncanmakepayment",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": null
@@ -739,10 +713,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "safari": {
               "version_added": null
@@ -751,7 +725,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1161,40 +1161,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onpaymentrequest",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "57",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
             "chrome_android": {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": null

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1063,7 +1063,7 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerglobalscope-onnotificationclick",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1334,7 +1334,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-serviceworkerglobalscope-onpushsubscriptionchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -404,16 +404,21 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onabortpayment",
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": "61",
               "flags": [
@@ -715,16 +720,21 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/oncanmakepayment",
           "support": {
-            "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": "61",
               "flags": [
@@ -1030,10 +1040,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessageerror",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "81"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "edge": {
               "version_added": null
@@ -1048,10 +1058,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
               "version_added": true
@@ -1060,10 +1070,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "81"
             }
           },
           "status": {
@@ -1079,7 +1089,7 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerglobalscope-onnotificationclick",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1129,7 +1139,7 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerglobalscope-onnotificationclose",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "50"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1177,16 +1187,21 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onpaymentrequest",
           "support": {
-            "chrome": {
-              "version_added": "57",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "57",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": "57",
               "flags": [
@@ -1295,7 +1310,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-serviceworkerglobalscope-onpush",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1345,7 +1360,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-serviceworkerglobalscope-onpushsubscriptionchange",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": {
               "version_added": "40"
@@ -1596,7 +1611,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-registration",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1693,7 +1708,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-skipwaiting",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "41"
             },
             "chrome_android": {
               "version_added": "40"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1087,7 +1087,7 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerglobalscope-onnotificationclose",
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1533,7 +1533,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-registration",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"
@@ -1630,7 +1630,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-skipwaiting",
           "support": {
             "chrome": {
-              "version_added": "41"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -404,40 +404,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onabortpayment",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": null

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1232,7 +1232,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-serviceworkerglobalscope-onpush",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
               "version_added": "40"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.0.2).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope

Additionally, this does a little bit of flag cleanup to simplify the data.