### PR TITLE
Add IE versions for api.Window.animationcancel_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -225,7 +225,7 @@
               "version_added": "54"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `animationcancel_event` member of the `Window` API by mirroring the data.
