### PR TITLE
Set api.Permission.camera_permission value

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -255,10 +255,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Set api.Permission.camera_permission value for Firefox & Firefox Android

Fixes #9855
