### PR TITLE
Add Safari versions for FullscreenOptions API

### DIFF
--- a/api/FullscreenOptions.json
+++ b/api/FullscreenOptions.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `FullscreenOptions` API.  There's no indication that the `navigationUI` option is supported when looking through the source,.  Additionally, the IDL for this method has no arguments, so there's no way this could be supported in the first place.
