### PR TITLE
Add spec_url  and mdn_url to HTMLImageElement.loading

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -688,6 +688,8 @@
       },
       "loading": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/loading",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-loading",
           "support": {
             "chrome": {
               "version_added": "77"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -689,7 +689,7 @@
       "loading": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/loading",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-loading",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-loading",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
HTMLImageElement.loading had neither a spec_url nor a mdn_url entries. This PR fixes it.