### PR TITLE
updating Chrome support for @counter-style API

### DIFF
--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -6,13 +6,13 @@
         "spec_url": "https://drafts.csswg.org/css-counter-styles/#the-csscounterstylerule-interface",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "91"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "91"
           },
           "edge": {
-            "version_added": false
+            "version_added": "91"
           },
           "firefox": {
             "version_added": "33"
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "91"
           }
         },
         "status": {
@@ -52,13 +52,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -99,13 +99,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -146,13 +146,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -193,13 +193,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -240,13 +240,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -273,7 +273,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -287,13 +287,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -334,13 +334,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -381,13 +381,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -414,7 +414,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -428,13 +428,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -461,7 +461,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -475,13 +475,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -508,7 +508,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {
@@ -522,13 +522,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -555,7 +555,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {

--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -320,7 +320,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "91"
             }
           },
           "status": {


### PR DESCRIPTION
The `@counter-style` rule shipped in Chrome 91, this updates the API data.

https://www.chromestatus.com/feature/5692693659254784 