### PR TITLE
Update Safari versions for VRPose API

### DIFF
--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -46,7 +46,8 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "11.1",
+            "version_removed": "14"
           },
           "samsunginternet_android": {
             "version_added": "6.0",
@@ -108,7 +109,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -171,7 +173,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -312,7 +315,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -375,7 +379,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -438,7 +443,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -501,7 +507,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `VRPose` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VRPose
