### PR TITLE
Update Chromium versions for api.ServiceWorkerGlobalScope.onpush

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1298,7 +1298,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "≤79"
@@ -1314,10 +1314,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "24"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "24"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "11.1"
@@ -1329,7 +1329,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "42"
             }
           },
           "status": {

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1295,7 +1295,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-serviceworkerglobalscope-onpush",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "40"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onpush` member of the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope/onpush
