### PR TITLE
Add Chromium versions for api.ExtendableEvent.waitUntil.async_waitUntil

### DIFF
--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -150,13 +150,13 @@
         },
         "async_waitUntil": {
           "__compat": {
-            "description": "Asynchronous <code>waitUntil</code>",
+            "description": "<code>waitUntil</code> may be called asynchronously",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "60"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "edge": {
                 "version_added": "17"
@@ -171,10 +171,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "47"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "44"
               },
               "safari": {
                 "version_added": false
@@ -183,10 +183,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "60"
               }
             },
             "status": {

--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -153,10 +153,10 @@
             "description": "Asynchronous <code>waitUntil</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": "17"
@@ -171,10 +171,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -183,10 +183,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `waitUntil.async_waitUntil` member of the `ExtendableEvent` API, based upon commit history.

Reasoning: Return type is void and has never changed to any other return type
Related line: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/service_worker/extendable_event.idl;l=36;bpv=0;bpt=0