### PR TITLE
Remove outdated setImmediate spec

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1165,7 +1165,6 @@
       "clearImmediate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/clearImmediate",
-          "spec_url": "https://w3c.github.io/setImmediate/#si-clearImmediate",
           "support": {
             "chrome": {
               "version_added": false
@@ -8944,7 +8943,6 @@
       "setImmediate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setImmediate",
-          "spec_url": "https://w3c.github.io/setImmediate/#si-setImmediate",
           "support": {
             "chrome": {
               "version_added": false

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -21,7 +21,6 @@ describe('spec_url data', () => {
 
     const specsExceptions = [
       'https://wicg.github.io/controls-list/',
-      'https://w3c.github.io/setImmediate/',
       'https://datatracker.ietf.org/doc/html/rfc2397',
       'https://datatracker.ietf.org/doc/html/rfc8942',
       'https://datatracker.ietf.org/doc/html/rfc7231',


### PR DESCRIPTION
This is no real spec, so we should remove it. Going to create a content PR, too.
standard_track is already false, too.

See https://github.com/w3c/browser-specs/issues/306