### PR TITLE
Add Firefox versions for api.DeviceMotionEvent.DeviceMotionEvent

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -67,7 +67,7 @@
               "version_added": "29"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -64,7 +64,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "29"
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DeviceMotionEvent` member of the `DeviceMotionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEvent/DeviceMotionEvent
