### PR TITLE
Add Firefox versions for ResizeObserverSize API

### DIFF
--- a/api/ResizeObserverSize.json
+++ b/api/ResizeObserverSize.json
@@ -15,10 +15,10 @@
             "version_added": "84"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "69"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "84"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "84"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `ResizeObserverSize` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ResizeObserverSize
