### PR TITLE
Add IE versions for RequestDestination API

### DIFF
--- a/api/RequestDestination.json
+++ b/api/RequestDestination.json
@@ -21,7 +21,7 @@
             "version_added": "61"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "52"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `RequestDestination` API by mirroring the data from Edge (AKA, IE can't be truthy if Edge is greater than 12).
