### PR TITLE
Update spec URLs for Class Fields

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -477,7 +477,7 @@
         "__compat": {
           "description": "Private class fields",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Private_class_fields",
-          "spec_url": "https://tc39.es/proposal-class-fields/#prod-PrivateIdentifier",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-PrivateIdentifier",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -556,7 +556,7 @@
         "__compat": {
           "description": "Public class fields",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_fields",
-          "spec_url": "https://tc39.es/proposal-class-fields/#prod-FieldDefinition",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition",
           "support": {
             "chrome": {
               "version_added": "72"
@@ -783,7 +783,7 @@
         "__compat": {
           "description": "Static class fields",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields",
-          "spec_url": "https://tc39.es/proposal-class-fields/#prod-FieldDefinition",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-FieldDefinition",
           "support": {
             "chrome": {
               "version_added": "72"


### PR DESCRIPTION
The Class Fields proposal has been merged into the ES spec itself. So this change updates the spec URLs for the class-fields features to their locations in the ES spec.