### PR TITLE
Add Chromium versions for VideoPlaybackQuality API

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -8,6 +8,9 @@
           "chrome": {
             "version_added": "23"
           },
+          "chrome_android": {
+            "version_added": "25"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -32,6 +35,9 @@
           },
           "safari_ios": {
             "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4.3"
@@ -102,6 +108,9 @@
             "chrome": {
               "version_added": "23"
             },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -126,6 +135,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -146,6 +158,9 @@
             "chrome": {
               "version_added": "23"
             },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -171,6 +186,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -188,6 +206,9 @@
           "support": {
             "chrome": {
               "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -213,6 +234,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -233,6 +257,9 @@
             "chrome": {
               "version_added": "23"
             },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -257,6 +284,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `VideoPlaybackQuality` API by mirroring the data.
