### PR TITLE
Add mdn_url and spec_url to CompressionStream and all its children

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -101,10 +101,7 @@
       "readable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/readable",
-          "spec_url": [
-            "https://wicg.github.io/compression/#compression-stream",
-            "https://streams.spec.whatwg.org/#dom-generictransformstream-readable"
-          ],
+          "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-readable",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -153,10 +150,7 @@
       "writable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/writable",
-          "spec_url": [
-            "https://wicg.github.io/compression/#compression-stream",
-            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"
-          ],
+          "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-writable",
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -155,7 +155,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/writable",
           "spec_url": [
             "https://wicg.github.io/compression/#compression-stream",
-            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"],
+            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -2,6 +2,8 @@
   "api": {
     "CompressionStream": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream",
+        "spec_url": "https://wicg.github.io/compression/#compression-stream",
         "support": {
           "chrome": {
             "version_added": "80"
@@ -49,6 +51,8 @@
       "CompressionStream": {
         "__compat": {
           "description": "<code>CompressionStream()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/CompressionStream",
+          "spec_url": "https://wicg.github.io/compression/#dom-compressionstream-compressionstream",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -96,6 +100,11 @@
       },
       "readable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/readable",
+          "spec_url": [
+            "https://wicg.github.io/compression/#compression-stream",
+            "https://streams.spec.whatwg.org/#dom-generictransformstream-readable"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -143,6 +152,10 @@
       },
       "writable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CompressionStream/writable",
+          "spec_url": [
+            "https://wicg.github.io/compression/#compression-stream",
+            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -101,10 +101,7 @@
       "readable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/readable",
-          "spec_url": [
-            "https://wicg.github.io/compression/#decompression-stream",
-            "https://streams.spec.whatwg.org/#dom-generictransformstream-readable"
-          ],
+          "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-readable",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -153,10 +150,7 @@
       "writable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/writable",
-          "spec_url": [
-            "https://wicg.github.io/compression/#decompression-stream",
-            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"
-          ],
+          "spec_url": "https://streams.spec.whatwg.org/#dom-generictransformstream-writable",
           "support": {
             "chrome": {
               "version_added": "80"

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -2,6 +2,8 @@
   "api": {
     "DecompressionStream": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream",
+        "spec_url": "https://wicg.github.io/compression/#decompression-stream",
         "support": {
           "chrome": {
             "version_added": "80"
@@ -49,6 +51,8 @@
       "DecompressionStream": {
         "__compat": {
           "description": "<code>DecompressionStream()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/DecompressionStream",
+          "spec_url": "https://wicg.github.io/compression/#dom-decompressionstream-decompressionstream",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -96,6 +100,11 @@
       },
       "readable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/readable",
+          "spec_url": [
+            "https://wicg.github.io/compression/#decompression-stream",
+            "https://streams.spec.whatwg.org/#dom-generictransformstream-readable"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"
@@ -143,6 +152,11 @@
       },
       "writable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DecompressionStream/writable",
+          "spec_url": [
+            "https://wicg.github.io/compression/#decompression-stream",
+            "https://streams.spec.whatwg.org/#dom-generictransformstream-writable"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"


### PR DESCRIPTION
#### Summary
Added (or fixed) mdn_url and spec_url field for CompressionStream and DecompressionStream and their children.

#### Test results and supporting details
No BCD changed, only links.

#### Related issues
Discovers when updating the MDN pages to use spec_url here.

Note that 2 children of each interfaces are defined in a mixin that is defined in another spec.
