### PR TITLE
Add IE/Edge versions for MediaSessionActionDetails API

### DIFF
--- a/api/MediaSessionActionDetails.json
+++ b/api/MediaSessionActionDetails.json
@@ -12,7 +12,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -35,7 +35,7 @@
             "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -74,7 +74,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -97,7 +97,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -137,7 +137,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -146,7 +146,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -186,7 +186,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -209,7 +209,7 @@
               "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -249,7 +249,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -258,7 +258,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `MediaSessionActionDetails` API.  `api.Navigator.mediaSession` is set to `false` for IE and "79" for for Edge, so it wouldn't make sense that this API would be supported before then.
