### PR TITLE
Add Chrome Android versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1389,6 +1389,9 @@
             "chrome": {
               "version_added": false
             },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -3485,6 +3488,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
           "support": {
             "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
               "version_added": false
             },
             "edge": {


### PR DESCRIPTION
This PR adds real values for Chrome Android for the `HTMLMediaElement` API, specifically the `fastSeek` and `seekToNextFrame` members, by mirroring the data.
