### PR TITLE
Add scripts for tracking demixes (and other interesting feature diffs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 *.log
 build/
+.features.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.idea
-/node_modules/
-*.log
-build/
-.features.json
 __enumerating__*/
+.features.json
+.idea
+*.log
+/node_modules/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 build/
 .features.json
+__enumerating__*/

--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -46,9 +46,7 @@ function enumerateFeatures(ref = 'HEAD') {
 
     return JSON.parse(fs.readFileSync('.features.json', { encoding: 'utf-8' }));
   } finally {
-    if (ref !== 'HEAD') {
-      execSync(`git worktree remove ${worktree}`);
-    }
+    execSync(`git worktree remove ${worktree}`);
   }
 }
 

--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -1,0 +1,95 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+const yargs = require('yargs');
+
+function main({ ref1, ref2, format }) {
+  let refA, refB;
+
+  if (ref1 === undefined && ref2 === undefined) {
+    // No refs: compare HEAD to parent commit
+    refA = 'HEAD^';
+    refB = 'HEAD';
+  } else if (ref2 === undefined) {
+    // One ref: compare ref to parent of ref
+    refB = `${ref1}`;
+    refA = `${ref1}^`;
+  } else {
+    // Two refs: compare ref2 to ref1
+    refA = `${ref2}`;
+    refB = `${ref1}`;
+  }
+
+  const aSide = new Set(enumerateFeatures(refA));
+  const bSide = new Set(enumerateFeatures(refB));
+
+  const results = {
+    added: [...bSide].filter(feature => !aSide.has(feature)),
+    removed: [...aSide].filter(feature => !bSide.has(feature)),
+  };
+
+  if (format === 'markdown') {
+    printMarkdown(results);
+  } else {
+    console.log(JSON.stringify(results, undefined, 2));
+  }
+}
+
+function enumerateFeatures(ref = 'HEAD') {
+  console.error(`Enumerating features on ${ref}`);
+  try {
+    if (ref !== 'HEAD') {
+      execSync(`git checkout --quiet ${ref}`);
+    }
+    execSync(`node ./scripts/enumerate-features.js`);
+    return JSON.parse(fs.readFileSync('.features.json', { encoding: 'utf-8' }));
+  } finally {
+    if (ref !== 'HEAD') {
+      execSync(`git switch -`);
+    }
+  }
+}
+
+function printMarkdown({ added, removed }) {
+  const fmtFeature = feat => `- \`${feat}\``;
+
+  if (removed.length) {
+    console.log('## Removed\n');
+    console.log(removed.map(fmtFeature).join('\n'));
+  }
+  if (added.length) {
+    if (removed.length) console.log('');
+    console.log('## Added\n');
+    console.log(added.map(fmtFeature).join('\n'));
+  }
+}
+
+const { argv } = yargs.command(
+  '$0 [ref1] [ref2]',
+  'Compare the set of features at refA and refB',
+  yargs => {
+    yargs
+      .positional('ref1', {
+        description: 'A Git ref (branch, tag, or commit)',
+        defaultDescription: 'ref1^',
+      })
+      .positional('ref2', {
+        description: 'A Git ref (branch, tag, or commit)',
+        defaultDescription: 'HEAD',
+      })
+      .option('format', {
+        type: 'string',
+        nargs: 1,
+        choices: ['json', 'markdown'],
+        demand: 'a named format is required',
+        default: 'markdown',
+      })
+      .example('$0', 'compare HEAD to parent commmit')
+      .example('$0 176d4ed', 'compare 176d4ed to its parent commmit')
+      .example('$0 topic-branch main', 'compare a branch to main');
+  },
+);
+
+if (require.main === module) {
+  main(argv);
+}

--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -36,11 +36,20 @@ function main({ ref1, ref2, format }) {
 }
 
 function enumerateFeatures(ref = 'HEAD') {
-  const worktree = `__enumerating__${ref}`;
+  // Get the short hash for this ref.
+  // Most of the time, you check out named references (a branch or a tag).
+  // However, if `ref` is already checked out, then `git worktree add` fails. As
+  // long as you haven't checked out a detached HEAD for `ref`, then
+  // `git worktree add` for the hash succeeds.
+  const hash = execSync(`git rev-parse --short ${ref}`, {
+    encoding: 'utf-8',
+  }).trim();
 
-  console.error(`Enumerating features on ${ref}`);
+  const worktree = `__enumerating__${hash}`;
+
+  console.error(`Enumerating features for ${ref} (${hash})`);
   try {
-    execSync(`git worktree add ${worktree} ${ref}`);
+    execSync(`git worktree add ${worktree} ${hash}`);
     execSync(`npm ci`, { cwd: worktree });
     execSync(`node ./scripts/enumerate-features.js --data-from=${worktree}`);
 

--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -36,16 +36,18 @@ function main({ ref1, ref2, format }) {
 }
 
 function enumerateFeatures(ref = 'HEAD') {
+  const worktree = `__enumerating__${ref}`;
+
   console.error(`Enumerating features on ${ref}`);
   try {
-    if (ref !== 'HEAD') {
-      execSync(`git checkout --quiet ${ref}`);
-    }
-    execSync(`node ./scripts/enumerate-features.js`);
+    execSync(`git worktree add ${worktree} ${ref}`);
+    execSync(`npm ci`, { cwd: worktree });
+    execSync(`node ./scripts/enumerate-features.js --data-from=${worktree}`);
+
     return JSON.parse(fs.readFileSync('.features.json', { encoding: 'utf-8' }));
   } finally {
     if (ref !== 'HEAD') {
-      execSync(`git switch -`);
+      execSync(`git worktree remove ${worktree}`);
     }
   }
 }

--- a/scripts/enumerate-features.js
+++ b/scripts/enumerate-features.js
@@ -1,0 +1,36 @@
+const yargs = require('yargs');
+
+const fs = require('fs');
+
+const { walk } = require('../utils');
+
+function features() {
+  const feats = [];
+
+  for (const { path, compat } of walk()) {
+    if (compat) {
+      feats.push(path);
+    }
+  }
+
+  return feats;
+}
+
+function main({ dest }) {
+  fs.writeFileSync(dest, JSON.stringify(features()));
+}
+
+const { argv } = yargs.command(
+  '$0 [dest]',
+  'Write a JSON-formatted list of feature paths',
+  yargs => {
+    yargs.positional('dest', {
+      default: '.features.json',
+      description: 'File destination',
+    });
+  },
+);
+
+if (require.main === module) {
+  main(argv);
+}


### PR DESCRIPTION
This PR adds two new scripts to the repo: `enumerate-features` and `diff-features`. Ostensibly, these two scripts make it easier for me to write release notes by helping me find out what features have been added or removed in a given commit, but these may also demonstrate the basis for additional automation and reporting on BCD. But it's also a step toward https://github.com/mdn/browser-compat-data/issues/10533.

The first script here is `enumerate-features`, which is like a lower-level plumbing alternative to `traverse`. Using the newish `walk()` util, `enumerate-features` writes out a JSON file listing every single feature in BCD (or, if specified, an alternate path to the package—this is is going to be significant later on).

The second script, `diff-features`, builds on the first. It runs `enumerate-features` against two different commits, then compares the set of features in each enumeration. This quickly produces a list of added or removed features. Because of the way we've implemented `walk()`, it even works with historic revisions, before we implemented `enumerate-features` itself.

The `diff-features` script could be a model for doing the tasks discussed in https://github.com/mdn/browser-compat-data/issues/10533. Instead of diffing between commits, we could have a script that runs `enumerate-features` for one set of criteria (e.g., "Supported in Safari 13") and again for another (e.g. "Supported in Safari for iOS 13"), then reports the symmetric difference.

A couple additional notes:

- Because it writes out to a JSON file, `enumerate-features` has a bunch of potential uses for workflow automation. For example, we could automatically count changes in the overall number of features for release notes…
- …or [save hashes of compat objects to detect when features have been modified](https://github.com/ddbeck/browser-compat-data/compare/inventory-paths...ddbeck:more-diffing). That seems to require an additional dependency, so I didn't include it in this PR.

