### PR TITLE
Firefox 90 aliases webkit-image-set() to image-set()

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1930,21 +1930,32 @@
                 "prefix": "-webkit-",
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "88",
-                "notes": [
-                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
-                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>.",
-                  "In Firefox 90, <code>-webkit-image-set()</code> was aliased to <code>image-set()</code>."
-                ]
-              },
-              "firefox_android": {
-                "version_added": "88",
-                "notes": [
-                  "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
-                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "88",
+                  "notes": [
+                    "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
+                    "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                  ]
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "90"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "88",
+                  "notes": [
+                    "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
+                    "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                  ]
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "90"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1934,7 +1934,8 @@
                 "version_added": "88",
                 "notes": [
                   "In <code>cursor</code> and <code>content</code> properties, gradients are not supported as arguments to <code>image-set()</code>. See <a href='https://bugzil.la/1696314'>bug 1696314</a>.",
-                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>."
+                  "Before Firefox 89, the <code>type()</code> function is not supported as an argument to <code>image-set()</code>.",
+                  "In Firefox 90, <code>-webkit-image-set()</code> was aliased to <code>image-set()</code>."
                 ]
               },
               "firefox_android": {


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/5379

Adds a note that `webkit-image-set()` has been aliased to `image-set()`.