### PR TITLE
Add spec_url  and mdn_url to HTMLInputElement.select

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1864,6 +1864,8 @@
       },
       "select": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/select",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea%2Finput-select",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The select property was missing, though being there since more than a decade. Fixed.