### PR TITLE
Add Chromium versions for RTCIdentityProviderRegistrar API

### DIFF
--- a/api/RTCIdentityProviderRegistrar.json
+++ b/api/RTCIdentityProviderRegistrar.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIdentityProviderRegistrar",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": null
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": null
@@ -35,10 +35,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
@@ -52,13 +52,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIdentityProviderRegistrar/register",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -82,10 +82,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCIdentityProviderRegistrar` API, based upon commit history and date.

Commit: No IDL in the source code, other than the web tests
