### PR TITLE
Add Chromium/Safari versions for api.Element.mousewheel_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5413,10 +5413,10 @@
           "description": "<code>mousewheel</code> event",
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "31"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -5431,19 +5431,19 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "18"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "18"
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/Element.json
+++ b/api/Element.json
@@ -5446,7 +5446,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -5416,7 +5416,7 @@
               "version_added": "31"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "edge": {
               "version_added": "≤79"
@@ -5431,10 +5431,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
               "version_added": null
@@ -5443,10 +5443,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2687,10 +2687,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onmousewheel",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -2705,22 +2705,22 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) and Safari for the `mousewheel_event` member of the `Element` API by mirroring the data.
