### PR TITLE
Add Firefox versions for RTCRtpSender API

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -160,10 +160,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -210,10 +210,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -310,10 +310,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCRtpSender` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpSender
