### PR TITLE
Add Safari versions for RTCAnswerOptions API

### DIFF
--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `RTCAnswerOptions` API, based upon commit history and date.

Commit: https://trac.webkit.org/changeset/213992/webkit
