### PR TITLE
Note Firefox implementation of contentBoxSize

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -112,7 +112,8 @@
               "version_added": "84"
             },
             "firefox": {
-              "version_added": "69"
+              "version_added": "69",
+              "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
             },
             "firefox_android": {
               "version_added": false

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -113,6 +113,7 @@
             },
             "firefox": {
               "version_added": "69",
+              "partial_implementation": true,
               "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
             },
             "firefox_android": {


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/10938 . 

I've tested this using the MDN example at https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#examples, and it's also filed as a Firefox bug at https://bugzilla.mozilla.org/show_bug.cgi?id=1689645.

This update is part of https://github.com/mdn/content/issues/3276.

I don't know what the Firefox for Android situation is so I've left it.
