### PR TITLE
Add Safari versions for MediaStreamConstraints API

### DIFF
--- a/api/MediaStreamConstraints.json
+++ b/api/MediaStreamConstraints.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaStreamConstraints` API, based upon manual testing.

Test Code Used: Tested each property in Safari using `navigator.mediaDevices.getUserMedia()`
