### PR TITLE
Add spec + mdn page to all feature already in font-face.json

### DIFF
--- a/svg/elements/font-face.json
+++ b/svg/elements/font-face.json
@@ -3,7 +3,7 @@
     "elements": {
       "font-face": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/font-face",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Element/font-face",
           "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElement",
           "support": {
             "chrome": {
@@ -51,6 +51,8 @@
         },
         "accent-height": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accent-height",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAccentHeightAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -98,6 +100,8 @@
         },
         "alphabetic": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alphabetic",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAlphabeticAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +149,8 @@
         },
         "ascent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAscentAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +198,8 @@
         },
         "bbox": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bbox",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementBboxAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +247,8 @@
         },
         "cap-height": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cap-height",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementCapHeightAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -286,6 +296,8 @@
         },
         "descent": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/descent",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementDescentAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -333,6 +345,8 @@
         },
         "font-family": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-family",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontFamilyAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -380,6 +394,8 @@
         },
         "font-size": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-size",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontSizeAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -427,6 +443,8 @@
         },
         "font-stretch": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-stretch",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontStretchAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -474,6 +492,8 @@
         },
         "font-style": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-style",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontStyleAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -521,6 +541,8 @@
         },
         "font-variant": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-variant",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontVariantAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -568,6 +590,8 @@
         },
         "font-weight": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-weight",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontWeightAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -615,6 +639,8 @@
         },
         "hanging": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/hanging",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementHangingAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -662,6 +688,8 @@
         },
         "ideographic": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ideographic",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementIdeographicAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -709,6 +737,8 @@
         },
         "mathematical": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/mathematical",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementMathematicalAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -756,6 +786,8 @@
         },
         "overline-position": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-position",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementOverlinePositionAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -803,6 +835,8 @@
         },
         "overline-thickness": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-position",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementOverlineThicknessAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -850,6 +884,8 @@
         },
         "panose-1": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/panose-1",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementPanose1Attribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -897,6 +933,8 @@
         },
         "slope": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/slope",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementSlopeAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -944,6 +982,8 @@
         },
         "stemh": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemh",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStemhAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -991,6 +1031,8 @@
         },
         "stemv": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemv",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStemvAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1038,6 +1080,8 @@
         },
         "strikethrough-position": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-position",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStrikeThroughPositionAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1085,6 +1129,8 @@
         },
         "strikethrough-thickness": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-thickness",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStrikeThroughThicknessAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1132,6 +1178,8 @@
         },
         "underline-position": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-position",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnderlinePositionAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1179,6 +1227,8 @@
         },
         "underline-thickness": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-thickness",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnderlineThicknessAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1226,6 +1276,8 @@
         },
         "unicode-range": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/unicode-range",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnicodeRangeAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1273,6 +1325,8 @@
         },
         "units-per-em": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/units-per-em",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnitsPerEmAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1320,6 +1374,8 @@
         },
         "v-alphabetic": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-alphabetic",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertAlphabeticAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1367,6 +1423,8 @@
         },
         "v-hanging": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-hanging",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertHangingAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1414,6 +1472,8 @@
         },
         "v-ideographic": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-ideographic",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertIdeographicAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1461,6 +1521,8 @@
         },
         "v-mathematical": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-mathematical",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertMathematicalAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1508,6 +1570,8 @@
         },
         "widths": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/widths",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementWidthsAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1555,6 +1619,8 @@
         },
         "x-height": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x-height",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementXHeightAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/font-face.json
