### PR TITLE
Add Chromium versions for WorkerNavigator API

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -6,10 +6,10 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#the-workernavigator-object",
         "support": {
           "chrome": {
-            "version_added": "31"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "31"
+            "version_added": true
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": "18"
+            "version_added": true
           },
           "opera_android": {
-            "version_added": "18"
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -36,10 +36,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": true
           },
           "webview_android": {
-            "version_added": "4.4.3"
+            "version_added": true
           }
         },
         "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -6,10 +6,10 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#the-workernavigator-object",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "31"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "31"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "18"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "safari": {
             "version_added": true
@@ -36,10 +36,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -202,10 +202,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#navigator-serviceworker",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": true
@@ -232,10 +232,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WorkerNavigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerNavigator
