### PR TITLE
add URLs to RemotePlayback

### DIFF
--- a/api/RemotePlayback.json
+++ b/api/RemotePlayback.json
@@ -2,6 +2,8 @@
   "api": {
     "RemotePlayback": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback",
+        "spec_url": "https://w3c.github.io/remote-playback/#remoteplayback-interface",
         "support": {
           "chrome": {
             "version_added": "56"
@@ -49,6 +51,8 @@
       },
       "cancelWatchAvailability": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/cancelWatchAvailability",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-cancelwatchavailability",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -96,6 +100,8 @@
       },
       "onconnect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/onconnect",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-onconnect",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -143,6 +149,8 @@
       },
       "onconnecting": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/onconnecting",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-onconnecting",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -190,6 +198,8 @@
       },
       "ondisconnect": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/ondisconnect",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-ondisconnect",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -237,6 +247,8 @@
       },
       "prompt": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/prompt",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-prompt",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -284,6 +296,8 @@
       },
       "state": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/state",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-state",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -331,6 +345,8 @@
       },
       "watchAvailability": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RemotePlayback/watchAvailability",
+          "spec_url": "https://w3c.github.io/remote-playback/#dom-remoteplayback-watchavailability",
           "support": {
             "chrome": {
               "version_added": "56"


### PR DESCRIPTION
I'm documenting RemotePlayback today, this PR adds the MDN and spec URLs to the BCD.