### PR TITLE
Add IE/Edge versions for api.WebSocket.worker_support

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -1029,7 +1029,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "37"
@@ -1038,7 +1038,7 @@
               "version_added": "37"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `worker_support` member of the `WebSocket` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebSocket
