### PR TITLE
Update IE versions for api.Document.transition_events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10969,7 +10969,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -11049,7 +11049,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -11099,7 +11099,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -11179,7 +11179,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -11040,7 +11040,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51"
@@ -11049,7 +11049,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": null
@@ -11090,7 +11090,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53"
@@ -11099,7 +11099,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": null
@@ -11170,7 +11170,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53"
@@ -11179,7 +11179,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -11050,7 +11050,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "This event's handler attribute (<code>ontransitionend</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionend', function() {});</code>."
+              "notes": "The <code>ontransitionend</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
               "version_added": null
@@ -11101,7 +11101,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "This event's handler attribute (<code>ontransitionrun</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionrun', function() {});</code>."
+              "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionrun', function() {});</code>."
             },
             "opera": {
               "version_added": null
@@ -11182,7 +11182,7 @@
             },
             "ie": {
               "version_added": "10",
-              "notes": "This event's handler attribute (<code>ontransitionstart</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionstart', function() {});</code>."
+              "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionstart', function() {});</code>."
             },
             "opera": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -11049,7 +11049,8 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "This event's handler attribute (<code>ontransitionend</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
               "version_added": null
@@ -11099,7 +11100,8 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "This event's handler attribute (<code>ontransitionrun</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionrun', function() {});</code>."
             },
             "opera": {
               "version_added": null
@@ -11179,7 +11181,8 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "This event's handler attribute (<code>ontransitionstart</code>) is not supported; however, the event itself is supported since IE 10. The event can be listened to via <code>document.addEventListener('transitionstart', function() {});</code>."
             },
             "opera": {
               "version_added": null

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4915,7 +4915,8 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The <code>ontransitionend</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
               "version_added": "66"
@@ -4975,7 +4976,8 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
               "version_added": "73"
@@ -5037,7 +5039,8 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
               "version_added": "73"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4977,7 +4977,7 @@
             },
             "ie": {
               "version_added": false,
-              "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
+              "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionrun', function() {});</code>."
             },
             "opera": {
               "version_added": "73"
@@ -5040,7 +5040,7 @@
             },
             "ie": {
               "version_added": false,
-              "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
+              "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionstart', function() {});</code>."
             },
             "opera": {
               "version_added": "73"


### PR DESCRIPTION
This PR updates real values for Internet Explorer for the `transition` events members of the `Document` API.  These events aren't supported in Edge.