### PR TITLE
Updates opera to version 77

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -587,14 +587,21 @@
         "76": {
           "release_date": "2021-04-28",
           "release_notes": "https://blogs.opera.com/desktop/2021/04/opera-76-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "77": {
-          "status": "beta",
+          "release_date": "2021-06-09",
+          "release_notes": "https://blogs.opera.com/desktop/2021/06/opera-77-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "91"
+        },
+        "78": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "92"
         }
       }
     }


### PR DESCRIPTION
According to Opera blog on [this link](https://blogs.opera.com/desktop/2021/06/opera-77-stable/), 77 is the current browser opera version.

Closes #10940.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any