### PR TITLE
Update Safari versions for AnimationEvent API

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -151,10 +151,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -357,10 +357,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -161,7 +161,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               {
                 "prefix": "WebKit",

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -150,12 +150,24 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "prefix": "WebKit",
+                "version_added": "6"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "prefix": "WebKit",
+                "version_added": "6"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "4.0"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `AnimationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationEvent
