### PR TITLE
Add Safari versions for api.CanvasRenderingContext2D.drawImage.SVGImageElement_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1244,10 +1244,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `drawImage.SVGImageElement_source_image` member of the `CanvasRenderingContext2D` API, based upon manual testing.

Test Code Used: `[Pending...]`
