### PR TITLE
Add missing spec_url in CSS* apis

### DIFF
--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -3,6 +3,7 @@
     "CSSPrimitiveValue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue",
+        "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue",
         "support": {
           "chrome": {
             "version_added": "1",
@@ -58,6 +59,7 @@
       "getCounterValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getCounterValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getCounterValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -114,6 +116,7 @@
       "getFloatValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getFloatValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getFloatValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -170,6 +173,7 @@
       "getRectValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRectValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getRectValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -226,6 +230,7 @@
       "getRGBColorValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getRGBColorValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getRGBColorValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -282,6 +287,7 @@
       "getStringValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/getStringValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getStringValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -338,6 +344,7 @@
       "primitiveType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/primitiveType",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-primitiveType",
           "support": {
             "chrome": {
               "version_added": false
@@ -388,6 +395,7 @@
       "setFloatValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setFloatValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-setFloatValue",
           "support": {
             "chrome": {
               "version_added": "1",
@@ -444,6 +452,7 @@
       "setStringValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPrimitiveValue/setStringValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-setStringValue",
           "support": {
             "chrome": {
               "version_added": "1",

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -151,6 +151,7 @@
       "getPropertyCSSValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/getPropertyCSSValue",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration",
           "support": {
             "chrome": {
               "version_added": "1",

--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -3,6 +3,7 @@
     "CSSValue": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValue",
+        "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue",
         "support": {
           "chrome": {
             "version_added": false
@@ -52,6 +53,7 @@
       "cssText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValue/cssText",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-cssText",
           "support": {
             "chrome": {
               "version_added": false
@@ -102,6 +104,7 @@
       "cssValueType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValue/cssValueType",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-cssValueType",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -3,6 +3,7 @@
     "CSSValueList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValueList",
+        "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValuesList",
         "support": {
           "chrome": {
             "version_added": false
@@ -52,6 +53,7 @@
       "item": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValueList/item",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValueList-item",
           "support": {
             "chrome": {
               "version_added": false
@@ -102,6 +104,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSValueList/length",
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValueList-length",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
Added a few missing spec_url on some old CSSOM* apis.