### PR TITLE
Adds reporting API and other reports

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -6,10 +6,10 @@
         "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "74"
           },
           "chrome_android": {
-            "version_added": "69"
+            "version_added": "74"
           },
           "edge": {
             "version_added": "79"
@@ -39,7 +39,7 @@
             "version_added": "10.0"
           },
           "webview_android": {
-            "version_added": "69"
+            "version_added": "74"
           }
         },
         "status": {
@@ -54,10 +54,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-blockedurl",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -87,7 +87,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -103,10 +103,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-columnnumber",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -136,7 +136,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -152,10 +152,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-disposition",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -185,7 +185,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -201,10 +201,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-documenturl",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -234,7 +234,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -250,10 +250,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-effectivedirective",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -283,7 +283,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -299,10 +299,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-linenumber",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -332,7 +332,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -348,10 +348,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-originalpolicy",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -381,7 +381,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -397,10 +397,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-referrer",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -430,7 +430,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -446,10 +446,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sample",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -479,7 +479,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -495,10 +495,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sourcefile",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -528,7 +528,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -544,10 +544,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-statuscode",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -577,7 +577,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {
@@ -593,10 +593,10 @@
           "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "74"
             },
             "edge": {
               "version_added": "79"
@@ -626,7 +626,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "74"
             }
           },
           "status": {

--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -1,0 +1,641 @@
+{
+  "api": {
+    "CSPViolationReportBody": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody",
+        "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
+        "support": {
+          "chrome": {
+            "version_added": "69"
+          },
+          "chrome_android": {
+            "version_added": "69"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "56"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "10.0"
+          },
+          "webview_android": {
+            "version_added": "69"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "blockedURL": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/blockedURL",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-blockedurl",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "columnNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/columnNumber",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-columnnumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disposition": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/disposition",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-disposition",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "documentURL": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/documentURL",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-documenturl",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "effectiveDirective": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/effectiveDirective",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-effectivedirective",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/lineNumber",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-linenumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "originalPolicy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/originalPolicy",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-originalpolicy",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "referrer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/referrer",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-referrer",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sample": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/sample",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sample",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceFile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/sourceFile",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sourcefile",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "statusCode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/statusCode",
+          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-statuscode",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/toJSON",
+          "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CrashReportBody.json
+++ b/api/CrashReportBody.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CrashReportBody.json
+++ b/api/CrashReportBody.json
@@ -1,0 +1,151 @@
+{
+  "api": {
+    "CrashReportBody": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CrashReportBody",
+        "spec_url": "https://wicg.github.io/crash-reporting/#crashreportbody",
+        "support": {
+          "chrome": {
+            "version_added": "72"
+          },
+          "chrome_android": {
+            "version_added": "72"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "60"
+          },
+          "opera_android": {
+            "version_added": "51"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "11.0"
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "reason": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CrashReportBody/reason",
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-crashreportbody-reason",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CrashReportBody/toJSON",
+          "spec_url": "https://wicg.github.io/crash-reporting/#dom-crashreportbody-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DeprecationReportBody.json
+++ b/api/DeprecationReportBody.json
@@ -1,0 +1,396 @@
+{
+  "api": {
+    "DeprecationReportBody": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody",
+        "spec_url": "https://wicg.github.io/deprecation-reporting/#deprecationreportbody",
+        "support": {
+          "chrome": {
+            "version_added": "69"
+          },
+          "chrome_android": {
+            "version_added": "69"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "56"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "10.0"
+          },
+          "webview_android": {
+            "version_added": "69"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "anticipatedRemoval": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/anticipatedRemoval",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-anticipatedremoval",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "columnNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/columnNumber",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-columnnumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/id",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-id",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/lineNumber",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-linenumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/message",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-message",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceFile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/sourceFile",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-sourcefile",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeprecationReportBody/toJSON",
+          "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/InterventionReportBody.json
+++ b/api/InterventionReportBody.json
@@ -1,0 +1,347 @@
+{
+  "api": {
+    "InterventionReportBody": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody",
+        "spec_url": "https://wicg.github.io/intervention-reporting/#intervention-report",
+        "support": {
+          "chrome": {
+            "version_added": "69"
+          },
+          "chrome_android": {
+            "version_added": "69"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "56"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "10.0"
+          },
+          "webview_android": {
+            "version_added": "69"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "columnNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/columnNumber",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-columnnumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/id",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-id",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/lineNumber",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-linenumber",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/message",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-message",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceFile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/sourceFile",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-sourcefile",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InterventionReportBody/toJSON",
+          "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PermissionsPolicyViolationReportBody.json
+++ b/api/PermissionsPolicyViolationReportBody.json
@@ -1,0 +1,394 @@
+{
+  "api": {
+    "PermissionsPolicyViolationReportBody": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody",
+        "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#permissionspolicyviolationreportbody",
+        "support": {
+          "chrome": {
+            "version_added": "88"
+          },
+          "chrome_android": {
+            "version_added": "88"
+          },
+          "edge": {
+            "version_added": "88"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "74"
+          },
+          "opera_android": {
+            "version_added": "63"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "88"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "columnNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/columnNumber",
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicyviolationreportbody-columnnumber",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disposition": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/disposition",
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicyviolationreportbody-disposition",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "featureId": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/featureId",
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicyviolationreportbody-featureid",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lineNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/lineNumber",
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicyviolationreportbody-linenumber",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/message",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sourceFile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/sourceFile",
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicyviolationreportbody-sourcefile",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionsPolicyViolationReportBody/toJSON",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "chrome_android": {
+              "version_added": "88"
+            },
+            "edge": {
+              "version_added": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "74"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "88"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Report.json
+++ b/api/Report.json
@@ -1,0 +1,249 @@
+{
+  "api": {
+    "Report": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report",
+        "spec_url": "https://w3c.github.io/reporting/#dom-report",
+        "support": {
+          "chrome": {
+            "version_added": "69"
+          },
+          "chrome_android": {
+            "version_added": "69"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "56"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "10.0"
+          },
+          "webview_android": {
+            "version_added": "69"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "body": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/body",
+          "spec_url": "https://w3c.github.io/reporting/#dom-report-body",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/toJSON",
+          "spec_url": "https://w3c.github.io/reporting/#dom-report-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/type",
+          "spec_url": "https://w3c.github.io/reporting/#dom-report-type",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/url",
+          "spec_url": "https://w3c.github.io/reporting/#dom-report-url",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -1,0 +1,102 @@
+{
+  "api": {
+    "Report": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReportBody",
+        "spec_url": "https://w3c.github.io/reporting/#reportbody",
+        "support": {
+          "chrome": {
+            "version_added": "69"
+          },
+          "chrome_android": {
+            "version_added": "69"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "56"
+          },
+          "opera_android": {
+            "version_added": "48"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "10.0"
+          },
+          "webview_android": {
+            "version_added": "69"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/toJSON",
+          "spec_url": "https://w3c.github.io/reporting/#dom-reportbody-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -50,7 +50,6 @@
       },
       "toJSON": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Report/toJSON",
           "spec_url": "https://w3c.github.io/reporting/#dom-reportbody-tojson",
           "support": {
             "chrome": {

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "Report": {
+    "ReportBody": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReportBody",
         "spec_url": "https://w3c.github.io/reporting/#reportbody",


### PR DESCRIPTION
Making a PR I need to get some feedback on this. 

The Reporting API is one of the things we're documenting over at Google and it was missing BCD.

This includes the Reporting API interfaces themselves, but also some reports which are now in separate specs (those Interfaces that are documented on MDN already refer to the old Reporting API spec which included them).

So this includes: 

- `Report`
- `ReportBody` 

Which are part of the Reporting API: https://w3c.github.io/reporting/#interface-reporting-observer
Chrome Status for the Reporting API: https://www.chromestatus.com/feature/4672626140119040

I believe that the original reports that were part of the Reporting API:

- `CrashReportBody`
- `DeprecationReportBody`
- `InterventionReportBody`

were shipped at the same time, but I'm having trouble confirming.

I also have `PermissionsPolicyViolationReportBody` from the Permissions Policy Spec: https://w3c.github.io/webappsec-permissions-policy/#permissionspolicyviolationreportbody

Chrome Status for the header/that spec although I know this has all recently changed from Feature Policy https://www.chromestatus.com/feature/5745992911552512 

`CSPViolationReportBody` from the Content Security Policy spec: https://www.w3.org/TR/CSP3/#cspviolationreportbody

Then there are two interfaces which seem to exist in Chrome IDLs but I can't find a spec for, so I haven't included them in this PR so far.

- `CoopViolationReportBody` which I only find mentioned in an explainer though it appears to have shipped in Chrome: https://www.chromestatus.com/feature/5755687994916864
- `DocumentPolicyViolationReportBody` which I can't find anywhere.

I did however find this issue: https://github.com/w3c/reporting/issues/216 

So that's where I got to, and I figured it might be easier to open this then ping relevant people to help me fill in the blanks.
