### PR TITLE
Copy data from api.PaymentRequest.onmerchantvalidation to its event

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -263,13 +263,13 @@
           "description": "<code>merchantvalidation</code> event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false,
@@ -283,19 +283,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR copies the data from `api.PaymentRequest.onmerchantvalidation` to `api.PaymentRequest.merchantvalidation_event`.  Looking through Chrome's source, I don't see any indication that the event is supported, and I highly doubt that the event handler would be missing if the event itself were implemented.
