### PR TITLE
Add IE/Edge versions for message/messageerror events

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -160,7 +160,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "57"
@@ -169,7 +169,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"
@@ -316,7 +316,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -181,7 +181,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "nodejs": {
               "version_added": "14.5.0",

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -994,7 +994,7 @@
               "version_added": "81"
             },
             "edge": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox": {
               "version_added": null

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -362,7 +362,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": null
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": "47"
@@ -411,7 +411,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "57"
@@ -420,7 +420,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"
@@ -467,7 +467,7 @@
                 "version_added": "57"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -427,7 +427,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "nodejs": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `onmessage` and `onmessageerror` members of various APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Window/onmessage
https://mdn-bcd-collector.appspot.com/tests/api/Window/onmessageerror