### PR TITLE
Add release notes for Safari 14.1 and Safari 15 beta.

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -176,9 +176,15 @@
         },
         "14.1": {
           "release_date": "2021-04-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "611.1.21.161.3"
+        },
+        "15": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -160,9 +160,15 @@
         },
         "14.5": {
           "release_date": "2021-04-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "611.1.21.161.6"
+        },
+        "15": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
I've added the missing release notes for Safari 14.1 (they've only been made available recently) and also added a beta entry for the just announced Safari 15 with relevant release notes.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes

https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes
