### PR TITLE
Note onmessageerror attributes in Safari as not really supported

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -431,10 +431,14 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11.1",
+              "partial_implementation": true,
+              "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1012,10 +1012,14 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11.1",
+              "partial_implementation": true,
+              "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=171216#c2

Part of an unfortunate series of events called the web platform.