### PR TITLE
Add versions for api.BeforeUnloadEvent.user_interaction

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -77,10 +77,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -62,10 +62,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -62,10 +62,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "61"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `user_interaction` member of the `BeforeUnloadEvent` API, based upon manual testing.

Test Code Used: `Used the example from the wiki page, and then reloaded the page to see if a dialog would come up.  No interactable elements were provided on the page.`
