### PR TITLE
Add spec + mdn page to features  in Filter Effects

### DIFF
--- a/svg/elements/feConvolveMatrix.json
+++ b/svg/elements/feConvolveMatrix.json
@@ -51,6 +51,8 @@
         },
         "bias": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/bias",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-bias",
             "support": {
               "chrome": {
                 "version_added": null
@@ -98,6 +100,8 @@
         },
         "divisor": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/divisor",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-divisor",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +149,8 @@
         },
         "edgeMode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/edgeMode",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-edgemode",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +198,8 @@
         },
         "in": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/in",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-in",
             "support": {
               "chrome": {
                 "version_added": true
@@ -239,6 +247,8 @@
         },
         "kernelMatrix": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/kernelMatrix",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-kernelmatrix",
             "support": {
               "chrome": {
                 "version_added": true
@@ -286,6 +296,8 @@
         },
         "kernelUnitLength": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/kernelUnitLength",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-kernelunitlength",
             "support": {
               "chrome": {
                 "version_added": null
@@ -333,6 +345,8 @@
         },
         "order": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/order",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-order",
             "support": {
               "chrome": {
                 "version_added": null
@@ -380,6 +394,8 @@
         },
         "preserveAlpha": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/preserveAlpha",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-preservealpha",
             "support": {
               "chrome": {
                 "version_added": null
@@ -427,6 +443,8 @@
         },
         "targetX": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/targetX",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-targetx",
             "support": {
               "chrome": {
                 "version_added": null
@@ -474,6 +492,8 @@
         },
         "targetY": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/targetY",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-targety",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/feDiffuseLighting.json
+++ b/svg/elements/feDiffuseLighting.json
@@ -101,7 +101,7 @@
         "in": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/in",
-            "spec_url": "https://drafts.fxtf.org/filter-effects/#feDelement-attrdef-filter-primitive-iniffuseLightingElement",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-in",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/feDiffuseLighting.json
+++ b/svg/elements/feDiffuseLighting.json
@@ -51,6 +51,8 @@
         },
         "diffuseConstant": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/diffuseConstant",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-diffuseconstant",
             "support": {
               "chrome": {
                 "version_added": null
@@ -98,6 +100,8 @@
         },
         "in": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/in",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#feDelement-attrdef-filter-primitive-iniffuseLightingElement",
             "support": {
               "chrome": {
                 "version_added": true
@@ -145,6 +149,8 @@
         },
         "kernelUnitLength": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/kernelUnitLength",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-kernelunitlength",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +198,8 @@
         },
         "surfaceScale": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/surfaceScale",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-surfacescale",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/feTurbulence.json
+++ b/svg/elements/feTurbulence.json
@@ -53,6 +53,8 @@
         },
         "baseFrequency": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/baseFrequency",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-basefrequency",
             "support": {
               "chrome": {
                 "version_added": true
@@ -102,6 +104,8 @@
         },
         "numOctaves": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/numOctaves",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-numoctaves",
             "support": {
               "chrome": {
                 "version_added": null
@@ -149,6 +153,8 @@
         },
         "seed": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/seed",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-seed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -198,6 +204,8 @@
         },
         "stitchTiles": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stitchTiles",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-stitchtiles",
             "support": {
               "chrome": {
                 "version_added": null
@@ -245,6 +253,8 @@
         },
         "type": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/type",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-type",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -51,6 +51,8 @@
         },
         "filterRes": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/filterRes",
+            "spec_url": "https://www.w3.org/TR/SVG11/filters.html#FilterElementFilterResAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -92,12 +94,14 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
         "filterUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/filterUnits",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-filterunits",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +149,8 @@
         },
         "height": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/height",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-height",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +198,8 @@
         },
         "primitiveUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/primitiveUnits",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitiveunits",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +247,8 @@
         },
         "width": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/width",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-width",
             "support": {
               "chrome": {
                 "version_added": null
@@ -286,6 +296,8 @@
         },
         "x": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/x",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-x",
             "support": {
               "chrome": {
                 "version_added": null
@@ -333,6 +345,8 @@
         },
         "xlink_href": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/xlink:href",
+            "spec_url": "https://www.w3.org/TR/SVG11/filters.html#FilterElementHrefAttribute",
             "description": "<code>xlink:href</code>",
             "support": {
               "chrome": {
@@ -381,6 +395,8 @@
         },
         "y": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/y",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-y",
             "support": {
               "chrome": {
                 "version_added": null


### PR DESCRIPTION
These features are already in browser-compat-data.
Element dealt with: `<feConvolveMatrix>`, `<feDiffuseLighting>`, `<feTurbulence>`, and `<filter>`

None of them had neither a spec_url nor a mdn_url. They are all already documented in MDN.