### PR TITLE
Add Firefox versions for OverconstrainedErrorEvent API

### DIFF
--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -15,10 +15,10 @@
             "version_removed": "79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `OverconstrainedErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OverconstrainedErrorEvent
