### PR TITLE
Set api.RTCPtpReceiver.getCapabilities as unsupported by Firefox

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -110,10 +110,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Set api.RTCPtpReceiver.getCapabilities value for Firefox & Firefox Android

Fixes #9786 
