### PR TITLE
Add BCD info for CSSConditionRule.conditionText

### DIFF
--- a/api/CSSConditionRule.json
+++ b/api/CSSConditionRule.json
@@ -47,6 +47,55 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "conditionText": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSConditionRule/conditionText",
+          "spec_url": "https://drafts.csswg.org/css-conditional/#dom-cssconditionrule-conditiontext",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "20"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "56"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
We had BCD for CSSConditionRule but not for CSSConditionRule.conditionText, added at the same time.

#### Test results and supporting details
https://bugzilla.mozilla.org/show_bug.cgi?id=814907
CSSConditionRule isn't useful without this property.

#### Related issues
Detected while replacing a hardcoded spec table on MDN.
