### PR TITLE
Add IE versions for api.GlobalEventHandlers.onanimationcancel

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -118,7 +118,7 @@
               "version_added": "54"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `onanimationcancel` member of the `GlobalEventHandlers` API by mirroring the data.
