### PR TITLE
Correct data for crypto.subtle and crypto.webkitSubtle in WebKit

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -140,19 +140,21 @@
             },
             "safari": [
               {
-                "version_added": "10.1"
+                "version_added": "11"
               },
               {
                 "version_added": "7",
+                "version_removed": "11.1",
                 "prefix": "webkit"
               }
             ],
             "safari_ios": [
               {
-                "version_added": "10.3"
+                "version_added": "11"
               },
               {
                 "version_added": "7",
+                "version_removed": "11.3",
                 "prefix": "webkit"
               }
             ],

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -36,19 +36,21 @@
           },
           "safari": [
             {
-              "version_added": "10.1"
+              "version_added": "11"
             },
             {
               "version_added": "7",
+              "version_removed": "11.1",
               "prefix": "WebKit"
             }
           ],
           "safari_ios": [
             {
-              "version_added": "10.3"
+              "version_added": "11"
             },
             {
               "version_added": "7",
+              "version_removed": "11.3",
               "prefix": "WebKit"
             }
           ],


### PR DESCRIPTION
version_added was wrong for the unprefixed variant, and webkitSubtle has
been removed. The two overlapped for one released.

Based on testing https://mdn-bcd-collector.appspot.com/tests/api/Crypto
in Safari 10.1, 11 and 11.1 on Sauce Labs.
