### PR TITLE
Add Safari versions for MediaKeySystemConfiguration API

### DIFF
--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -225,10 +225,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": "13.1"
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": "13.4"
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -225,10 +225,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaKeySystemConfiguration` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/tags/Safari-607.1.40.3.1/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl
