### PR TITLE
Add spec + mdn page to all feature already in feDistantLight.json

### DIFF
--- a/svg/elements/feDistantLight.json
+++ b/svg/elements/feDistantLight.json
@@ -51,6 +51,8 @@
         },
         "azimuth": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/azimuth",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fedistantlight-azimuth",
             "support": {
               "chrome": {
                 "version_added": null
@@ -98,6 +100,8 @@
         },
         "elevation": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/elevation",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fedistantlight-elevation",
             "support": {
               "chrome": {
                 "version_added": null


### PR DESCRIPTION
These features are already in browser-compat-data.

None of them had neither a spec_url nor a mdn_url. They are all already documented in MDN.