### PR TITLE
Safari desktop supports module workers as of 14.1, mobile as of 15

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -171,7 +171,7 @@
                 "version_added": "57"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -174,7 +174,7 @@
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "13.0"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -174,7 +174,7 @@
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari desktop supports module workers as of 14.1

No mention in the release note, but a [blogger covered it](https://levelup.gitconnected.com/safari-webkit-about-to-release-support-for-js-modules-inside-the-worker-scope-9dd33fc20190).
