### PR TITLE
Javascript private class fields supported from FF90

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -489,36 +489,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1562054'>bug 1562054</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.private_fields",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.private_methods",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "90"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Available only in nightly builds. See <a href='https://bugzil.la/1562054'>bug 1562054</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.private_fields",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "javascript.options.experimental.private_methods",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "90"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF90 adds support for [private class fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1708235) and [private class methods](https://bugzilla.mozilla.org/show_bug.cgi?id=1708236). 

Previously this was only supported on Nightly build and behind a preference. Because the preference was never available in release build (AFAK - or at least documented that way) I have removed the old preference info altogether from BCD as "not relevant".

Docs tracking for this is in https://github.com/mdn/content/issues/5386

As an aside, might be a good time to consider whether we want to do the work suggested in #9833