### PR TITLE
Add Firefox versions for WebGLObject API

### DIFF
--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -14,10 +14,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": "11"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `WebGLObject` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGLObject
