### PR TITLE
Add Safari versions for CompositionEvent API

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -224,10 +224,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CompositionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CompositionEvent
