### PR TITLE
Add Safari versions for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -774,13 +774,11 @@
             },
             "safari": {
               "version_added": "5.1",
-              "version_removed": "7",
-              "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "5.1",
-              "version_removed": "7",
-              "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -314,10 +314,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -364,10 +364,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "11.0"
@@ -778,7 +778,9 @@
               "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5.1",
+              "version_removed": "7",
+              "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2011,10 +2013,10 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator
