### PR TITLE
Add Safari iOS versions for VR* API

### DIFF
--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -108,6 +111,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -173,6 +179,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -234,6 +243,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -299,6 +311,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -360,6 +375,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -425,6 +443,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -486,6 +507,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -551,6 +575,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -614,6 +641,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -662,6 +692,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -724,6 +757,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -789,6 +825,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -827,6 +866,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -889,6 +931,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -954,6 +999,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -1015,6 +1063,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -1080,6 +1131,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -1141,6 +1195,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -1206,6 +1263,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -1267,6 +1327,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -109,6 +112,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -174,6 +180,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -235,6 +244,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -110,6 +113,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -160,6 +166,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": false
             },
@@ -207,6 +216,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -271,6 +283,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -309,6 +324,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -373,6 +391,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -411,6 +432,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -473,6 +497,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -86,6 +89,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -148,6 +154,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -213,6 +222,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -276,6 +288,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -337,6 +352,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -109,6 +112,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -174,6 +180,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -235,6 +244,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -300,6 +312,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -361,6 +376,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -426,6 +444,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -487,6 +508,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -108,6 +111,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -173,6 +179,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -234,6 +243,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -46,8 +46,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "11.1",
-            "version_removed": "14"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -112,8 +111,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -179,8 +177,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -330,8 +327,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -397,8 +393,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -464,8 +459,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -531,8 +525,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1",
-              "version_removed": "14"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -46,6 +46,10 @@
             "version_added": null
           },
           "safari": {
+            "version_added": "11.1",
+            "version_removed": "14"
+          },
+          "safari_ios": {
             "version_added": false
           },
           "samsunginternet_android": {
@@ -108,6 +112,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -171,6 +179,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -213,6 +225,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": false
             },
@@ -250,6 +265,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -312,6 +330,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -375,6 +397,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -438,6 +464,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -501,6 +531,10 @@
               "version_added": null
             },
             "safari": {
+              "version_added": "11.1",
+              "version_removed": "14"
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -542,6 +576,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -48,6 +48,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "6.0",
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -108,6 +111,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
@@ -173,6 +179,9 @@
             "safari": {
               "version_added": false
             },
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": {
               "version_added": "6.0",
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
@@ -234,6 +243,9 @@
               "version_added": null
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `VR*` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VR*
