### PR TITLE
Add Firefox versions for MediaEncryptedEvent API

### DIFF
--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -14,10 +14,10 @@
             "version_added": "13"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "38"
           },
           "ie": {
             "version_added": false
@@ -62,10 +62,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -110,10 +110,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -158,10 +158,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaEncryptedEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  Results are manually confirmed for accuracy.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaEncryptedEvent
