### PR TITLE
Add IE versions for api.BeforeUnloadEvent.user_interaction

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -68,7 +68,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `user_interaction` member of the `BeforeUnloadEvent` API.  I have set it to `false` based upon the time when it was implemented in other browsers.  It's highly unlikely y that it was in Internet Explorer considering the timing of implementation in Chrome.
