### PR TITLE
Add all browsers versions for api.Window.open.once_per_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5800,13 +5800,13 @@
             "description": "One <code>Window.open()</code> call per event",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "23"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "65"
@@ -5815,25 +5815,25 @@
                 "version_added": "65"
               },
               "ie": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
-                "version_added": null
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `open.once_per_event` member of the `Window` API, based upon manual testing.

Test Code Used:
```js
document.getElementById('hello').onclick = function(e) {
  window.open('https://www.google.com');
  window.open('https://developer.mozilla.org');
}

// Based results off of whether one or both tabs opened
```
