### PR TITLE
Add (or fix) mdn_url and spec_url to CookieStoreManager and co.

### DIFF
--- a/api/CookieStoreManager.json
+++ b/api/CookieStoreManager.json
@@ -2,6 +2,8 @@
   "api": {
     "CookieStoreManager": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStoreManager",
+        "spec_url": "https://wicg.github.io/cookie-store/#cookiestoremanager",
         "support": {
           "chrome": {
             "version_added": "87"
@@ -48,6 +50,8 @@
       },
       "getSubscriptions": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStoreManager/getSubscriptions",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestoremanager-getsubscriptions",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -95,6 +99,8 @@
       },
       "subscribe": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStoreManager/subscribe",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestoremanager-subscribe",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -142,6 +148,8 @@
       },
       "unsubscribe": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStoreManager/unsubscribe",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestoremanager-unsubscribe",
           "support": {
             "chrome": {
               "version_added": "87"


### PR DESCRIPTION

#### Summary
Added (or fixed) mdn_url and spec_url field for CookieStoreManager and its children.

#### Test results and supporting details
No BCD changed, only links.

#### Related issues
Discovers when updating the MDN pages to use spec_url here.
