### PR TITLE
Add Chromium versions for SourceBuffer API

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -626,6 +626,9 @@
             "chrome": {
               "version_added": "53"
             },
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "17"
             },
@@ -640,10 +643,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "8"
@@ -651,8 +654,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "53"
             }
           },
           "status": {
@@ -669,6 +675,9 @@
             "chrome": {
               "version_added": "53"
             },
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "17"
             },
@@ -683,10 +692,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "8"
@@ -694,8 +703,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "53"
             }
           },
           "status": {
@@ -712,6 +724,9 @@
             "chrome": {
               "version_added": "53"
             },
+            "chrome_android": {
+              "version_added": "53"
+            },
             "edge": {
               "version_added": "17"
             },
@@ -726,10 +741,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "8"
@@ -737,8 +752,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "53"
             }
           },
           "status": {
@@ -755,47 +773,7 @@
             "chrome": {
               "version_added": "53"
             },
-            "edge": {
-              "version_added": "17"
-            },
-            "firefox": {
-              "version_added": "42"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": "11",
-              "notes": "Only works on Windows 8+."
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "8"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "4.4.3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onupdatestart": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onupdatestart",
-          "support": {
-            "chrome": {
+            "chrome_android": {
               "version_added": "53"
             },
             "edge": {
@@ -812,10 +790,10 @@
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "8"
@@ -823,8 +801,60 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onupdatestart": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/onupdatestart",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "11",
+              "notes": "Only works on Windows 8+."
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "8"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SourceBuffer` API, based upon information in a tracking bug.

Tracking Bug: https://www.chromestatus.com/feature/5696773133697024
