### PR TITLE
Add mdn_url, spec_url and bcd to DOMPoint.* that were missing

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -100,7 +100,6 @@
       },
       "fromPoint": {
         "__compat": {
-          "description": "<code>DOMPoint()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/fromPoint",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint",
           "support": {
@@ -150,7 +149,6 @@
       },
       "w": {
         "__compat": {
-          "description": "<code>DOMPoint()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/w",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-w",
           "support": {
@@ -248,7 +246,6 @@
       },
       "x": {
         "__compat": {
-          "description": "<code>DOMPoint()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/x",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-x",
           "support": {
@@ -298,7 +295,6 @@
       },
       "y": {
         "__compat": {
-          "description": "<code>DOMPoint()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/y",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-y",
           "support": {
@@ -348,7 +344,6 @@
       },
       "z": {
         "__compat": {
-          "description": "<code>DOMPoint()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/z",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-z",
           "support": {

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -98,6 +98,256 @@
           }
         }
       },
+      "fromPoint": {
+        "__compat": {
+          "description": "<code>DOMPoint()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/fromPoint",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "w": {
+        "__compat": {
+          "description": "<code>DOMPoint()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/w",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-w",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "description": "<code>DOMPoint()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/x",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-x",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "description": "<code>DOMPoint()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/y",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-y",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "z": {
+        "__compat": {
+          "description": "<code>DOMPoint()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/z",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-z",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -92,7 +92,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -101,7 +101,7 @@
       "fromPoint": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/fromPoint",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/fromPoint",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint",
           "support": {
             "chrome": {
@@ -142,7 +142,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -151,7 +151,7 @@
       "w": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/w",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/w",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-w",
           "support": {
             "chrome": {
@@ -192,7 +192,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -249,7 +249,7 @@
       "x": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/x",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/x",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-x",
           "support": {
             "chrome": {
@@ -290,7 +290,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -299,7 +299,7 @@
       "y": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/y",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/y",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-y",
           "support": {
             "chrome": {
@@ -340,7 +340,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -349,7 +349,7 @@
       "z": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/DOMPoint/z",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/z",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-z",
           "support": {
             "chrome": {
@@ -390,7 +390,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -198,6 +198,54 @@
           }
         }
       },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "x": {
         "__compat": {
           "description": "<code>DOMPoint()</code> constructor",
@@ -343,54 +391,6 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": {
-              "version_added": "61"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "69"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "48"
-            },
-            "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "61"
-            }
-          },
-          "status": {
-            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The children of `DOMPoint` (`w`, `x`, `y`, `z`, `fromPoint`) were not listed. I added them.