### PR TITLE
Add spec_url to Gamepad.displayId

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -341,6 +341,7 @@
       "displayId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/displayId",
+          "spec_url": "https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute",
           "support": {
             "chrome": {
               "version_added": "55",


### PR DESCRIPTION
spec_url was missing from Gamepad.displayId. This PR fixes it.