### PR TITLE
Add IE/Edge versions for api.CanvasRenderingContext2D.drawImage

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1137,7 +1137,7 @@
                 "version_added": "42"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "17"
@@ -1187,7 +1187,7 @@
                 "notes": "See <a href='https://bugzil.la/1360415'>bug 1360415</a> for details."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -1235,7 +1235,7 @@
                 "version_added": "56"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "46"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1176,7 +1176,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "56",
@@ -1226,7 +1226,7 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "56"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `drawImage` member of the `CanvasRenderingContext2D` API, based upon a combination of manual testing, and the time of implementation in other browsers, including Firefox and Edge.