### PR TITLE
Add Chromium/Safari versions for api.Window.postMessage.transfer_argument_support

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6872,10 +6872,10 @@
             "description": "<code>transfer</code> argument",
             "support": {
               "chrome": {
-                "version_added": "38"
+                "version_added": "4"
               },
               "chrome_android": {
-                "version_added": "38"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -6890,10 +6890,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": "25"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "25"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": null
@@ -6902,10 +6902,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "3.0"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "38"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -6896,10 +6896,10 @@
                 "version_added": "≤14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "5"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "4"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -6872,10 +6872,10 @@
             "description": "<code>transfer</code> argument",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -6890,10 +6890,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "safari": {
                 "version_added": null
@@ -6902,10 +6902,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "38"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) and Safari (Desktop and iOS/iPadOS) for the `postMessage.transfer_argument_support` member of the `Window` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/d0cf776d6ff039396acb08430e64567eb311c08a (by commit date of September 3, 2009 for Chrome 4)
