### PR TITLE
Add all browsers versions for Point API

### DIFF
--- a/api/Point.json
+++ b/api/Point.json
@@ -5,13 +5,19 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Point",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "2",
+            "version_removed": "39",
+            "prefix": "WebKit"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18",
+            "version_removed": "39",
+            "prefix": "WebKit"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12",
+            "version_removed": "79",
+            "prefix": "WebKit"
           },
           "firefox": {
             "version_added": false
@@ -20,27 +26,35 @@
             "version_added": false
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "15",
+            "version_removed": "26",
+            "prefix": "WebKit"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "14",
+            "version_removed": "26",
+            "prefix": "WebKit"
           },
           "safari": {
-            "version_added": true,
+            "version_added": "4",
             "prefix": "WebKit"
           },
           "safari_ios": {
-            "version_added": true,
+            "version_added": "3.2",
             "prefix": "WebKit"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "version_removed": "4.0",
+            "prefix": "WebKit"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "2",
+            "version_removed": "39",
+            "prefix": "WebKit"
           }
         },
         "status": {
@@ -53,13 +67,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "2",
+              "version_removed": "39"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "39"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -68,25 +85,29 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15",
+              "version_removed": "26"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "26"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "2",
+              "version_removed": "39"
             }
           },
           "status": {
@@ -100,13 +121,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "2",
+              "version_removed": "39"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "39"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -115,25 +139,29 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15",
+              "version_removed": "26"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "26"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "2",
+              "version_removed": "39"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `Point` API, based upon manual testing.

Test Code Used: `new WebKitPoint(); new MSPoint(); new OPoint(); new Point(); // AKA, trying all the different prefix variants in each browser`
