### PR TITLE
Update Safari versions for DOMParser API

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -33,7 +33,7 @@
             "version_added": "3.2"
           },
           "safari_ios": {
-            "version_added": "1.3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -82,7 +82,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": "1.3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -131,7 +131,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": "1.3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -226,7 +226,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": "1.3"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -274,7 +274,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": "1.3"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -131,7 +131,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -226,7 +226,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -274,7 +274,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -33,7 +33,7 @@
             "version_added": "3.2"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "1.3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -82,7 +82,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1.3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -131,7 +131,7 @@
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -226,7 +226,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "1.3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -274,7 +274,7 @@
                 "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "1.3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -30,10 +30,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3.2"
+            "version_added": "1.3"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -79,10 +79,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -223,10 +223,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -271,10 +271,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR updates the Safari versions for the `DOMParser` API based upon commit history (see below) and manual testing.
