### PR TITLE
updating FontFace with spec URLs and data

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -100,6 +100,8 @@
       },
       "ascentOverride": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/ascentOverride",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfacedescriptors-ascentoverride",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -111,10 +113,10 @@
               "version_added": "87"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -123,7 +125,7 @@
               "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -139,7 +141,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -147,6 +149,8 @@
       },
       "descentOverride": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/descentOverride",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfacedescriptors-descentoverride",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -158,10 +162,10 @@
               "version_added": "87"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -170,7 +174,7 @@
               "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -186,7 +190,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -235,7 +239,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -284,7 +288,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -333,7 +337,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -341,6 +345,8 @@
       },
       "lineGapOverride": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/lineGapOverride",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfacedescriptors-linegapoverride",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -352,10 +358,10 @@
               "version_added": "87"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -364,7 +370,7 @@
               "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -380,7 +386,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -461,7 +467,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -542,7 +548,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -591,7 +597,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -640,7 +646,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -689,7 +695,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -738,7 +744,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -787,7 +793,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -795,15 +801,17 @@
       },
       "variationSettings": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/variationSettings",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfacedescriptors-variationsettings",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "62"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "62"
@@ -815,10 +823,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -827,10 +835,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "62"
             }
           },
           "status": {
@@ -883,7 +891,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
I have created pages for some missing properties linked to the new @FontFace descriptors so this adds their spec and MDN urls and also missing support data.

re: https://github.com/mdn/content/pull/5887