### PR TITLE
Chromium browsers have arbitrary caps on rtt and downlink

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -55,7 +55,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": {
               "version_added": "38",

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -59,11 +59,11 @@
             },
             "chrome_android": {
               "version_added": "38",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "edge": {
               "version_added": "79",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
               "version_added": false
@@ -76,11 +76,11 @@
             },
             "opera": {
               "version_added": "48",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
               "version_added": "45",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "safari": {
               "version_added": false
@@ -90,11 +90,11 @@
             },
             "samsunginternet_android": {
               "version_added": "3.0",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "webview_android": {
               "version_added": "50",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             }
           },
           "status": {
@@ -309,15 +309,15 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": {
               "version_added": "38",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "edge": {
               "version_added": "79",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
               "version_added": false
@@ -330,11 +330,11 @@
             },
             "opera": {
               "version_added": "48",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
               "version_added": "45",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "safari": {
               "version_added": false
@@ -344,11 +344,11 @@
             },
             "samsunginternet_android": {
               "version_added": "3.0",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "webview_android": {
               "version_added": "50",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             }
           },
           "status": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -54,13 +54,16 @@
           "spec_url": "https://wicg.github.io/netinfo/#dom-networkinformation-downlink",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "61",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": "38",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "firefox": {
               "version_added": false
@@ -72,10 +75,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "safari": {
               "version_added": false
@@ -84,10 +89,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": "50",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             }
           },
           "status": {
@@ -301,13 +308,16 @@
           "spec_url": "https://wicg.github.io/netinfo/#dom-networkinformation-rtt",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "61",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": "38",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "firefox": {
               "version_added": false
@@ -319,10 +329,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "safari": {
               "version_added": false
@@ -331,10 +343,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": "50",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             }
           },
           "status": {

--- a/http/headers/downlink.json
+++ b/http/headers/downlink.json
@@ -8,15 +8,15 @@
           "support": {
             "chrome": {
               "version_added": "67",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": {
               "version_added": "67",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "edge": {
               "version_added": "≤79",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
               "version_added": null
@@ -29,11 +29,11 @@
             },
             "opera": {
               "version_added": "54",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
               "version_added": "48",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "safari": {
               "version_added": null
@@ -43,11 +43,11 @@
             },
             "samsunginternet_android": {
               "version_added": "9.0",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "webview_android": {
               "version_added": "67",
-              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             }
           },
           "status": {

--- a/http/headers/downlink.json
+++ b/http/headers/downlink.json
@@ -7,13 +7,16 @@
           "spec_url": "https://wicg.github.io/netinfo/#downlink-request-header-field",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "≤79",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "firefox": {
               "version_added": null
@@ -25,10 +28,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "54",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "safari": {
               "version_added": null
@@ -37,10 +42,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "9.0",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 10Mbps as an anti-fingerprinting measure. This limit is not present in the specification."
             }
           },
           "status": {

--- a/http/headers/rtt.json
+++ b/http/headers/rtt.json
@@ -7,13 +7,16 @@
           "spec_url": "https://wicg.github.io/netinfo/#rtt-request-header-field",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "≤79",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "firefox": {
               "version_added": null
@@ -25,10 +28,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "54",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "safari": {
               "version_added": null
@@ -37,10 +42,12 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "9.0",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "67",
+              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
             }
           },
           "status": {

--- a/http/headers/rtt.json
+++ b/http/headers/rtt.json
@@ -8,15 +8,15 @@
           "support": {
             "chrome": {
               "version_added": "67",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "chrome_android": {
               "version_added": "67",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "edge": {
               "version_added": "≤79",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "firefox": {
               "version_added": null
@@ -29,11 +29,11 @@
             },
             "opera": {
               "version_added": "54",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
               "version_added": "48",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "safari": {
               "version_added": null
@@ -43,11 +43,11 @@
             },
             "samsunginternet_android": {
               "version_added": "9.0",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "webview_android": {
               "version_added": "67",
-              "notes": "The value is capped to 3000 ms as an anti-fingerprinting measure. This limit is not present in the specification."
+              "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             }
           },
           "status": {


### PR DESCRIPTION
Chrome adds arbitrary limits on the downlink and rtt client hints. Discovered this in https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink where you can see this note:
![image](https://user-images.githubusercontent.com/5368500/121991505-1e075780-cde3-11eb-8c20-35274c91a9a4.png)

The link takes you to here: https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/network/network_state_notifier.cc;l=460;drc=49bf35554c123bbc44a0ef52675144eba2dd7bbc;bpv=1;bpt=1?originalUrl=https:%2F%2Fcs.chromium.org%2F where you can see `kMaxDownlinkKbps = 10.0 * 1000;`. A search finds https://chromium-review.googlesource.com/c/chromium/src/+/1002232/8/chrome/browser/client_hints/client_hints.cc#121 , which shows `static const double kMaxRttMsec = 3.0 * 1000;`

I think BCD is right place for this. Not sure if there is a better in-source link we can provide as a bug reference though (I am concerned that if Chrome changed this we might not hear about it).

If this goes in, that note in https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink should be removed.