### PR TITLE
HTTP spec urls for rtt, downlink, ect headers 

### DIFF
--- a/http/headers/downlink.json
+++ b/http/headers/downlink.json
@@ -4,6 +4,7 @@
       "downlink": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/downlink",
+          "spec_url": "https://wicg.github.io/netinfo/#downlink-request-header-field",
           "support": {
             "chrome": {
               "version_added": "67"

--- a/http/headers/ect.json
+++ b/http/headers/ect.json
@@ -4,6 +4,7 @@
       "ect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ect",
+          "spec_url": "https://wicg.github.io/netinfo/#ect-request-header-field",
           "support": {
             "chrome": {
               "version_added": "67"

--- a/http/headers/rtt.json
+++ b/http/headers/rtt.json
@@ -4,6 +4,7 @@
       "rtt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/rtt",
+          "spec_url": "https://wicg.github.io/netinfo/#rtt-request-header-field",
           "support": {
             "chrome": {
               "version_added": "67"


### PR DESCRIPTION
I'm getting ready to do the docs for these HTTP headers. This adds spec urls. All three are in https://wicg.github.io/netinfo/