### PR TITLE
Add WebView versions for XRSessionMode API

### DIFF
--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -39,7 +39,7 @@
             "version_added": "11.2"
           },
           "webview_android": {
-            "version_added": "79"
+            "version_added": false
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "12.1"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -136,7 +136,7 @@
               "version_added": "11.2"
             },
             "webview_android": {
-              "version_added": "79"
+              "version_added": false
             }
           },
           "status": {
@@ -185,7 +185,7 @@
               "version_added": "11.2"
             },
             "webview_android": {
-              "version_added": "79"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `XRSessionMode` API.  XR isn't supported in WebView altogether, so it doesn't make sense that this would be supported.
