### PR TITLE
Add all browsers versions for api.SubtleCrypto.worker_support

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -776,12 +776,18 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": "37"
             },
             "edge": {
-              "version_added": null
+              "version_added": "79"
             },
             "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
               "version_added": "48"
             },
             "ie": {
@@ -791,10 +797,22 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `worker_support` member of the `SubtleCrypto` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SubtleCrypto
