### PR TITLE
Add mdn_url and spec_url to Document.all

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -367,6 +367,8 @@
       },
       "all": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/all",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
Add mdn_url and spec_url to the single standard Document.all entry.

No BCD touched.