### PR TITLE
Add WebView versions for api.XRSessionMode.immersive-ar

### DIFF
--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -87,7 +87,7 @@
               "version_added": "12.1"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "81"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `immersive-ar` member of the `XRSessionMode` API, based upon manual testing.

Test Code Used: `Copied data from Chrome Android`
