### PR TITLE
Update data for Service Worker APIs shipped in Safari 11.1 / iOS 11.3

### DIFF
--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -31,10 +31,10 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -81,10 +81,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -130,10 +130,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -177,10 +177,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -31,10 +31,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -81,10 +81,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -131,10 +131,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -181,10 +181,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -230,10 +230,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -280,10 +280,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -330,10 +330,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -179,10 +179,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -430,10 +430,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -579,10 +579,10 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1054,10 +1054,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -80,10 +80,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -180,10 +180,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
The Safari 11.1 data comes from mdn-bcd-collector 3.1.4 results for
Safari 11 and 11.1. The iOS 11.3 data was confirmed by older collector
results for just iOS 11.3:
https://github.com/foolip/mdn-bcd-results/pull/1815

Other than the tests being wrong, the only room for error is that some
of this could have been shipped earlier in iOS, but in context that is
very unlikely and not worth verifying further.

Finally, the async_waitUntil is based on WebKit source, where the
current comment in ExtendableEvent::waitUntil makes it clear it's
supported, and the latest change to it was in trunk version 605.1.13
which predates the Safari 11.1 version:
https://trac.webkit.org/changeset/224584/webkit#file19
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=224584