### PR TITLE
Add Chromium versions for api.SourceBuffer.trackDefaults

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -1045,10 +1045,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/trackDefaults",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -1060,12 +1063,21 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
               "version_added": false
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `trackDefaults` member of the `SourceBuffer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SourceBuffer/trackDefaults
