### PR TITLE
Add Edge versions for api.Request.context

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -506,7 +506,7 @@
               "version_removed": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "39",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `context` member of the `Request` API by mirroring the data.
