### PR TITLE
Add Safari versions for MediaCapabilitiesInfo API

### DIFF
--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "13"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "13"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -173,10 +173,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaCapabilitiesInfo` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/tags/Safari-608.2.11/Source/WebCore/platform/MediaCapabilitiesInfo.h
