### PR TITLE
Add IE/Edge versions for api.IDB*.worker_support

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -655,7 +655,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -664,7 +664,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -145,7 +145,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "42"
@@ -154,7 +154,7 @@
               "version_added": "42"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -848,7 +848,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -857,7 +857,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -296,7 +296,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -305,7 +305,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -849,7 +849,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -858,7 +858,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -523,7 +523,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -532,7 +532,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -1096,7 +1096,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -1105,7 +1105,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -297,7 +297,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -306,7 +306,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -595,7 +595,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -604,7 +604,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -841,7 +841,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -850,7 +850,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -227,7 +227,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -236,7 +236,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `worker_support` member of the `IDB*` APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.