### PR TITLE
Update IE versions for DataTransfer API

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -23,7 +23,7 @@
             "notes": "As of Firefox 52, the <a href='https://developer.mozilla.org/docs/Web/API/DataTransfer/types'><code>DataTransfer.types</code></a> property returns a frozen array of <a href='https://developer.mozilla.org/docs/Web/API/DOMString'><code>DOMString</code></a>s as per spec, rather than a <a href='https://developer.mozilla.org/docs/Web/API/DOMStringList'><code>DOMStringList</code></a>."
           },
           "ie": {
-            "version_added": "10"
+            "version_added": "8"
           },
           "opera": {
             "version_added": "12"
@@ -169,7 +169,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -218,7 +218,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -267,7 +267,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -316,7 +316,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -365,7 +365,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true
@@ -857,7 +857,7 @@
               "version_added": "10"
             },
             "ie": {
-              "version_added": false
+              "version_added": "8"
             },
             "opera": {
               "version_added": "12"
@@ -906,7 +906,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `DataTransfer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransfer
