### PR TITLE
Add Firefox versions for PushSubscriptionOptions API

### DIFF
--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -15,10 +15,10 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "48"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "48"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "48"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -113,10 +113,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -15,10 +15,10 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "48"
+            "version_added": "44"
           },
           "firefox_android": {
-            "version_added": "48"
+            "version_added": "44"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `PushSubscriptionOptions` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushSubscriptionOptions
