### PR TITLE
Add Firefox versions for DeviceOrientationEvent API

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -70,10 +70,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "17"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "17"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DeviceOrientationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceOrientationEvent
