### PR TITLE
Update Chromium versions for ServiceWorkerGlobalScope API

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1129,10 +1129,10 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerglobalscope-onnotificationclose",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "50"
             },
             "edge": {
               "version_added": "≤79"
@@ -1148,10 +1148,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "24"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "24"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11.1"
@@ -1160,10 +1160,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "50"
             }
           },
           "status": {
@@ -1596,10 +1596,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-registration",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "≤79"
@@ -1615,10 +1615,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "24"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "24"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "11.1"
@@ -1630,7 +1630,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "42"
             }
           },
           "status": {
@@ -1693,10 +1693,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#service-worker-global-scope-skipwaiting",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "≤79"
@@ -1712,10 +1712,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "24"
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": "24"
+              "version_added": "25"
             },
             "safari": {
               "version_added": "11.1"
@@ -1727,7 +1727,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "41"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope
