### PR TITLE
[Chrome] Update “CSS Logical Properties” support

### DIFF
--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,7 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -75,21 +79,9 @@
                 ]
               }
             ],
-            "opera_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "opera_android": {
+              "version_added": "62"
+            },
             "safari": {
               "version_added": "14.1"
             },

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -54,13 +54,34 @@
             "description": "Flow-relative values <code>inline-start</code> and <code>inline-end</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "55"
@@ -72,7 +93,14 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "57",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -54,13 +54,34 @@
             "description": "Flow-relative values <code>inline-start</code> and <code>inline-end</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "55"
@@ -72,7 +93,14 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "57",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -80,6 +83,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -6,15 +6,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-end",
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-padding",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "41"
             },
@@ -24,11 +63,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": "48"
+              "version_added": "62"
             },
             "safari": {
               "version_added": "12.1"
@@ -37,10 +89,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -6,15 +6,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-start",
           "spec_url": "https://drafts.csswg.org/css-logical/#margin-properties",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "41"
             },
@@ -24,11 +63,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": "48"
+              "version_added": "62"
             },
             "safari": {
               "version_added": "12.1"
@@ -37,10 +89,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -8,7 +8,18 @@
           "support": {
             "chrome": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "2",
@@ -17,7 +28,18 @@
             ],
             "chrome_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "18",
@@ -26,7 +48,18 @@
             ],
             "edge": [
               {
-                "version_added": "79"
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "79",
@@ -56,7 +89,18 @@
             },
             "opera": [
               {
-                "version_added": "56"
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "15",
@@ -65,7 +109,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "48"
+                "version_added": "62"
               },
               {
                 "version_added": "14",
@@ -92,7 +136,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": "10.0"
+                "version_added": "14.0"
               },
               {
                 "alternative_name": "-webkit-margin-end",
@@ -101,7 +145,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
               },
               {
                 "version_added": "2",

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -8,7 +8,18 @@
           "support": {
             "chrome": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "2",
@@ -17,7 +28,18 @@
             ],
             "chrome_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "18",
@@ -26,7 +48,18 @@
             ],
             "edge": [
               {
-                "version_added": "79"
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "79",
@@ -56,7 +89,18 @@
             },
             "opera": [
               {
-                "version_added": "56"
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "15",
@@ -65,7 +109,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "48"
+                "version_added": "62"
               },
               {
                 "version_added": "14",
@@ -92,7 +136,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": "10.0"
+                "version_added": "14.0"
               },
               {
                 "alternative_name": "-webkit-margin-start",
@@ -101,7 +145,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
               },
               {
                 "version_added": "2",

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -6,15 +6,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-end",
           "spec_url": "https://drafts.csswg.org/css-logical/#padding-properties",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "41"
             },
@@ -24,11 +63,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": "48"
+              "version_added": "62"
             },
             "safari": {
               "version_added": "12.1"
@@ -37,10 +89,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -6,15 +6,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-start",
           "spec_url": "https://drafts.csswg.org/css-logical/#padding-properties",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "41"
             },
@@ -24,11 +63,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "56"
-            },
+            "opera": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": "48"
+              "version_added": "62"
             },
             "safari": {
               "version_added": "12.1"
@@ -37,10 +89,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "87"
             }
           },
           "status": {

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -8,7 +8,18 @@
           "support": {
             "chrome": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "2",
@@ -17,7 +28,18 @@
             ],
             "chrome_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "18",
@@ -26,7 +48,18 @@
             ],
             "edge": [
               {
-                "version_added": "79"
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "79",
@@ -56,7 +89,18 @@
             },
             "opera": [
               {
-                "version_added": "56"
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "15",
@@ -65,7 +109,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "48"
+                "version_added": "62"
               },
               {
                 "version_added": "14",
@@ -92,7 +136,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": "10.0"
+                "version_added": "14.0"
               },
               {
                 "alternative_name": "-webkit-padding-end",
@@ -101,7 +145,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
               },
               {
                 "version_added": "2",

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -8,7 +8,18 @@
           "support": {
             "chrome": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "2",
@@ -17,7 +28,18 @@
             ],
             "chrome_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "18",
@@ -26,7 +48,18 @@
             ],
             "edge": [
               {
-                "version_added": "79"
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "79",
@@ -56,7 +89,18 @@
             },
             "opera": [
               {
-                "version_added": "56"
+                "version_added": "73"
+              },
+              {
+                "version_added": "56",
+                "version_removed": "73",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               {
                 "version_added": "15",
@@ -65,7 +109,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "48"
+                "version_added": "62"
               },
               {
                 "version_added": "14",
@@ -92,7 +136,7 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": "10.0"
+                "version_added": "14.0"
               },
               {
                 "alternative_name": "-webkit-padding-start",
@@ -101,7 +145,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "69"
+                "version_added": "87"
               },
               {
                 "version_added": "2",

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -27,6 +28,7 @@
               },
               {
                 "version_added": "69",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -42,6 +44,7 @@
               },
               {
                 "version_added": "79",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -66,6 +69,7 @@
               },
               {
                 "version_added": "56",
+                "version_removed": "73",
                 "flags": [
                   {
                     "type": "preference",
@@ -76,14 +80,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -104,13 +104,34 @@
             "description": "Support for flow-relative values <code>block</code> and <code>inline</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "63"
@@ -122,7 +143,14 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "57",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- `float: inline‑start | inline‑end`, `clear: inline‑start | inline‑end`, and `resize: block | inline`<br
/>were implemented in [Bug 850004](https://crbug.com/850004).
- The `{inset|margin|padding}‑{block|inline}‑{start|end}` properties were shipped in <https://github.com/chromium/chromium/commit/f13ce426d1f2ac45ca5bd2b8c728d8832d9598c0>

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- [Bug 850004](https://crbug.com/850004)
	- <https://github.com/chromium/chromium/commit/c2ffe93299c49e5d6c6db6d1df34fa1f6c713913> ([Shipped in 69.0.3482.0](https://storage.googleapis.com/chromium-find-releases-static/c2f.html#c2ffe93299c49e5d6c6db6d1df34fa1f6c713913))
	- <https://github.com/chromium/chromium/commit/502e56bfc1675124aee807d9d1fe4977d972f7d8>([Shipped in 70.0.3518.0](https://storage.googleapis.com/chromium-find-releases-static/502.html#502e56bfc1675124aee807d9d1fe4977d972f7d8))
- [Bug 497851](https://crbug.com/497851)
	- <https://github.com/chromium/chromium/commit/f13ce426d1f2ac45ca5bd2b8c728d8832d9598c0> ([Shipped in 87.0.4253.0](https://storage.googleapis.com/chromium-find-releases-static/141.html#14115cf9e3e8f32e494208f4c10dd96f2c28fb60))

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- <https://github.com/mdn/browser-compat-data/pull/2639> – They were implemented _but not shipped yet_ in **Chrome 69**. 🤦🏻‍♂️

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

---

review(@ddbeck, @Elchi3, @jpmedley)