### PR TITLE
Add release note for SVGAnimatedPoints demix (retroactively)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -119,6 +119,19 @@ June 4, 2021
 
   </details>
 
+- The `api.SVGAnimatedPoints` mixin has been removed and replaced by features representing its exposed interfaces. ([#10698](https://github.com/mdn/browser-compat-data/pull/10698))
+
+  <details>
+
+  <summary>New features ex-<code>SVGAnimatedPoints</code></summary>
+
+  - `api.SVGPolygonElement.animatedPoints`
+  - `api.SVGPolygonElement.points`
+  - `api.SVGPolylineElement.animatedPoints`
+  - `api.SVGPolylineElement.points`
+
+  </details>
+
 - The mixin `api.GeometryUtils` has been removed and replaced by features representing its exposed interfaces. ([#10721](https://github.com/mdn/browser-compat-data/pull/10721))
 
   <details>


### PR DESCRIPTION
v3.3.6 had a bunch of changes and I missed #10698.

This fixes `RELEASE_NOTES.md` but, after merging, [the release on GitHub](https://github.com/mdn/browser-compat-data/releases/tag/v3.3.6) needs be updated too.