### PR TITLE
Update Chromium versions for ReadableStreamDefaultController API

### DIFF
--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -6,13 +6,13 @@
         "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "52"
+            "version_added": "89"
           },
           "chrome_android": {
-            "version_added": "52"
+            "version_added": "89"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "89"
           },
           "firefox": {
             "version_added": "65"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "39"
+            "version_added": "75"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "63"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "52"
+            "version_added": "89"
           }
         },
         "status": {
@@ -54,13 +54,13 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-close①",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "89"
             },
             "edge": {
-              "version_added": null
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "65"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "89"
             }
           },
           "status": {
@@ -103,13 +103,13 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-desired-size②",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "89"
             },
             "edge": {
-              "version_added": null
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "65"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "89"
             }
           },
           "status": {
@@ -152,13 +152,13 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-enqueue①",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "89"
             },
             "edge": {
-              "version_added": null
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "65"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -182,10 +182,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "89"
             }
           },
           "status": {
@@ -201,13 +201,13 @@
           "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-error",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "89"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "89"
             },
             "edge": {
-              "version_added": null
+              "version_added": "89"
             },
             "firefox": {
               "version_added": "65"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -231,10 +231,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "89"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ReadableStreamDefaultController` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableStreamDefaultController
