### PR TITLE
Add Safari versions for EffectTiming API

### DIFF
--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -44,10 +44,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "13.4"
           },
           "samsunginternet_android": [
             {
@@ -106,10 +106,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -155,10 +155,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -204,10 +204,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -253,10 +253,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -350,10 +350,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -399,10 +399,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -448,10 +448,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -497,10 +497,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -300,10 +300,10 @@
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `EffectTiming` API.  The data was created based upon a combination of mirroring from `api.Element.animate`, as well as viewing the source for the file itself on WebKit Trac: https://trac.webkit.org/browser/webkit/tags/Safari-609.2.1/Source/WebCore/animation/EffectTiming.idl
