### PR TITLE
Update visibilitychange data to reflect Safari 14 fix

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11324,7 +11324,7 @@
                 "partial_implementation": true,
                 "notes": [
                   "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                  "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
+                  "The event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
                   "Before Safari 10.1, the <code>onvisibilitychange</code> attribute is not supported. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>."
                 ]
               }

--- a/api/Document.json
+++ b/api/Document.json
@@ -7935,6 +7935,7 @@
                 "version_added": "14.1"
               },
               {
+                "version_removed": "14.1",
                 "version_added": "10.1",
                 "partial_implementation": true,
                 "notes": [
@@ -7948,6 +7949,7 @@
                 "version_added": "14.5"
               },
               {
+                "version_removed": "14.5",
                 "version_added": "10.3",
                 "partial_implementation": true,
                 "notes": [
@@ -11320,6 +11322,7 @@
                 "version_added": "14.1"
               },
               {
+                "version_removed": "14.1",
                 "version_added": "7",
                 "partial_implementation": true,
                 "notes": [
@@ -11334,6 +11337,7 @@
                 "version_added": "14.5"
               },
               {
+                "version_removed": "14.5",
                 "version_added": "7",
                 "partial_implementation": true,
                 "notes": [

--- a/api/Document.json
+++ b/api/Document.json
@@ -11317,7 +11317,7 @@
             ],
             "safari": [
               {
-                "version_added": "14"
+                "version_added": "14.1"
               },
               {
                 "version_added": "7",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7945,7 +7945,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "14"
+                "version_added": "14.5"
               },
               {
                 "version_added": "10.3",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7932,7 +7932,7 @@
             },
             "safari": [
               {
-                "version_added": "14"
+                "version_added": "14.1"
               },
               {
                 "version_added": "10.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -11331,7 +11331,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "14"
+                "version_added": "14.5"
               },
               {
                 "version_added": "7",

--- a/api/Document.json
+++ b/api/Document.json
@@ -7930,22 +7930,32 @@
               "version_added": "46",
               "notes": "Before Opera Android 46, this event handler attribute is not supported; however, the event itself is supported since Opera Android 20. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
             },
-            "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": [
-                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
-              ]
-            },
-            "safari_ios": {
-              "version_added": "10.3",
-              "partial_implementation": true,
-              "notes": [
-                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "Before Safari iOS 10.3, this event handler attribute was not supported; however, the event itself was supported since Safari iOS 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
-              ]
-            },
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "10.1",
+                "partial_implementation": true,
+                "notes": [
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "10.3",
+                "partial_implementation": true,
+                "notes": [
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Before Safari 10.1, this event handler attribute was not supported; however, the event itself was supported since Safari 7. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "8.0",
               "notes": "Before Samsung Internet 8.0, this event handler attribute is not supported; however, the event itself is supported since Samsung Internet 2.0. The event can be listened to via <code>document.addEventListener('visibilitychange', function() {});</code>."
@@ -11305,24 +11315,34 @@
                 "version_removed": "14"
               }
             ],
-            "safari": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": [
-                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
-                "Before Safari 10.1, the <code>onvisibilitychange</code> attribute is not supported. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>."
-              ]
-            },
-            "safari_ios": {
-              "version_added": "7",
-              "partial_implementation": true,
-              "notes": [
-                "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                "Before Safari iOS 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
-                "Before Safari iOS 10.3, the <code>onvisibilitychange</code> attribute is not supported. To listen to this event in earlier versions of Safari iOS, use <code>document.addEventListener('visibilitychange', function() {});</code>."
-              ]
-            },
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "7",
+                "partial_implementation": true,
+                "notes": [
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
+                  "Before Safari 10.1, the <code>onvisibilitychange</code> attribute is not supported. To listen to this event in earlier versions of Safari, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "7",
+                "partial_implementation": true,
+                "notes": [
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Before Safari iOS 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
+                  "Before Safari iOS 10.3, the <code>onvisibilitychange</code> attribute is not supported. To listen to this event in earlier versions of Safari iOS, use <code>document.addEventListener('visibilitychange', function() {});</code>."
+                ]
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "2.0",


### PR DESCRIPTION
https://trac.webkit.org/changeset/267614/webkit shipped in Safari 14 and fixed as problem in Safari’s `visibilitychange` behavior which had led to it being marked as `partial_implementation` in BCD, with an associated Note.

So this change updates BCD to reflect that as of version 14, Safari has full support for `visibilitychange` and `onvisibilitychange`.