### PR TITLE
Adds Edge support for @counter-style

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -14,7 +14,7 @@
               "version_added": "91"
             },
             "edge": {
-              "version_added": false
+              "version_added": "91"
             },
             "firefox": {
               "version_added": "33"
@@ -63,7 +63,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -113,7 +113,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -163,7 +163,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -213,7 +213,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -263,7 +263,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -313,7 +313,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -413,7 +413,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"
@@ -467,7 +467,9 @@
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "edge": {
-                "version_added": false
+                "version_added": "91",
+                "partial_implementation": true,
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "firefox": {
                 "version_added": "33",
@@ -523,7 +525,7 @@
                 "version_added": "91"
               },
               "edge": {
-                "version_added": false
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "33"


### PR DESCRIPTION
Edge supports `@counter-style` as of version 91. Already had Chrome data so this just brings Edge up to date.
