### PR TITLE
Add IE/Edge versions for MediaSessionAction API

### DIFF
--- a/api/MediaSessionAction.json
+++ b/api/MediaSessionAction.json
@@ -13,7 +13,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -36,7 +36,7 @@
             "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -75,7 +75,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -98,7 +98,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -138,7 +138,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -161,7 +161,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -201,7 +201,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -224,7 +224,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -264,7 +264,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -287,7 +287,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -327,7 +327,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -350,7 +350,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -390,7 +390,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -413,7 +413,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -453,7 +453,7 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -476,7 +476,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -516,7 +516,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -539,7 +539,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -579,7 +579,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -602,7 +602,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MediaSessionAction` API.  `api.Navigator.mediaSession` is set to `false` for IE and "79" for for Edge, so it wouldn't make sense that this API would be supported before then.
