### PR TITLE
Add IE/Edge versions for api.WorkerGlobalScope.importScripts.mime_checks

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -255,7 +255,7 @@
                 "version_added": "71"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "67"
@@ -264,7 +264,7 @@
                 "version_added": "67"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "58"
@@ -404,7 +404,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "17"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -452,7 +452,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": "3.5",
@@ -463,7 +463,7 @@
               "version_removed": "50"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "11.5"
@@ -552,7 +552,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "74"
@@ -561,7 +561,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "11.5"
@@ -601,7 +601,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -650,7 +650,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -699,7 +699,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "34"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -404,7 +404,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "3.5"
@@ -452,7 +452,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5",
@@ -463,7 +463,7 @@
               "version_removed": "50"
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": "11.5"
@@ -552,7 +552,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "74"
@@ -561,7 +561,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": "11.5"
@@ -601,7 +601,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "29"
@@ -650,7 +650,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "29"
@@ -699,7 +699,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": "34"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `importScripts.mime_checks` member of the `WorkerGlobalScope` API.  Based upon when this security check was implemented in other browsers, it doesn't seem likely that this would be around in Trident/EdgeHTML.
