### PR TITLE
Sort out FetchEvent data

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -100,54 +100,6 @@
           }
         }
       },
-      "client": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/client",
-          "support": {
-            "chrome": {
-              "version_added": "42"
-            },
-            "chrome_android": {
-              "version_added": "44"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "27"
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "42"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "clientId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/clientId",
@@ -248,55 +200,6 @@
           }
         }
       },
-      "navigationPreload": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/navigationPreload",
-          "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload",
-          "support": {
-            "chrome": {
-              "version_added": "59"
-            },
-            "chrome_android": {
-              "version_added": "59"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "46"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
-            "webview_android": {
-              "version_added": "59"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "preloadResponse": {
         "__compat": {
           "support": {
@@ -310,10 +213,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -356,14 +259,13 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "65"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -375,10 +277,14 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "alternative_name": "targetClientId",
+              "version_added": "11.1",
+              "notes": "See <a href='https://webkit.org/b/226638'>bug 226638</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "alternative_name": "targetClientId",
+              "version_added": "11.3",
+              "notes": "See <a href='https://webkit.org/b/226638'>bug 226638</a>."
             },
             "samsunginternet_android": {
               "version_added": false
@@ -563,7 +469,7 @@
               "version_added": "72"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "65"
@@ -597,54 +503,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "targetClientId": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/targetClientId",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": "11.1"
-            },
-            "safari_ios": {
-              "version_added": "11.3"
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
There was an unusual amount wrong here...

The current state of things in source:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/service_worker/fetch_event.idl;drc=fc05b522c6d4a85354c9d6f39b76c3d7f8448b68
https://github.com/mozilla/gecko-dev/blob/a4c86edb340aeee2b91a2ab617c66cb4ea7b7b66/dom/webidl/FetchEvent.webidl
https://github.com/WebKit/WebKit/blob/af262cabe3e5b067a177fb4203a7112f14028092/Source/WebCore/workers/service/FetchEvent.idl

The client attribute is removed as irrelevant as it actually never
shipped in Chrome, it was landed and reverted in 2015 and didn't reach
stable, and was removed in Gecko in 2015 before FetchEvent shipped:
https://chromium.googlesource.com/chromium/src/+/4e79b14a361c3960c11a2139df74a315b915c740
https://chromium.googlesource.com/chromium/src/+/ade5cc571923215463317b3212f7a50683f79038
https://github.com/mozilla/gecko-dev/commit/7029e804f87ef631b5307756f5b0f21c8d6c8b92

The navigationPreload attribute was the original name for
preloadResponse, but was renamed in Chromium before it reached stable:
https://chromium.googlesource.com/chromium/src/+/111601216214188fc2ace390da5b2af0095564fd
https://chromium.googlesource.com/chromium/src/+/95d26e23d47ff912eefe1d1caa7dc67552b3ffae

The preloadResponse attribute isn't in Gecko/WebKit source, see above.

The replacesClientId attribute turns out to not be in the source of any
engine (see above) and test shows it actually wasn't in Edge 18 either:
https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent/replacesClientId

As a minor error, the resultingClientId attribute also wasn't in Edge 18:
https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent/resultingClientId

Finally, the targetClientId was shipped in Safari, but in the spec it
was renamed to replacesClientId (see above) which hasn't shipped in any
browser: https://github.com/w3c/ServiceWorker/pull/1333

Nevertheless, treat Safari's targetClientId as an alternative name for
replacesClientId to combine the entries.