### PR TITLE
Add Firefox versions for DeviceMotionEventAcceleration API

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -23,10 +23,14 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "ie": {
             "version_added": false
@@ -88,10 +92,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
               "version_added": false
@@ -142,10 +146,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false
@@ -196,10 +204,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false
@@ -250,10 +262,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -23,7 +23,7 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
             "version_added": null
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -142,7 +142,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -196,7 +196,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -91,7 +91,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -145,7 +145,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -199,7 +199,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -253,7 +253,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -146,14 +146,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -204,14 +200,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -262,14 +254,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DeviceMotionEventAcceleration` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEventAcceleration
