### PR TITLE
Add Chromium versions for DOMPointInit API

### DIFF
--- a/api/DOMPointInit.json
+++ b/api/DOMPointInit.json
@@ -6,13 +6,13 @@
         "spec_url": "https://drafts.fxtf.org/geometry/#dictdef-dompointinit",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": "61"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "61"
           },
           "edge": {
-            "version_added": null
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "62"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "48"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "45"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": "61"
           }
         },
         "status": {
@@ -54,13 +54,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointinit-w",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "61"
             }
           },
           "status": {
@@ -103,13 +103,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointinit-x",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "61"
             }
           },
           "status": {
@@ -152,13 +152,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointinit-y",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -182,10 +182,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "61"
             }
           },
           "status": {
@@ -201,13 +201,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointinit-z",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -231,10 +231,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DOMPointInit` API.  This dictionary was added into Chrome a little after DOMPoint was implemented but before it was exposed by default, so tI'm confident to set this to the same versions as DOMPoint.  See https://source.chromium.org/chromium/chromium/src/+/a23c0523692fe0ddf105a1cfbf63ca02af555c31 for the exact commit.
