### PR TITLE
Chrome doesn't implement strict MIME checks for Workers

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -110,13 +110,13 @@
             "description": "Strict MIME type checks for shared worker scripts",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "81"
@@ -128,7 +128,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -110,13 +110,16 @@
             "description": "Strict MIME type checks for shared worker scripts",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "firefox": {
                 "version_added": "81"
@@ -128,10 +131,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "safari": {
                 "version_added": false
@@ -140,10 +145,12 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               }
             },
             "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -195,13 +195,16 @@
             "description": "Strict MIME type checks for worker scripts",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "firefox": {
                 "version_added": "81"
@@ -213,10 +216,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "safari": {
                 "version_added": null
@@ -225,10 +230,12 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               }
             },
             "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -195,13 +195,13 @@
             "description": "Strict MIME type checks for worker scripts",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "81"
@@ -213,10 +213,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -225,10 +225,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets Chromium to false for `api.[Shared]Worker.[Shared]Worker.mime_checks`.  Looking through the code, I can't find anything that suggests that Chrome checks the MIME type and enforces `text/javascript`.  Additionally, [wpt.fyi](https://wpt.fyi/results/workers/Worker_script_mimetype.htm?label=master&product=chrome%5Bexperimental%5D&product=chrome%5Bstable%5D&aligned) indicates that in the latest stable Chrome, it does not.
