### PR TITLE
Correct Safari versions for MediaStreamAudioSourceOptions API

### DIFF
--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -30,10 +30,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "11"
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": "11"
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "6.0"

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -33,7 +33,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "6.0"

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -30,10 +30,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "6.0"


### PR DESCRIPTION
This PR corrects values for Safari for the `MediaStreamAudioSourceOptions` API by mirroring the data from `MediaStreamAudioSourceNode`.