### PR TITLE
Add Edge versions for SubmitEvent API

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -12,7 +12,7 @@
             "version_added": "81"
           },
           "edge": {
-            "version_added": null
+            "version_added": "81"
           },
           "firefox": {
             "version_added": "75"
@@ -61,7 +61,7 @@
               "version_added": "81"
             },
             "edge": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox": {
               "version_added": "75"
@@ -110,7 +110,7 @@
               "version_added": "81"
             },
             "edge": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox": {
               "version_added": "75"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `SubmitEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SubmitEvent
