### PR TITLE
Add Safari 15 compat data

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -30,10 +30,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15"
           },
           "samsunginternet_android": {
             "version_added": "7.0"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -69,10 +69,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -675,10 +675,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.2"

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -34,10 +34,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -34,10 +34,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -122,11 +122,10 @@
                 "version_added": "63"
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/202484'>bug 202484</a>"
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1884,10 +1884,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Following WWDC here are the updated compat data of features I could match in the repo

Here is a list of things to mark as done if we deem it ok to not include them as part of this pull request

#### Questions

- ~~Where to include predefined color spaces using the color() syntax?~~ should probably be tackled as part of #10658
- ~~What about `lab()`, `lch()`, `hwb()`? There are currently no references to those features in the dataset~~ should probably be tackled as part of #10658
- `Error.cause` is inexistant in MDN at the moment, should I create a new file for it even though the page does not exist yet?
- There are currently no differences between private data members and private class methods on MDN they are documented under the same dataset
- Shall I mark the `WebShare` enhancements as a note under the `Navigator.share()` entry?
