### PR TITLE
Update Safari data for api.HTMLCanvasElement.getContext.webgl_context

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -428,9 +428,15 @@
                   "alternative_name": "experimental-webgl"
                 }
               ],
-              "safari_ios": {
-                "version_added": "8"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "8"
+                },
+                {
+                  "version_added": "8",
+                  "alternative_name": "experimental-webgl"
+                }
+              ],
               "samsunginternet_android": [
                 {
                   "version_added": "2.0"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -419,13 +419,17 @@
                   "alternative_name": "experimental-webgl"
                 }
               ],
-              "safari": {
-                "version_added": "5.1",
-                "alternative_name": "experimental-webgl"
-              },
+              "safari": [
+                {
+                  "version_added": "8"
+                },
+                {
+                  "version_added": "5.1",
+                  "alternative_name": "experimental-webgl"
+                }
+              ],
               "safari_ios": {
-                "version_added": "5.1",
-                "alternative_name": "experimental-webgl"
+                "version_added": "8"
               },
               "samsunginternet_android": [
                 {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -424,7 +424,8 @@
                 "alternative_name": "experimental-webgl"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5.1",
+                "alternative_name": "experimental-webgl"
               },
               "samsunginternet_android": [
                 {


### PR DESCRIPTION
This PR updates the data for the `getContext.webgl_context` member of the `HTMLCanvasElement` API.  By running a line of test code (`document.createElement('canvas').getContext('webgl')`) in a few different Safari versions, I found out that Safari included support for the regular `webgl` value to `getContext` along with `experimental-webgl` in Safari 8.  Additionally, this updates the Safari iOS data to reflect the same version stated in `WebGLRenderingContext`.