### PR TITLE
Add IE versions for SVGViewElement API

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -72,7 +72,7 @@
               "version_removed": "61"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true,


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `SVGViewElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGViewElement
