### PR TITLE
Add Chromium versions for api.SourceBuffer.appendStream

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -248,6 +248,9 @@
             "chrome": {
               "version_added": false
             },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12",
               "version_removed": "79"
@@ -264,10 +267,19 @@
             "opera": {
               "version_added": false
             },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": null
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
               "version_added": false
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `appendStream` member of the `SourceBuffer` API by mirroring the data.
