### PR TITLE
Add Safari versions for BeforeUnloadEvent API

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -30,10 +30,10 @@
             "version_added": "18"
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `BeforeUnloadEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BeforeUnloadEvent
