### PR TITLE
Add Safari iOS versions for api.IDBCursor.worker_support

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -676,7 +676,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `worker_support` member of the `IDBCursor` API by mirroring the data.
