### PR TITLE
Add mdn_url and spec_url to CookieStore and all its children

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -2,6 +2,8 @@
   "api": {
     "CookieStore": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore",
+        "spec_url": "https://wicg.github.io/cookie-store/#CookieStore",
         "support": {
           "chrome": {
             "version_added": "87"
@@ -48,6 +50,8 @@
       },
       "delete": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/delete",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-delete",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -95,6 +99,8 @@
       },
       "get": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/get",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-get",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -142,6 +148,8 @@
       },
       "getAll": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/getAll",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-getall",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -189,6 +197,8 @@
       },
       "onchange": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/onchange",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-onchange",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -236,6 +246,8 @@
       },
       "set": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/set",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-set",
           "support": {
             "chrome": {
               "version_added": "87"


### PR DESCRIPTION
#### Summary
Added (or fixed) mdn_url and spec_url field for CookieStore and its children.

#### Test results and supporting details
No BCD changed, only links.

#### Related issues
Discovers when updating the MDN pages to use spec_url here.
