### PR TITLE
Add Chromium versions for api.URL.createObjectURL.no_MediaStream_argument

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -229,10 +229,10 @@
             "description": "No longer accepts <code>MediaStream</code> object",
             "support": {
               "chrome": {
-                "version_added": "72"
+                "version_added": "71"
               },
               "chrome_android": {
-                "version_added": "72"
+                "version_added": "71"
               },
               "edge": {
                 "version_added": "79"
@@ -250,10 +250,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "60"
+                "version_added": "59"
               },
               "opera_android": {
-                "version_added": "51"
+                "version_added": "50"
               },
               "safari": {
                 "version_added": null,
@@ -264,10 +264,10 @@
                 "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
               },
               "samsunginternet_android": {
-                "version_added": "11.0"
+                "version_added": "10.0"
               },
               "webview_android": {
-                "version_added": "72"
+                "version_added": "71"
               }
             },
             "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -229,16 +229,13 @@
             "description": "No longer accepts <code>MediaStream</code> object",
             "support": {
               "chrome": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "72"
               },
               "chrome_android": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "72"
               },
               "edge": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "62"
@@ -247,18 +244,16 @@
                 "version_added": "62"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": false
               },
               "opera": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "51"
               },
               "safari": {
                 "version_added": null,
@@ -269,12 +264,10 @@
                 "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
               },
               "samsunginternet_android": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "11.0"
               },
               "webview_android": {
-                "version_added": null,
-                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
+                "version_added": "72"
               }
             },
             "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -250,7 +250,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "59"
+                "version_added": "60"
               },
               "opera_android": {
                 "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createObjectURL.no_MediaStream_argument` member of the `URL` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/742.html#7422130d3da18b70d4cc81951feda2ab615edef9
