### PR TITLE
Add Edge versions for KeyframeEffect API

### DIFF
--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -110,7 +110,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": null
+              "version_added": "84"
             },
             "firefox": [
               {
@@ -185,7 +185,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": null
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"
@@ -234,7 +234,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `KeyframeEffect` API by mirroring the data.
