### PR TITLE
Update Safari versions for AnimationPlaybackEvent API

### DIFF
--- a/api/AnimationPlaybackEvent.json
+++ b/api/AnimationPlaybackEvent.json
@@ -30,10 +30,10 @@
             "version_added": "60"
           },
           "safari": {
-            "version_added": false
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": "14.0"
@@ -79,10 +79,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -128,10 +128,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -177,10 +177,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `AnimationPlaybackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationPlaybackEvent
