### PR TITLE
Add Safari versions for DeviceMotionEvent API

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -30,7 +30,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": "4.2"
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -128,7 +128,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -177,7 +177,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -226,7 +226,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -275,7 +275,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `DeviceMotionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEvent
