### PR TITLE
Update Edge versions for SVGSVGElement API

### DIFF
--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -58,7 +58,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "1.5"
@@ -205,7 +205,8 @@
               "version_removed": "36"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "1.5",
@@ -262,7 +263,8 @@
               "version_removed": "36"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "1.5",
@@ -1740,7 +1742,8 @@
               "version_removed": "55"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "18"
             },
             "firefox": {
               "version_added": "1.5",


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `SVGSVGElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGSVGElement
