### PR TITLE
Fix a few CSSOM View spec URLs

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6868,7 +6868,7 @@
       "scroll": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scroll",
-          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scroll-options-options",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scroll",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -7015,7 +7015,7 @@
       "scrollBy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollBy",
-          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollby-options-options",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollby",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -7466,7 +7466,7 @@
       "scrollTo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollTo",
-          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollto-options-options",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollto",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
The previous URLs were into the IDL blocks, not the method definitions
themselves.
