### PR TITLE
Add Firefox versions for api.PerformanceObserver.worker_support

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -333,10 +333,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "57"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "57"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `worker_support` member of the `PerformanceObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserver
