### PR TITLE
Add spec_url to FileSystemDirectoryReader[\.*]?

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -3,6 +3,7 @@
     "FileSystemDirectoryReader": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader",
+        "spec_url": "https://wicg.github.io/entries-api/#api-directoryreader",
         "support": {
           "chrome": {
             "version_added": "8",
@@ -56,6 +57,7 @@
       "readEntries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader/readEntries",
+          "spec_url": "https://wicg.github.io/entries-api/#dom-filesystemdirectoryreader-readentries",
           "support": {
             "chrome": {
               "version_added": "8"


### PR DESCRIPTION
Add spec_url link to all entries (2) related to FileSystemDirectoryReader.