### PR TITLE
Add IE versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4312,7 +4312,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -4360,7 +4360,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `GlobalEventHandlers` API by mirroring the data.
