### PR TITLE
Add IE versions for SourceBuffer API

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -262,7 +262,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": false
@@ -553,7 +553,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1102,7 +1102,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -262,7 +262,8 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "11",
+              "notes": "Only works on Windows 8+."
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `SourceBuffer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SourceBuffer
