### PR TITLE
Add Firefox versions for RTCPeerConnectionIceEvent API

### DIFF
--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -29,10 +29,10 @@
             "version_added": "15"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "24"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "24"
           },
           "ie": {
             "version_added": false
@@ -92,10 +92,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "ie": {
               "version_added": false
@@ -141,10 +141,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "ie": {
               "version_added": false
@@ -189,10 +189,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCPeerConnectionIceEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnectionIceEvent
