### PR TITLE
Add Safari versions for api.CanvasRenderingContext2D.drawImage.ImageBitmap_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1146,10 +1146,12 @@
                 "version_added": "18"
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/149990'>bug 149990</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/149990'>bug 149990</a>."
               },
               "samsunginternet_android": {
                 "version_added": "2.0"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1146,10 +1146,10 @@
                 "version_added": "18"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "2.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `drawImage.ImageBitmap_source_image` member of the `CanvasRenderingContext2D` API.  The `ImageBitmap` API isn't supported in Safari, so it wouldn't be plausible for this method to support an unsupported interface.
