### PR TITLE
Add Firefox versions for api.SVGImageElement.crossOrigin

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -63,10 +63,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `crossOrigin` member of the `SVGImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGImageElement/crossOrigin
