### PR TITLE
Add Firefox versions for FontFaceSetLoadEvent API

### DIFF
--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -15,10 +15,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "41"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -113,10 +113,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `FontFaceSetLoadEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFaceSetLoadEvent
