### PR TITLE
Mark ServiceWorkerContainer.onerror as supported only in Firefox

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -305,45 +305,46 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/onerror",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
               "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "notes": "See <a href='https://bugzil.la/1714533'>bug 1714533</a>."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "44",
+              "notes": "See <a href='https://bugzil.la/1714533'>bug 1714533</a>."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": false
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": true
           }


### PR DESCRIPTION
The existing data was incorrect.

https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerContainer/onerror
was used to manually confirm no support in:
 - Chrome 90
 - Edge 18 (also checked `navigator.serviceWorker.onerror`)
 - Safari 14.1

Additionally, the string "onerror" has never appeared in Chromium or
WebKit source, confirmed with `git log -S onerror` on these files:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/service_worker/service_worker_container.idl;l=1;drc=af69d93ec0d5334cdc03316058660a37116f32b3
https://github.com/WebKit/WebKit/blob/217b2531a97f217b61eb4f501666291e2a64a14f/Source/WebCore/workers/service/ServiceWorkerContainer.idl

https://bugzilla.mozilla.org/show_bug.cgi?id=1714533 was filed and
linked for Firefox. The ESR notes aren't important here.

Finally, this can't be considered experimental, more like accidental.