### PR TITLE
Add Safari versions for api.MediaDevices.getUserMedia.secure_context_required

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -431,10 +431,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getUserMedia.secure_context_required` member of the `MediaDevices` API.  The data was determined by running https://mdn-bcd-collector.appspot.com/tests/api/MediaStream in both HTTP and HTTPS and comparing whether the API showed up as supported.
