### PR TITLE
Add PaymentMethodChangeEvent constructor

### DIFF
--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -66,12 +66,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -54,6 +54,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/PaymentMethodChangeEvent",
           "spec_url": "https://w3c.github.io/payment-request/#dom-paymentmethodchangeevent-constructor",
+          "description": "<code>PaymentMethodChangeEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -57,13 +57,13 @@
           "description": "<code>PaymentMethodChangeEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -77,26 +77,26 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -50,6 +50,57 @@
           "deprecated": false
         }
       },
+      "PaymentMethodChangeEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/PaymentMethodChangeEvent",
+          "spec_url": "https://w3c.github.io/payment-request/#dom-paymentmethodchangeevent-constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Available only in nightly builds. Requires <code>dom.payments.request.enabled</code> to be set to <code>true</code> and the comma-delineated list in <code>dom.payments.request.supportedRegions</code> to contain one or more of the supported 2-character ISO locales, currently US and CA."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "methodDetails": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentMethodChangeEvent/methodDetails",


### PR DESCRIPTION
Adding the PaymentMethodChangeEvent constructor that was missing.

Sources:
1. It is in standard: https://w3c.github.io/payment-request/#dom-paymentmethodchangeevent-constructor
2. It is on MDN: https://developer.mozilla.org/en-US/docs/Web/API/PaymentMethodChangeEvent/PaymentMethodChangeEvent
3. It is implemented in Chromium: https://chromium.googlesource.com/chromium/src/+blame/03a4cbda6cf358d742f059aae5c73852aa38cd3d/third_party/blink/renderer/modules/payments/payment_method_change_event.idl (line 10) and the blame function tel us this idl has never been edited, so it has been done at the same time as the initial creation.