### PR TITLE
Add Edge versions for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -624,7 +624,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -1421,7 +1421,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -8157,7 +8157,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Element` API.  These events were not supported in Edge, so it's not possible these would be in IE.
