### PR TITLE
Add spec_url  and mdn_url to FileReader constructor

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -52,6 +52,8 @@
       "FileReader": {
         "__compat": {
           "description": "<code>FileReader()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/FileReader",
+          "spec_url": "https://w3c.github.io/FileAPI/#filereaderConstrctr",
           "support": {
             "chrome": {
               "version_added": "7"


### PR DESCRIPTION
FileReader() was the only entry on this interface without mdn_url and spec_url. This PR fixes it.