+++ b/svg/elements/font-face.json
@@ -3,7 +3,7 @@
     "elements": {
       "font-face": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Element/font-face",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Element/font-face",
           "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElement",
           "support": {
             "chrome": {
@@ -51,7 +51,7 @@
         },
         "accent-height": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accent-height",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/accent-height",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAccentHeightAttribute",
             "support": {
               "chrome": {
@@ -100,7 +100,7 @@
         },
         "alphabetic": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alphabetic",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/alphabetic",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAlphabeticAttribute",
             "support": {
               "chrome": {
@@ -149,7 +149,7 @@
         },
         "ascent": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/ascent",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementAscentAttribute",
             "support": {
               "chrome": {
@@ -198,7 +198,7 @@
         },
         "bbox": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bbox",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/bbox",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementBboxAttribute",
             "support": {
               "chrome": {
@@ -247,7 +247,7 @@
         },
         "cap-height": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cap-height",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/cap-height",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementCapHeightAttribute",
             "support": {
               "chrome": {
@@ -296,7 +296,7 @@
         },
         "descent": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/descent",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/descent",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementDescentAttribute",
             "support": {
               "chrome": {
@@ -345,7 +345,7 @@
         },
         "font-family": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-family",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-family",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontFamilyAttribute",
             "support": {
               "chrome": {
@@ -394,7 +394,7 @@
         },
         "font-size": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-size",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-size",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontSizeAttribute",
             "support": {
               "chrome": {
@@ -443,7 +443,7 @@
         },
         "font-stretch": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-stretch",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-stretch",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontStretchAttribute",
             "support": {
               "chrome": {
@@ -492,7 +492,7 @@
         },
         "font-style": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-style",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-style",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontStyleAttribute",
             "support": {
               "chrome": {
@@ -541,7 +541,7 @@
         },
         "font-variant": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-variant",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-variant",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontVariantAttribute",
             "support": {
               "chrome": {
@@ -590,7 +590,7 @@
         },
         "font-weight": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-weight",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/font-weight",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementFontWeightAttribute",
             "support": {
               "chrome": {
@@ -639,7 +639,7 @@
         },
         "hanging": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/hanging",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/hanging",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementHangingAttribute",
             "support": {
               "chrome": {
@@ -688,7 +688,7 @@
         },
         "ideographic": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ideographic",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/ideographic",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementIdeographicAttribute",
             "support": {
               "chrome": {
@@ -737,7 +737,7 @@
         },
         "mathematical": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/mathematical",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/mathematical",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementMathematicalAttribute",
             "support": {
               "chrome": {
@@ -786,7 +786,7 @@
         },
         "overline-position": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-position",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/overline-position",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementOverlinePositionAttribute",
             "support": {
               "chrome": {
@@ -835,7 +835,7 @@
         },
         "overline-thickness": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-position",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/overline-position",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementOverlineThicknessAttribute",
             "support": {
               "chrome": {
@@ -884,7 +884,7 @@
         },
         "panose-1": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/panose-1",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/panose-1",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementPanose1Attribute",
             "support": {
               "chrome": {
@@ -933,7 +933,7 @@
         },
         "slope": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/slope",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/slope",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementSlopeAttribute",
             "support": {
               "chrome": {
@@ -982,7 +982,7 @@
         },
         "stemh": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemh",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stemh",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStemhAttribute",
             "support": {
               "chrome": {
@@ -1031,7 +1031,7 @@
         },
         "stemv": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemv",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stemv",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStemvAttribute",
             "support": {
               "chrome": {
@@ -1080,7 +1080,7 @@
         },
         "strikethrough-position": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-position",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/strikethrough-position",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStrikeThroughPositionAttribute",
             "support": {
               "chrome": {
@@ -1129,7 +1129,7 @@
         },
         "strikethrough-thickness": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-thickness",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/strikethrough-thickness",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementStrikeThroughThicknessAttribute",
             "support": {
               "chrome": {
@@ -1178,7 +1178,7 @@
         },
         "underline-position": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-position",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/underline-position",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnderlinePositionAttribute",
             "support": {
               "chrome": {
@@ -1227,7 +1227,7 @@
         },
         "underline-thickness": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-thickness",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/underline-thickness",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnderlineThicknessAttribute",
             "support": {
               "chrome": {
@@ -1276,7 +1276,7 @@
         },
         "unicode-range": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/unicode-range",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/unicode-range",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnicodeRangeAttribute",
             "support": {
               "chrome": {
@@ -1325,7 +1325,7 @@
         },
         "units-per-em": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/units-per-em",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/units-per-em",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementUnitsPerEmAttribute",
             "support": {
               "chrome": {
@@ -1374,7 +1374,7 @@
         },
         "v-alphabetic": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-alphabetic",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/v-alphabetic",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertAlphabeticAttribute",
             "support": {
               "chrome": {
@@ -1423,7 +1423,7 @@
         },
         "v-hanging": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-hanging",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/v-hanging",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertHangingAttribute",
             "support": {
               "chrome": {
@@ -1472,7 +1472,7 @@
         },
         "v-ideographic": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-ideographic",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/v-ideographic",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertIdeographicAttribute",
             "support": {
               "chrome": {
@@ -1521,7 +1521,7 @@
         },
         "v-mathematical": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-mathematical",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/v-mathematical",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementVertMathematicalAttribute",
             "support": {
               "chrome": {
@@ -1570,7 +1570,7 @@
         },
         "widths": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/widths",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/widths",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementWidthsAttribute",
             "support": {
               "chrome": {
@@ -1619,7 +1619,7 @@
         },
         "x-height": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x-height",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/x-height",
             "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceElementXHeightAttribute",
             "support": {
               "chrome": {


### PR DESCRIPTION
These features are already in browser-compat-data.

None of them had neither a spec_url nor a mdn_url. They are all already documented in MDN, and all are specificied in SVG 1.1.