### PR TITLE
Add BCD for children of ContentIndexEvent

### DIFF
--- a/api/ContentIndexEvent.json
+++ b/api/ContentIndexEvent.json
@@ -47,6 +47,105 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "ContentIndexEvent": {
+        "__compat": {
+          "description": "<code>ContentIndexEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentIndexEvent/ContentIndexEvent",
+          "spec_url": "https://wicg.github.io/content-index/spec/#content-index-event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "60"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "in": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentIndexEvent/id",
+          "spec_url": "https://wicg.github.io/content-index/spec/#dom-contentindexevent-id",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "60"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "84"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
ContextIndexEvent has two children (its constructor and the id property) that were added at the same type as the interface

#### Related issues
Detected because we are now sourcing spec from here on MDN.