### PR TITLE
Add Firefox versions for DeviceMotionEventRotationRate API

### DIFF
--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -23,10 +23,10 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -90,10 +90,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -144,10 +144,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -198,10 +198,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -250,10 +250,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -94,14 +94,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -152,14 +148,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -210,14 +202,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "6"
             },
             "ie": {
               "version_added": false

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -23,10 +23,14 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "6",
+            "partial_implementation": true,
+            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
           },
           "ie": {
             "version_added": false
@@ -90,10 +94,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false
@@ -144,10 +152,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false
@@ -198,10 +210,14 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6",
+              "partial_implementation": true,
+              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
             },
             "ie": {
               "version_added": false
@@ -250,10 +266,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": null
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DeviceMotionEventRotationRate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEventRotationRate
