### PR TITLE
Add Chromium versions for WebGLVertexArrayObjectOES API

### DIFF
--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -6,10 +6,10 @@
         "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.6",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
             "version_added": "17"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -6,10 +6,10 @@
         "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.6",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "24"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "25"
           },
           "edge": {
             "version_added": "17"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "14"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WebGLVertexArrayObjectOES` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (pending PR).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGLVertexArrayObjectOES
