### PR TITLE
Update Chromium versions for ReadableStreamDefaultReader API

### DIFF
--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -6,10 +6,10 @@
         "spec_url": "https://streams.spec.whatwg.org/#default-reader-class",
         "support": {
           "chrome": {
-            "version_added": "52"
+            "version_added": "78"
           },
           "chrome_android": {
-            "version_added": "52"
+            "version_added": "78"
           },
           "edge": {
             "version_added": "79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "39"
+            "version_added": "65"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "56"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "12.0"
           },
           "webview_android": {
-            "version_added": "52"
+            "version_added": "78"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "description": "<code>ReadableStreamDefaultReader()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -85,10 +85,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "78"
             }
           },
           "status": {
@@ -104,10 +104,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-generic-reader-cancel②",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -134,10 +134,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "78"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-generic-reader-closed②",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -183,10 +183,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "78"
             }
           },
           "status": {
@@ -202,10 +202,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-read①",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -232,10 +232,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "78"
             }
           },
           "status": {
@@ -251,10 +251,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-reader-release-lock②",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "65"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "56"
             },
             "safari": {
               "version_added": false
@@ -281,10 +281,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "78"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ReadableStreamDefaultReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableStreamDefaultReader
