### PR TITLE
Add all browsers versions for api.SVGElement.*_event

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -358,11 +358,13 @@
             },
             "firefox": {
               "version_added": "4",
-              "alternative_name": "SVGLoad"
+              "alternative_name": "SVGLoad",
+              "notes": "See <a href='https://bugzill.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
             "firefox_android": {
               "version_added": "4",
-              "alternative_name": "SVGLoad"
+              "alternative_name": "SVGLoad",
+              "notes": "See <a href='https://bugzill.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -55,40 +55,40 @@
           "spec_url": "https://dom.spec.whatwg.org/#eventdef-abortsignal-abort",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": null
             },
             "ie": {
-              "version_added": "9"
+              "version_added": null
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "safari": {
-              "version_added": "3"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": null
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": null
             }
           },
           "status": {
@@ -675,40 +675,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-window-resize",
           "support": {
             "chrome": {
-              "version_added": "34"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "34"
+              "version_added": true
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": null
             },
             "opera": {
-              "version_added": "21"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "21"
+              "version_added": true
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": true
             }
           },
           "status": {
@@ -725,40 +725,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-document-scroll",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": null
             },
             "ie": {
-              "version_added": "9"
+              "version_added": null
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "safari": {
-              "version_added": "3"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": null
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": null
             }
           },
           "status": {
@@ -775,40 +775,40 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#UnloadEvent",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": null
             },
             "ie": {
-              "version_added": "9"
+              "version_added": null
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": null
             },
             "safari": {
-              "version_added": "3"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": null
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": null
             }
           },
           "status": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -359,12 +359,12 @@
             "firefox": {
               "version_added": "4",
               "alternative_name": "SVGLoad",
-              "notes": "See <a href='https://bugzill.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
+              "notes": "See <a href='https://bugzil.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
             "firefox_android": {
               "version_added": "4",
               "alternative_name": "SVGLoad",
-              "notes": "See <a href='https://bugzill.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
+              "notes": "See <a href='https://bugzil.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
             "ie": {
               "version_added": "9"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -55,40 +55,40 @@
           "spec_url": "https://dom.spec.whatwg.org/#eventdef-abortsignal-abort",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -201,40 +201,40 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#ErrorEvent",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -348,42 +348,42 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#LoadEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "4",
               "alternative_name": "SVGLoad"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "alternative_name": "SVGLoad"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -675,40 +675,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-window-resize",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "34"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "21"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "21"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -725,40 +725,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-document-scroll",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1"
             }
           },
           "status": {
@@ -775,40 +775,40 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#UnloadEvent",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the events of the `SVGElement` API.  The data for theese events was determined by a combination of copying data from the event handlers (from `GlobalEventHandlerers`) and manual testing (for `load_event` and `unload_event` especially).
