### PR TITLE
add chrome & firefox versions for {String,Array,TypedArray}.prototype.at

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -151,7 +151,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -111,19 +111,19 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-array-prototype-additions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "92"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "90"
               },
               "ie": {
                 "version_added": false
@@ -147,7 +147,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "92"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -164,19 +164,19 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-string-prototype-additions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "92"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "90"
               },
               "ie": {
                 "version_added": false
@@ -200,7 +200,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "92"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -204,7 +204,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -150,7 +150,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -110,19 +110,19 @@
             "spec_url": "https://tc39.es/proposal-relative-indexing-method/#sec-%typedarray.prototype%-additions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "92"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "90"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "90"
               },
               "ie": {
                 "version_added": false
@@ -146,7 +146,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "92"
               }
             },
             "status": {


### PR DESCRIPTION
#### Summary
Adds Chrome and Firefox versions for `String.prototype.at()`, `Array.prototype.at()`, and `TypedArray.prototype.at()` as described in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at.

#### Test results and supporting details
the previous PR for this, #8721, was reverted in #8869 because we wouldn't know the exact Chrome version number for 6 weeks. It's been 19 weeks since then, and now the feature is listed as enabled by default in Chrome 92: https://www.chromestatus.com/feature/6123640410079232#details

if the Chrome versioning is still considered "not ready", this PR may still be merged with just the Firefox versioning. in the initial #8721 PR the bugzilla bug was not ["resolved fixed"](https://github.com/mdn/browser-compat-data/pull/8721#discussion_r560263847) so it was removed, but now it is and is marked for Firefox 90 so we have a specific version: https://bugzilla.mozilla.org/show_bug.cgi?id=1681371

#### Related issues
Fixes #9881