### PR TITLE
Update Firefox versions for BlobEvent API

### DIFF
--- a/api/BlobEvent.json
+++ b/api/BlobEvent.json
@@ -15,10 +15,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "22"
+            "version_added": "21"
           },
           "firefox_android": {
-            "version_added": "22"
+            "version_added": "21"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "21"
             },
             "ie": {
               "version_added": false
@@ -113,10 +113,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "21"
             },
             "ie": {
               "version_added": false
@@ -162,10 +162,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/BlobEvent.json
+++ b/api/BlobEvent.json
@@ -15,10 +15,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "21"
+            "version_added": "25"
           },
           "firefox_android": {
-            "version_added": "21"
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -113,10 +113,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `BlobEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BlobEvent
