### PR TITLE
Add Firefox versions for SVGHKernElement API

### DIFF
--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -17,10 +17,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `SVGHKernElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGHKernElement
