### PR TITLE
Add Safari versions for AudioNodeOptions API

### DIFF
--- a/api/AudioNodeOptions.json
+++ b/api/AudioNodeOptions.json
@@ -30,10 +30,10 @@
             "version_added": "42"
           },
           "safari": {
-            "version_added": null
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `AudioNodeOptions` API.  The data is copied from api.AnalyserNode.AnalyserNode, as it is for all the other browsers.
