### PR TITLE
Update Safari versions for Geolocation APIs

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -82,7 +82,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -131,7 +131,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -229,7 +229,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -34,7 +34,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -78,7 +78,8 @@
             },
             {
               "alternative_name": "Coordinates",
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "13.1"
             }
           ],
           "safari_ios": [
@@ -87,7 +88,8 @@
             },
             {
               "alternative_name": "Coordinates",
-              "version_added": "4.2"
+              "version_added": "4.2",
+              "version_removed": "13.4"
             }
           ],
           "samsunginternet_android": {

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -88,7 +88,7 @@
             },
             {
               "alternative_name": "Coordinates",
-              "version_added": "4.2",
+              "version_added": "≤3",
               "version_removed": "13.4"
             }
           ],
@@ -158,7 +158,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -219,7 +219,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -280,7 +280,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -341,7 +341,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -402,7 +402,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -463,7 +463,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -572,7 +572,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -72,14 +72,24 @@
               "version_removed": "14"
             }
           ],
-          "safari": {
-            "alternative_name": "Coordinates",
-            "version_added": "5"
-          },
-          "safari_ios": {
-            "alternative_name": "Coordinates",
-            "version_added": "4.2"
-          },
+          "safari": [
+            {
+              "version_added": "13.1"
+            },
+            {
+              "alternative_name": "Coordinates",
+              "version_added": "5"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "13.4"
+            },
+            {
+              "alternative_name": "Coordinates",
+              "version_added": "4.2"
+            }
+          ],
           "samsunginternet_android": {
             "alternative_name": "Coordinates",
             "version_added": "1.0"
@@ -146,7 +156,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -207,7 +217,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -268,7 +278,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -329,7 +339,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -390,7 +400,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -451,7 +461,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -560,7 +570,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -61,14 +61,26 @@
             "alternative_name": "Position",
             "version_added": "16"
           },
-          "safari": {
-            "alternative_name": "Position",
-            "version_added": "5"
-          },
-          "safari_ios": {
-            "alternative_name": "Position",
-            "version_added": true
-          },
+          "safari": [
+            {
+              "version_added": "13.1"
+            },
+            {
+              "alternative_name": "Position",
+              "version_added": "5",
+              "version_removed": "13.1"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "13.4"
+            },
+            {
+              "alternative_name": "Position",
+              "version_added": "≤3",
+              "version_removed": "13.4"
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "12.0"
@@ -129,7 +141,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -226,7 +238,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -827,7 +827,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `GeolocationCoordinates` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Geolocation
https://mdn-bcd-collector.appspot.com/tests/api/GeolocationCoordinates
https://mdn-bcd-collector.appspot.com/tests/api/GeolocationPosition