### PR TITLE
Add IE/Edge versions for api.WindowOrWorkerGlobalScope.isSecureContext

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -929,7 +929,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "52"
@@ -938,7 +938,7 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `isSecureContext` member of the `WindowOrWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Window/isSecureContext
https://mdn-bcd-collector.appspot.com/tests/api/WorkerGlobalScope/isSecureContext