### PR TITLE
Add Chromium versions for api.Headers.lexicographical_sorting

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -844,13 +844,13 @@
           "description": "Lexicographical sorting, and values from duplicate header names combined when iterated.",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "57"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44"
@@ -862,10 +862,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "28"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -874,10 +874,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "57"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `lexicographical_sorting` member of the `Headers` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/abb.html#abbafbc0bacfca5beada1e3d1a5299569e0a5262 / https://storage.googleapis.com/chromium-find-releases-static/da6.html#da6e2412d9e3547954e1196c3b8d523be7090df6
