### PR TITLE
Add APIs for custom state pseudo class

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -1,18 +1,17 @@
 {
   "api": {
-    "ElementInternals": {
+    "CustomStateSet": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals",
-        "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface",
+        "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
         "support": {
           "chrome": {
-            "version_added": "77"
+            "version_added": "90"
           },
           "chrome_android": {
-            "version_added": "77"
+            "version_added": "90"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "90"
           },
           "firefox": {
             "version_added": false
@@ -24,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "64"
+            "version_added": "76"
           },
           "opera_android": {
-            "version_added": "55"
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -36,364 +35,21 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "12.0"
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "77"
+            "version_added": "90"
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
       },
-      "checkValidity": {
+      "add": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/checkValidity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-elementinternals-checkvalidity",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "form": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/form",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-elementinternals-form",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "labels": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/labels",
-          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#dom-elementinternals-labels",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "reportValidity": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/reportValidity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-elementinternals-reportvalidity",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "setFormValue": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/setFormValue",
-          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setformvalue",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "setValidity": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/setValidity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setvalidity",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "shadowRoot": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/shadowRoot",
-          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-shadowroot",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "states": {
-        "__compat": {
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#dom-elementinternals-states",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#dom-customstateset-add",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -439,19 +95,18 @@
           }
         }
       },
-      "validationMessage": {
+      "clear": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/validationMessage",
-          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-validationmessage",
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "90"
             },
             "firefox": {
               "version_added": false
@@ -463,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -475,32 +130,31 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "90"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "validity": {
+      "delete": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/validity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-elementinternals-validity",
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "90"
             },
             "firefox": {
               "version_added": false
@@ -512,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -524,32 +178,31 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "90"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "willValidate": {
+      "entries": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/willValidate",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-elementinternals-willvalidate",
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "90"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "90"
             },
             "firefox": {
               "version_added": false
@@ -561,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -573,14 +226,302 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "90"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "forEach": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "has": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keys": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "values": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "@@iterator": {
+        "__compat": {
+          "spec_url": "https://heycam.github.io/webidl/#idl-setlike",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Spec: https://wicg.github.io/custom-state-pseudo-class/.

Most of the API surface comes from the `setlike<DOMString>` declaration,
which can't be linked directly, so no `spec_url` for those.

The flag was enabled for Chromium 90 here:
https://storage.googleapis.com/chromium-find-releases-static/78f.html#78fbd97dbf148a448be60f038701037ac6cb9151

This hasn't reached Opera for Android or Samsung Internet yet.