### PR TITLE
index.js: only perform extend() if there's data to add

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function load() {
 
     // The JSON data is independent of the actual file
     // hierarchy, so it is essential to extend "deeply".
-    extend(result, extra);
+    if (extra) extend(result, extra);
   }
 
   for (dir of arguments) {


### PR DESCRIPTION
This PR resolves an issue I have just found in the code introduced in #9821.  When I was attempting to run the tests on my own to get to the bottom of an error now found in #10724, I ended up finding another issue along the way, hence sparking the creation of this PR.

In `index.js`, the `extend()` function is coded so that it raises an error if both the target and source are not plain objects.  However, in `processFilename()`, we are initializing the source (i.e. the `extra` variable) with no value; in other words, `undefined`.  We then set the value of `extra` to the value from the JSON file we're trying to load, or the iteration of the directory.  But what if the JSON file load crashes, or we don't have a JSON file, such as system invisibles (namely `.DS_Store` on macOS)?  `extra` is left as `undefined`, thus causing `index.js` to throw an error and crash.

This adds a clause to tell the function to run `extend()` if, and only if, there is data to extend in the first place.

@ddbeck, this is an issue that is directly impacting my workflow, and I imagine it's impacting others too.  I don't think this affect the release bundles since we have a custom `index.js`, however it would be great to merge before the v3.3.6 release.