### PR TITLE
Ensure that extend's second argument is not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,18 +11,24 @@ function load() {
     const fp = path.join(dir, fn);
     let extra;
 
-    // If the given filename is a directory, recursively load it.
     if (fs.statSync(fp).isDirectory()) {
+      // If the given filename is a directory, recursively load it.
       extra = load(fp);
     } else if (path.extname(fp) === '.json') {
       try {
         extra = JSON.parse(fs.readFileSync(fp));
-      } catch (e) {}
+      } catch (e) {
+        // Skip invalid JSON. Tests will flag the problem separately.
+        return;
+      }
+    } else {
+      // Skip anything else, such as *~ backup files or similar.
+      return;
     }
 
     // The JSON data is independent of the actual file
     // hierarchy, so it is essential to extend "deeply".
-    if (extra) extend(result, extra);
+    extend(result, extra);
   }
 
   for (dir of arguments) {


### PR DESCRIPTION
Most importantly, be explicit about skipping things that aren't
directories or *.json files. Also skip extend() for invalid JSON and
explain why that's actually OK.
