### PR TITLE
Demix Body to Request and Response

### DIFF
--- a/api/_mixins/Body__Request.json
+++ b/api/_mixins/Body__Request.json
@@ -1,53 +1,9 @@
 {
   "api": {
-    "Body": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body",
-        "spec_url": "https://fetch.spec.whatwg.org/#body-mixin",
-        "support": {
-          "chrome": {
-            "version_added": "42"
-          },
-          "chrome_android": {
-            "version_added": "42"
-          },
-          "edge": {
-            "version_added": "≤18"
-          },
-          "firefox": {
-            "version_added": "39"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": {
-            "version_added": "29"
-          },
-          "opera_android": {
-            "version_added": "29"
-          },
-          "safari": {
-            "version_added": "10.1"
-          },
-          "safari_ios": {
-            "version_added": "10.3"
-          },
-          "samsunginternet_android": {
-            "version_added": "4.0"
-          },
-          "webview_android": {
-            "version_added": "42"
-          }
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
+    "Request": {
       "arrayBuffer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/arrayBuffer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-arraybuffer①",
           "support": {
             "chrome": {
@@ -57,13 +13,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -84,11 +40,11 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -96,7 +52,7 @@
       },
       "blob": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/blob",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/blob",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-blob①",
           "support": {
             "chrome": {
@@ -106,13 +62,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -133,11 +89,11 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -145,32 +101,36 @@
       },
       "body": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/body",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/body",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-body①",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/688906'>bug 688906</a>."
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/688906'>bug 688906</a>."
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "65"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1387483'>bug 1387483</a>"
             },
             "firefox_android": {
-              "version_added": "65"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1387483'>bug 1387483</a>"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "39"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -179,14 +139,14 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": false
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -194,23 +154,23 @@
       },
       "bodyUsed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/bodyUsed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/bodyUsed",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-bodyused①",
           "support": {
             "chrome": {
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -228,14 +188,14 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -243,7 +203,7 @@
       },
       "formData": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/formData",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/formData",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-formdata①",
           "support": {
             "chrome": {
@@ -253,13 +213,13 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -270,16 +230,26 @@
             "opera_android": {
               "version_added": "44"
             },
-            "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": "From Safari 10.1, the method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
-            },
-            "safari_ios": {
-              "version_added": "10.3",
-              "partial_implementation": true,
-              "notes": "From Safari for iOS 10.3, the method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "The method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11.3",
+                "partial_implementation": true,
+                "notes": "The method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "8.0"
             },
@@ -288,7 +258,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -296,7 +266,7 @@
       },
       "json": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/json",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/json",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-json①",
           "support": {
             "chrome": {
@@ -306,13 +276,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -333,11 +303,11 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -345,7 +315,7 @@
       },
       "text": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Body/text",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/text",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-text①",
           "support": {
             "chrome": {
@@ -355,13 +325,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -382,11 +352,11 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/_mixins/Body__Response.json
+++ b/api/_mixins/Body__Response.json
@@ -1,0 +1,363 @@
+{
+  "api": {
+    "Response": {
+      "arrayBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/arrayBuffer",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-arraybuffer①",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blob": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/blob",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-blob①",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "body": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/body",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-body①",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bodyUsed": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/bodyUsed",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-bodyused①",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/formData",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-formdata①",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "10.1",
+                "partial_implementation": true,
+                "notes": "The method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "10.3",
+                "partial_implementation": true,
+                "notes": "The method exists but always rejects with <code>NotSupportedError</code>. See <a href='https://webkit.org/b/215671'>bug 215671</a>."
+              }
+            ],
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "json": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/json",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-json①",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/text",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-text①",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Data from mdn-bcd-collector was used to confirm data for these versions:
- Chrome 42 (most entries)
- Chrome 43 (Response.body)
- Chrome 60 (formData attributes)
- Edge 14 (most entries)
- Edge 79 (formData attributes)
- Firefox 39 (most entries)
- Firefox 65 (Response.body)
- Safari 10.1 (most entries, including always-rejecting Response.formData)
- Safari 11.1 (Request.body + always-rejecting Request.formData)

The fixed formData attributes in Safari 14.1 / iOS 14.3 is based on:
https://github.com/mdn/browser-compat-data/issues/6620

Anything else was mirrored, including all mobile browser data. IE was
not tested at all.

Notable differences to the original data:
- Request.body is not shipped in Chrome/Firefox:
  https://crbug.com/688906
  https://bugzil.la/1387483
- Response.body was shipped in Chrome 43:
  https://bugs.chromium.org/p/chromium/issues/detail?id=240603#c40
- Edge ≤18 versions all replaced
- A bunch of false values changed to real version

This also changes the experimental status to false, since this has all
been shipped basically everywhere now.

Closes https://github.com/mdn/browser-compat-data/issues/6620.