### PR TITLE
adding spec and MDN URLs.

### DIFF
--- a/api/OTPCredential.json
+++ b/api/OTPCredential.json
@@ -2,6 +2,8 @@
   "api": {
     "OTPCredential": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/OTPCredential",
+        "spec_url": "https://wicg.github.io/web-otp/#OTPCredential",
         "support": {
           "chrome": {
             "version_added": false
@@ -48,6 +50,8 @@
       },
       "code": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OTPCredential/code",
+          "spec_url": "https://wicg.github.io/web-otp/#dom-otpcredential-code",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
I'm documenting OTPCredential. We already have compat data, this PR updates to add the MDN URLs which will exist shortly, and the spec URLs:

Spec: https://wicg.github.io/web-otp/#OTPCredential