### PR TITLE
Add Firefox versions for api.ShadowRoot.delegatesFocus

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -63,10 +63,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `delegatesFocus` member of the `ShadowRoot` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot/delegatesFocus
