### PR TITLE
Add Firefox versions for TrackEvent API

### DIFF
--- a/api/TrackEvent.json
+++ b/api/TrackEvent.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "27"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "27"
           },
           "ie": {
             "version_added": "10"
@@ -63,10 +63,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "ie": {
               "version_added": "10"

--- a/api/TrackEvent.json
+++ b/api/TrackEvent.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "27"
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": "27"
+            "version_added": "31"
           },
           "ie": {
             "version_added": "10"
@@ -63,10 +63,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TrackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TrackEvent
