### PR TITLE
Add Edge versions for api.BeforeUnloadEvent.user_interaction

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -59,7 +59,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `user_interaction` member of the `BeforeUnloadEvent` API, based upon manual testing.

Test Code Used: `Used the example from the wiki page, and then reloaded the page to see if a dialog would come up.  No interactable elements were provided on the page.`
