### PR TITLE
Add Firefox versions for ErrorEvent API

### DIFF
--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "27"
+            "version_added": "30"
           },
           "firefox_android": {
-            "version_added": "27"
+            "version_added": "30"
           },
           "ie": {
             "version_added": true
@@ -63,10 +63,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "ie": {
               "version_added": null
@@ -207,10 +207,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "ie": {
               "version_added": null
@@ -255,10 +255,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "ie": {
               "version_added": null
@@ -303,10 +303,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "30"
             },
             "ie": {
               "version_added": null

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "27"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "27"
           },
           "ie": {
             "version_added": true
@@ -63,10 +63,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "ie": {
               "version_added": null
@@ -111,10 +111,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": null
@@ -159,10 +159,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": null
@@ -207,10 +207,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "ie": {
               "version_added": null
@@ -255,10 +255,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "ie": {
               "version_added": null
@@ -303,10 +303,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `ErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ErrorEvent
