### PR TITLE
Add Firefox versions for UIEvent API

### DIFF
--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": true
@@ -113,10 +113,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9",
@@ -164,10 +164,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": null
@@ -264,10 +264,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -312,10 +312,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -364,10 +364,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": "9"
@@ -420,10 +422,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1",
+              "version_removed": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": "9"
@@ -473,10 +477,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -522,10 +526,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -570,10 +574,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `UIEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/UIEvent
